### PR TITLE
Abort on error

### DIFF
--- a/changelog.d/7.fixed.md
+++ b/changelog.d/7.fixed.md
@@ -1,0 +1,1 @@
+mirrord now aborts execution on errors.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -48,22 +48,20 @@ data class MirrordExecution(
  * Wrapper around Gson for parsing messages from the mirrord binary.
  */
 private class SafeParser {
-    class ParseError(e: Exception) : Exception() {
-        override val message = "failed to parse a message from the mirrord binary, try updating to the latest version"
-        override val cause = e
-    }
-
     private val gson = Gson()
 
     /**
-     * @throws ParseError
+     * @throws MirrordError
      */
     fun <T> parse(value: String, classOfT: Class<T>): T {
         return try {
             gson.fromJson(value, classOfT)
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             MirrordLogger.logger.debug("failed to parse mirrord binary message", e)
-            throw ParseError(e)
+            throw MirrordError(
+                "failed to parse a message from the mirrord binary, try updating to the latest version",
+                e
+            )
         }
     }
 }
@@ -88,7 +86,7 @@ class MirrordApi(private val service: MirrordProjectService) {
         cli: String,
         configFile: String?,
         wslDistribution: WSLDistribution?
-    ): List<String>? {
+    ): List<String> {
         logger.debug("listing pods")
 
         val commandLine = GeneralCommandLine(cli, "ls", "-o", "json")
@@ -118,24 +116,17 @@ class MirrordApi(private val service: MirrordProjectService) {
 
         logger.debug("process wait finished, reading output")
 
-        // failure -> error
-        // success -> empty -> targetless, else -> list of pods + targetless
-        val gson = Gson()
         if (process.exitValue() != 0) {
             val processStdError = process.errorStream.bufferedReader().readText()
-            if (processStdError.startsWith("Error: ")) {
-                val trimmedError = processStdError.removePrefix("Error: ")
-                val error = gson.fromJson(trimmedError, Error::class.java)
-                service.notifier.notifyRichError(error.message)
-                service.notifier.notifySimple(error.help, NotificationType.INFORMATION)
-            }
-            logger.error("mirrord ls failed: $processStdError")
-            return null
+            throw MirrordError.fromStdErr(processStdError)
         }
 
         val data = process.inputStream.bufferedReader().readText()
         logger.debug("parsing $data")
-        val pods = gson.fromJson(data, Array<String>::class.java).toMutableList()
+
+        val pods = SafeParser()
+            .parse(data, Array<String>::class.java)
+            .toMutableList()
 
         if (pods.isEmpty()) {
             service.notifier.notifySimple(
@@ -154,7 +145,7 @@ class MirrordApi(private val service: MirrordProjectService) {
         configFile: String?,
         executable: String?,
         wslDistribution: WSLDistribution?
-    ): MirrordExecution? {
+    ): MirrordExecution {
         bumpFeedbackCounter()
 
         val commandLine = GeneralCommandLine(cli, "ext").apply {
@@ -191,7 +182,7 @@ class MirrordApi(private val service: MirrordProjectService) {
         val parser = SafeParser()
         val bufferedReader = process.inputStream.reader().buffered()
 
-        val environment = CompletableFuture<MirrordExecution?>()
+        val environment = CompletableFuture<MirrordExecution>()
 
         val mirrordProgressTask = object : Task.Backgroundable(service.project, "mirrord", true) {
             override fun run(indicator: ProgressIndicator) {
@@ -202,9 +193,9 @@ class MirrordApi(private val service: MirrordProjectService) {
                     val message = parser.parse(line, Message::class.java)
                     when {
                         message.name == "mirrord preparing to launch" && message.type == MessageType.FinishedTask -> {
-                            val success = message.success ?: throw Error("Invalid message")
+                            val success = message.success ?: throw MirrordError("invalid message received from the mirrord binary")
                             if (success) {
-                                val innerMessage = message.message ?: throw Error("Invalid inner message")
+                                val innerMessage = message.message ?: throw MirrordError("invalid message received from the mirrord binary")
                                 val executionInfo = parser.parse(innerMessage, MirrordExecution::class.java)
                                 indicator.text = "mirrord is running"
                                 environment.complete(executionInfo)
@@ -249,31 +240,16 @@ class MirrordApi(private val service: MirrordProjectService) {
 
         try {
             return environment.get(30, TimeUnit.SECONDS)
-        } catch (e: Exception) {
-            var message = "mirrord failed to fetch the env"
-            logger.debug(message, e)
-            e.message?.let { message += ": $it" }
-            service.notifier.notifyRichError(message)
-        }
+        } catch (e: Throwable) {
+            logger.debug("failed to fetch the env", e)
 
-        val processStdError = process.errorStream.reader().readText()
-        if (processStdError.startsWith("Error: ")) {
-            val trimmedError = processStdError.removePrefix("Error: ")
-
-            try {
-                val error = parser.parse(trimmedError, Error::class.java)
-                service.notifier.notifyRichError(error.message)
-                service.notifier.notifySimple(error.help, NotificationType.INFORMATION)
-            } catch (e: SafeParser.ParseError) {
-                service.notifier.notifyRichError(trimmedError)
-                service.notifier.notifySimple(e.message, NotificationType.WARNING)
+            val processStdError = process.errorStream.reader().readText()
+            if (processStdError.startsWith("Error: ")) {
+                throw MirrordError.fromStdErr(processStdError)
             }
 
-            return null
+            throw MirrordError("failed to fetch the env", e)
         }
-
-        logger.error("mirrord stderr: $processStdError")
-        throw Error("mirrord failed to start")
     }
 
     /**

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -280,9 +280,10 @@ class MirrordBinaryManager {
      * Finds a local installation of the mirrord binary.
      * Schedules a binary update task to be executed in the background.
      *
+     * @throws MirrordError if no local binary was found
      * @return the path to the binary
      */
-    fun getBinary(product: String, wslDistribution: WSLDistribution?, project: Project): String? {
+    fun getBinary(product: String, wslDistribution: WSLDistribution?, project: Project): String {
         UpdateTask(project, product, wslDistribution, true).queue()
 
         latestSupportedVersion?.let { version ->
@@ -304,6 +305,9 @@ class MirrordBinaryManager {
             return it.command
         }
 
-        return null
+        throw MirrordError(
+            "no local installation of mirrord binary was found",
+            "mirrord binary will be downloaded in the background"
+        )
     }
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigAPI.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigAPI.kt
@@ -33,9 +33,7 @@ private const val DEFAULT_CONFIG =
 }
 """
 
-class InvalidConfigException(path: String, reason: String) : Exception() {
-    override val message: String = "failed to process mirrord config $path: $reason"
-}
+class InvalidConfigException(path: String, reason: String) : MirrordError("failed to process config $path - $reason")
 
 /**
  * Searches mirrord config for target.
@@ -62,13 +60,12 @@ fun isTargetSet(configPath: String): Boolean {
         val parsed = gson.fromJson(contents, ConfigDataSimple::class.java)
         return parsed?.target != null
     } catch (_: Exception) {
-        throw InvalidConfigException(configPath, "invalid config")
     }
+
+    throw InvalidConfigException(configPath, "invalid config")
 }
 
-class InvalidProjectException(project: Project, reason: String) : Exception() {
-    override val message: String = "${project.name}: $reason"
-}
+class InvalidProjectException(project: Project, reason: String) : MirrordError("${project.name} - $reason")
 
 /**
  * Object for interacting with the mirrord config file.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordError.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordError.kt
@@ -1,0 +1,44 @@
+package com.metalbear.mirrord
+
+import com.google.gson.Gson
+import com.intellij.execution.ExecutionException
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+
+open class MirrordError(private val richMessage: String, private val help: String?, override val cause: Throwable?) : ExecutionException(cause) {
+    override val message: String = "mirrord failed"
+
+    companion object {
+        fun fromStdErr(processStdErr: String): MirrordError {
+            val info = try {
+                val trimmedError = processStdErr.removePrefix("Error: ")
+                val gson = Gson()
+                val error = gson.fromJson(trimmedError, Error::class.java)
+                Pair(error.message, error.help)
+            } catch (e: Throwable) {
+                MirrordLogger.logger.debug("failed to deserialize stderr: $processStdErr", e)
+                Pair(processStdErr, null)
+            }
+
+            return MirrordError(info.first, info.second, null)
+        }
+    }
+
+    constructor(richMessage: String) : this(richMessage, null, null)
+
+    constructor(richMessage: String, help: String) : this(richMessage, help, null)
+
+    constructor(richMessage: String, cause: Throwable) : this(richMessage, null, cause)
+
+    fun showHelp(project: Project) {
+        val notifier = project
+            .service<MirrordProjectService>()
+            .notifier
+
+        notifier.notifyRichError(richMessage)
+        help?.let {
+            notifier.notifySimple(it, NotificationType.INFORMATION)
+        }
+    }
+}

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNpmExecutionListener.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNpmExecutionListener.kt
@@ -40,13 +40,11 @@ class MirrordNpmExecutionListener : ExecutionListener {
 
             executionGuard.originEnv = LinkedHashMap(runSettings.envs)
 
-            service.execManager.start(
-                wslDistribution,
-                executablePath,
-                "JS",
-                runSettings.envs[CONFIG_ENV_NAME]
-            )?.let { (newEnv, patchedPath) ->
-
+            service.execManager.wrapper("JS").apply {
+                wsl = wslDistribution
+                executable = executablePath
+                configFromEnv = runSettings.envs[CONFIG_ENV_NAME]
+            }.start()?.let { (newEnv, patchedPath) ->
                 runSettings.envs = executionGuard.originEnv + newEnv
 
                 patchedPath?.let {

--- a/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
+++ b/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
@@ -47,11 +47,10 @@ class GolandRunConfigurationExtension : GoRunConfigurationExtension() {
                 }
             }
 
-            service.execManager.start(
-                wsl,
-                "goland",
-                configuration.getCustomEnvironment()[CONFIG_ENV_NAME]
-            )?.let { env ->
+            service.execManager.wrapper("goland").apply {
+                this.wsl = wsl
+                configFromEnv = configuration.getCustomEnvironment()[CONFIG_ENV_NAME]
+            }.start()?.first?.let { env ->
                 for (entry in env.entries.iterator()) {
                     cmdLine.addEnvironmentVariable(entry.key, entry.value)
                 }

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
@@ -53,11 +53,10 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
 
         val mirrordEnv = HashMap<String, String>()
         MirrordLogger.logger.debug("calling start")
-        service.execManager.start(
-            wsl,
-            "idea",
-            getMirrordConfigPath(configuration, params)
-        )?.let { env ->
+        service.execManager.wrapper("idea").apply {
+            this.wsl = wsl
+            configFromEnv = getMirrordConfigPath(configuration, params)
+        }.start()?.first?.let { env ->
             for (entry in env.entries.iterator()) {
                 mirrordEnv[entry.key] = entry.value
             }

--- a/modules/products/nodejs/src/main/kotlin/com/metalbear/mirrord/products/nodejs/NodeRunConfigurationExtension.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/metalbear/mirrord/products/nodejs/NodeRunConfigurationExtension.kt
@@ -31,7 +31,10 @@ class NodeRunConfigurationExtension : AbstractNodeRunConfigurationExtension() {
         }
 
         val config = configuration as NodeJsRunConfiguration
-        service.execManager.start(wsl, "npm", config.envs[CONFIG_ENV_NAME])?.let { env ->
+        service.execManager.wrapper("npm").apply {
+            this.wsl = wsl
+            configFromEnv = config.envs[CONFIG_ENV_NAME]
+        }.start()?.first?.let { env ->
             config.envs = config.envs + env
         }
 

--- a/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonRunConfigurationExtension.kt
+++ b/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonRunConfigurationExtension.kt
@@ -37,7 +37,10 @@ class PythonRunConfigurationExtension : PythonRunConfigurationExtension() {
 
         val currentEnv = cmdLine.environment
 
-        service.execManager.start(wsl, "pycharm", currentEnv[CONFIG_ENV_NAME])?.let { env ->
+        service.execManager.wrapper("pycharm").apply {
+            this.wsl = wsl
+            configFromEnv = currentEnv[CONFIG_ENV_NAME]
+        }.start()?.first?.let { env ->
             for (entry in env.entries.iterator()) {
                 currentEnv[entry.key] = entry.value
             }

--- a/modules/products/rider/src/main/kotlin/com/metalbear/mirrord/products/rider/RiderPatchCommandLineExtension.kt
+++ b/modules/products/rider/src/main/kotlin/com/metalbear/mirrord/products/rider/RiderPatchCommandLineExtension.kt
@@ -27,11 +27,10 @@ class RiderPatchCommandLineExtension : PatchCommandLineExtension {
             }
         }
 
-        service.execManager.start(
-            wsl,
-            "rider",
-            commandLine.environment[CONFIG_ENV_NAME]
-        )?.let { env ->
+        service.execManager.wrapper("rider").apply {
+            this.wsl = wsl
+            configFromEnv = commandLine.environment[CONFIG_ENV_NAME]
+        }.start()?.first?.let { env ->
             for (entry in env.entries.iterator()) {
                 commandLine.withEnvironment(entry.key, entry.value)
             }

--- a/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
+++ b/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
@@ -37,11 +37,10 @@ class RubyMineRunConfigurationExtension : RubyRunConfigurationExtension() {
 
         val currentEnv = configuration.envs
 
-        service.execManager.start(
-            wsl,
-            "rubymine",
-            currentEnv[CONFIG_ENV_NAME]
-        )?.let { env ->
+        service.execManager.wrapper("rubymine").apply {
+            this.wsl = wsl
+            configFromEnv = currentEnv[CONFIG_ENV_NAME]
+        }.start()?.first?.let { env ->
             for (entry in env.entries.iterator()) {
                 currentEnv[entry.key] = entry.value
             }


### PR DESCRIPTION
Closes #7 

Errors encountered in the mirrord flow are now passed to the IntelliJ platform as `ExecutionException`s. This aborts the execution. The platform displays a simple error notification. I couldn't find any way to inject our "get help" links there, so the final result looks like this:
![Screenshot from 2023-08-16 13-47-33](https://github.com/metalbear-co/mirrord-intellij/assets/34063647/a30a77fe-787d-46ca-a38e-b1cc2ca5214f)
