### PR TITLE
Fixed plugin version param in `:runIde`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -158,6 +158,10 @@ tasks {
 
     }
 
+    runIde {
+        environment("PLUGIN_TESTING_ENVIRONMENT", "true")
+    }
+
     // Configure UI tests plugin
     // Read more: https://github.com/JetBrains/intellij-ui-test-robot
     runIdeForUiTests {

--- a/changelog.d/+fixed-plugin-version-in-runide.internal.md
+++ b/changelog.d/+fixed-plugin-version-in-runide.internal.md
@@ -1,0 +1,1 @@
+Binary version request now says `version=test` when sent from `:runIde` task.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -96,7 +96,9 @@ object MirrordBinaryManager {
             override fun run(indicator: ProgressIndicator) {
                 indicator.text = "mirrord is checking the latest supported version..."
 
-                val version = if (System.getenv("CI_BUILD_PLUGIN") == "true") {
+                val testing = System.getenv("CI_BUILD_PLUGIN") == "true"
+                        || System.getenv("PLUGIN_TESTING_ENVIRONMENT") == "true"
+                val version = if (testing) {
                     "test"
                 } else {
                     MirrordVersionCheck.version ?: "unknown"


### PR DESCRIPTION
Binary version request is now sending `test` plugin version in the `:runIde` task