### PR TITLE
Added searchbox placeholder and pod/deployment filters

### DIFF
--- a/changelog.d/25.added.md
+++ b/changelog.d/25.added.md
@@ -1,0 +1,1 @@
+Target selection dialog now allows filtering for pods and deployments.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecDialog.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecDialog.kt
@@ -2,13 +2,20 @@ package com.metalbear.mirrord
 
 import com.intellij.openapi.ui.DialogBuilder
 import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBBox
+import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBOptionButton
+import com.intellij.ui.components.JBRadioButton
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.JBUI
+import java.awt.Button
 import java.awt.Dimension
-import java.awt.event.KeyEvent
-import java.awt.event.KeyListener
+import java.awt.event.*
 import javax.swing.*
+import javax.swing.event.ChangeEvent
+import javax.swing.event.ChangeListener
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
 
@@ -16,6 +23,7 @@ import javax.swing.event.DocumentListener
 object MirrordExecDialog {
     private const val dialogHeading: String = "mirrord"
     private const val targetLabel = "Select Target"
+    private const val searchPlaceHolder = "Filter targets..."
 
     /**
      * Label that's used to select targetless mode
@@ -27,59 +35,130 @@ object MirrordExecDialog {
      *
      * @return a target selected from the given list, targetlessTargetName constant if user selected targetless, null if the user cancelled
      */
-    fun selectTargetDialog(podTargets: List<String>): String? {
-        val targets = podTargets.sorted().toMutableList()
-        MirrordSettingsState.instance.mirrordState.lastChosenTarget?.let {
-            val idx = targets.indexOf(it)
-            if (idx != -1) {
-                targets.removeAt(idx)
-                targets.add(0, it)
+    fun selectTargetDialog(availableTargets: List<String>): String? {
+        val targetsState = object {
+            private var _targets = availableTargets
+                    .sorted()
+                    .toMutableList()
+                    .apply {
+                        // Initially, the last used target is at the top
+                        MirrordSettingsState.instance.mirrordState.lastChosenTarget?.let {
+                            val idx = this.indexOf(it)
+                            if (idx != -1) {
+                                this.removeAt(idx)
+                                this.add(0, it)
+                            }
+                        }
+                    }
+                    .toList()
+            val targets: List<String>
+                get() {
+                    return this._targets + targetlessTargetName
+                }
+            var pods = true
+                set(value) {
+                    field = value
+                    this.update()
+                }
+            var deployments = true
+                set(value) {
+                    field = value
+                    this.update()
+                }
+            var searchPhrase = ""
+                set(value) {
+                    field = value
+                    this.update()
+                }
+
+            private fun update() {
+                this._targets = availableTargets
+                        .filter { (it.startsWith("pod/") && this.pods) || (it.startsWith("deployment/") && this.deployments) }
+                        .filter { it.contains(this.searchPhrase) }
+                        .sorted()
             }
         }
-        targets.add(targetlessTargetName)
 
-        val jbTargets = targets.asJBList()
-        val searchField = JTextField()
-        searchField.document.addDocumentListener(object : DocumentListener {
-            override fun insertUpdate(e: DocumentEvent) = updateList()
-            override fun removeUpdate(e: DocumentEvent) = updateList()
-            override fun changedUpdate(e: DocumentEvent) = updateList()
+        val jbTargets = (targetsState.targets).asJBList()
+        val searchField = JTextField().apply {
+            val field = this
 
-            private fun updateList() {
-                val searchTerm = searchField.text
-                val filteredTargets = targets
-                        .dropLast(1) // targetless is always last
-                        .filter { it.contains(searchTerm, true) }
-                        .sorted() + targetlessTargetName
-                jbTargets.setListData(filteredTargets.toTypedArray())
-            }
-
-        })
-
-        // Add focus logic then we can change back and forth from search field
-        // to target selection using tab/shift+tab
-        searchField.addKeyListener(object : KeyListener {
-            override fun keyTyped(p0: KeyEvent) {
-            }
-
-            override fun keyPressed(e: KeyEvent) {
-                if (e.keyCode == KeyEvent.VK_TAB) {
-                    if (e.modifiersEx > 0) {
-                        searchField.transferFocusBackward()
-                    } else {
-                        searchField.transferFocus()
+            // Add an informative placeholder.
+            val previousForeground = foreground
+            text = searchPlaceHolder
+            foreground = JBColor.GRAY
+            addFocusListener(object : FocusListener {
+                override fun focusGained(e: FocusEvent) {
+                    if (field.text.equals(searchPlaceHolder)) {
+                        field.text = ""
+                        field.foreground = previousForeground
                     }
-                    e.consume()
                 }
-            }
 
-            override fun keyReleased(p0: KeyEvent) {
-            }
-        })
+                override fun focusLost(e: FocusEvent) {
+                    if (field.text.isEmpty()) {
+                        field.foreground = JBColor.GRAY
+                        field.text = searchPlaceHolder
+                    }
+                }
+            })
+
+            // Add filtering logic on search field update.
+            document.addDocumentListener(object : DocumentListener {
+                override fun insertUpdate(e: DocumentEvent) = updateList()
+                override fun removeUpdate(e: DocumentEvent) = updateList()
+                override fun changedUpdate(e: DocumentEvent) = updateList()
+
+                private fun updateList() {
+                    val searchTerm = field.text
+                    if (!searchTerm.equals(searchPlaceHolder)) {
+                        targetsState.searchPhrase = searchTerm
+                        jbTargets.setListData(targetsState.targets.toTypedArray())
+                    }
+                }
+            })
+
+            // Add focus logic so that the user can change back and forth from search field
+            // to target selection using tab/shift+tab.
+            addKeyListener(object : KeyListener {
+                override fun keyTyped(p0: KeyEvent) {
+                }
+
+                override fun keyPressed(e: KeyEvent) {
+                    if (e.keyCode == KeyEvent.VK_TAB) {
+                        if (e.modifiersEx > 0) {
+                            field.transferFocusBackward()
+                        } else {
+                            field.transferFocus()
+                        }
+                        e.consume()
+                    }
+                }
+
+                override fun keyReleased(p0: KeyEvent) {
+                }
+            })
+        }
+        val filterHelpers = listOf(
+                JBCheckBox("Pods", true).apply {
+                    this.addActionListener {
+                        targetsState.pods = this.isSelected
+                        jbTargets.setListData(targetsState.targets.toTypedArray())
+                    }
+                },
+                JBCheckBox("Deployments", true).apply {
+                    this.addActionListener {
+                        targetsState.deployments = this.isSelected
+                        jbTargets.setListData(targetsState.targets.toTypedArray())
+                    }
+                }
+        )
         val result = DialogBuilder().apply {
-            setCenterPanel(createSelectionDialog(jbTargets, searchField))
+            setCenterPanel(createSelectionDialog(jbTargets, searchField, filterHelpers))
             setTitle(dialogHeading)
+            setPreferredFocusComponent(searchField)
         }.show()
+
         if (result == DialogWrapper.OK_EXIT_CODE) {
             if (jbTargets.isSelectionEmpty) {
                 // The user did not select any target, and clicked ok.
@@ -89,6 +168,7 @@ object MirrordExecDialog {
             MirrordSettingsState.instance.mirrordState.lastChosenTarget = selectedValue
             return selectedValue
         }
+
         // The user clicked cancel, or closed the dialog.
         return null
     }
@@ -97,12 +177,20 @@ object MirrordExecDialog {
         selectionMode = ListSelectionModel.SINGLE_SELECTION
     }
 
-    private fun createSelectionDialog(items: JBList<String>, searchField: JTextField): JPanel =
+    private fun createSelectionDialog(items: JBList<String>, searchField: JTextField, filterHelpers: List<JComponent>): JPanel =
             JPanel().apply {
                 layout = BoxLayout(this, BoxLayout.Y_AXIS)
                 border = JBUI.Borders.empty(10, 5)
                 add(JLabel(targetLabel).apply {
                     alignmentX = JLabel.LEFT_ALIGNMENT
+                })
+                add(Box.createRigidArea(Dimension(0, 10)))
+                add(JBBox.createHorizontalBox().apply {
+                    filterHelpers.forEach {
+                        this.add(it)
+                        this.add(Box.createRigidArea(Dimension(10, 0)))
+                    }
+                    alignmentX = JBBox.LEFT_ALIGNMENT
                 })
                 add(Box.createRigidArea(Dimension(0, 10)))
                 add(searchField.apply {

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecDialog.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecDialog.kt
@@ -6,16 +6,11 @@ import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBBox
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBList
-import com.intellij.ui.components.JBOptionButton
-import com.intellij.ui.components.JBRadioButton
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.JBUI
-import java.awt.Button
 import java.awt.Dimension
 import java.awt.event.*
 import javax.swing.*
-import javax.swing.event.ChangeEvent
-import javax.swing.event.ChangeListener
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsState.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsState.kt
@@ -27,5 +27,7 @@ open class MirrordSettingsState : PersistentStateComponent<MirrordSettingsState.
         var telemetryEnabled: Boolean? = null
         var versionCheckEnabled: Boolean = false
         var lastChosenTarget: String? = null
+        var showPodsInSelection: Boolean? = null
+        var showDeploymentsInSelection: Boolean? = null
     }
 }


### PR DESCRIPTION
Closes #25
[Screencast from 26.06.2023 14:22:50.webm](https://github.com/metalbear-co/mirrord-intellij/assets/34063647/6c098e08-e89c-4204-9aa4-baa3f131614f) (listing deployments in `mirrord ls` is not yet released, so no deployments in the dialog)