### PR TITLE
Fix unhandled exception

### DIFF
--- a/changelog.d/+fix-fetching-error.fixed.md
+++ b/changelog.d/+fix-fetching-error.fixed.md
@@ -1,0 +1,1 @@
+Errors during binary fetching are now properly handled.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -121,6 +121,10 @@ object MirrordBinaryManager {
 
                 environment.complete(response.body())
             }
+
+            override fun onThrowable(error: Throwable) {
+                MirrordLogger.logger.debug(error)
+            }
         }
 
         ProgressManager.getInstance().run(versionCheckTask)
@@ -172,6 +176,10 @@ object MirrordBinaryManager {
 
                 stream.close()
                 environment.complete(bytes)
+            }
+
+            override fun onThrowable(error: Throwable) {
+                MirrordLogger.logger.debug(error)
             }
         }
 


### PR DESCRIPTION
Exception in dynamic fetch background tasks are:
1. logged on `debug` level
2. shown to the user as error notifications

Additionally, version check is done only once per run (was twice - one for `mirrord ls`, one for `mirrord ext`)

PS Automatic code format changed most lines :V