### PR TITLE
Made mirrord actions dumb-aware

### DIFF
--- a/changelog.d/55.added.md
+++ b/changelog.d/55.added.md
@@ -1,0 +1,1 @@
+The user can now toggle mirrord and jump to settings when the IDE is in indexing mode.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigDropDown.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigDropDown.kt
@@ -6,6 +6,8 @@ import com.intellij.openapi.actionSystem.ex.ComboBoxAction
 import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.ProjectLocator
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -15,7 +17,7 @@ import com.intellij.util.io.KeyDescriptor
 import java.util.Collections
 import javax.swing.JComponent
 
-class MirrordConfigDropDown : ComboBoxAction() {
+class MirrordConfigDropDown : ComboBoxAction(), DumbAware {
     private class EnableMirrordAction(val enabled: Boolean) : AnAction(if (enabled) "Enabled" else "Disabled") {
         override fun actionPerformed(e: AnActionEvent) {
             val service = e.project?.service<MirrordProjectService>() ?: return
@@ -51,6 +53,13 @@ class MirrordConfigDropDown : ComboBoxAction() {
 
             service.activeConfig = selection.option?.let { configs[it] }
         }
+
+        override fun update(e: AnActionEvent) {
+            e.presentation.isEnabled = e.project?.let { !DumbService.isDumb(it) } ?: false
+            super.update(e)
+        }
+
+        override fun getActionUpdateThread() = ActionUpdateThread.BGT
     }
 
     private class SettingsAction : AnAction("Settings") {

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordEnabler.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordEnabler.kt
@@ -4,8 +4,9 @@ import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbAware
 
-class MirrordEnabler : ToggleAction() {
+class MirrordEnabler : ToggleAction(), DumbAware {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun isSelected(e: AnActionEvent): Boolean {

--- a/src/test/kotlin/com/metalbear/mirrord/MirrordPluginTest.kt
+++ b/src/test/kotlin/com/metalbear/mirrord/MirrordPluginTest.kt
@@ -92,18 +92,7 @@ internal class MirrordPluginTest {
         }
         idea {
             step("Create config file") {
-                dumbAware {
-                    waitFor(ofSeconds(60)) {
-                        mirrordDropdownButton.isShowing
-                    }
-                }
-
                 mirrordDropdownButton.click()
-
-                waitFor(ofSeconds(60)) {
-                    mirrordDropdownMenu.isShowing
-                }
-
                 mirrordDropdownMenu.findText("Settings").click()
 
                 editorTabs {

--- a/src/test/kotlin/com/metalbear/mirrord/MirrordPluginTest.kt
+++ b/src/test/kotlin/com/metalbear/mirrord/MirrordPluginTest.kt
@@ -92,7 +92,14 @@ internal class MirrordPluginTest {
         }
         idea {
             step("Create config file") {
+                waitFor(ofSeconds(30)) {
+                    mirrordDropdownButton.isShowing
+                }
                 mirrordDropdownButton.click()
+
+                waitFor(ofSeconds(30)) {
+                    mirrordDropdownMenu.isShowing
+                }
                 mirrordDropdownMenu.findText("Settings").click()
 
                 editorTabs {

--- a/src/test/kotlin/com/metalbear/mirrord/MirrordPluginTest.kt
+++ b/src/test/kotlin/com/metalbear/mirrord/MirrordPluginTest.kt
@@ -92,8 +92,10 @@ internal class MirrordPluginTest {
         }
         idea {
             step("Create config file") {
-                waitFor(ofSeconds(30)) {
-                    mirrordDropdownButton.isShowing
+                dumbAware {
+                    waitFor(ofSeconds(30)) {
+                        mirrordDropdownButton.isShowing
+                    }
                 }
                 mirrordDropdownButton.click()
 

--- a/src/test/kotlin/com/metalbear/mirrord/utils/IdeaFrame.kt
+++ b/src/test/kotlin/com/metalbear/mirrord/utils/IdeaFrame.kt
@@ -31,7 +31,7 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
 
     val mirrordDropdownMenu
         get() = find<ContainerFixture>(
-            byXpath("//div[@class='MyList' and @visible_text='Disabled || Select Active Config || Configuration || Settings']"),
+            byXpath("//div[@class='MyList' and (@visible_text='Disabled || Select Active Config || Configuration || Settings' or @visible_text='Disabled || Settings || Configuration')]"),
             Duration.ofSeconds(30)
         )
 


### PR DESCRIPTION
Closes #55 

The user can now use all actions when the IDE is indexing, except `Select active config` (which accesses our index)