### PR TITLE
Run plugin verifier for latest releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,10 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches-ignore: [staging-squash-merge.tmp]
+    branches-ignore: [ staging-squash-merge.tmp ]
   pull_request:
-    branches: [main, staging, trying]
-    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [ main, staging, trying ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
 
 # Cancel previous runs on the same PR.
 concurrency:
@@ -59,45 +59,20 @@ jobs:
           name: mirrord-build
           path: build/
 
-
   lint:
     runs-on: ubuntu-latest
     steps:
-     - uses: actions/checkout@v3
-     - name: Setup Java
-       uses: actions/setup-java@v3
-       with:
-         distribution: zulu
-         java-version: 17
-     - name: Run ktlint
-       run: ./gradlew ktlintCheck
-
-  pluginVerifier:
-    strategy:
-      matrix:
-        ide: [IU, IC, PY, PC, GO, RD]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Remove unnecessary files
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v3
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 17
-      - name: Run plugin verifier
-        env:
-          CI_BUILD_PLUGIN: true
-          IDE: ${{ matrix.ide }}
-        run: |
-          ./gradlew runPluginVerifier
-
+      - name: Run ktlint
+        run: ./gradlew ktlintCheck
 
   e2e:
-    needs: [build]
+    needs: [ build ]
     runs-on: ubuntu-latest
     env:
       CI_BUILD_PLUGIN: "true"
@@ -150,7 +125,7 @@ jobs:
           run: ./gradlew test
       - name: Move video
         if: ${{ failure() }}
-        run: |          
+        run: |
           mv video build/reports
       - name: Save fails report
         if: ${{ failure() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,18 +53,47 @@ jobs:
         run: |
           chmod +x ./gradlew
           ./gradlew buildPlugin
-      - name: Run plugin verifier
-        env:
-          CI_BUILD_PLUGIN: true
-        run: |
-          ./gradlew runPluginVerifier
-      - name: Run ktlint
-        run: ./gradlew ktlintCheck
       - name: Upload build folder
         uses: actions/upload-artifact@v3
         with:
           name: mirrord-build
           path: build/
+
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+     - uses: actions/checkout@v3
+     - name: Setup Java
+       uses: actions/setup-java@v3
+       with:
+         distribution: zulu
+         java-version: 17
+     - name: Run ktlint
+       run: ./gradlew ktlintCheck
+
+  pluginVerifier:
+    strategy:
+      matrix:
+        ide: [IU, IC, PY, PC, GO, RD]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove unnecessary files
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - uses: actions/checkout@v3
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 17
+      - name: Run plugin verifier
+        env:
+          CI_BUILD_PLUGIN: true
+          IDE: ${{ matrix.ide }}
+        run: |
+          ./gradlew runPluginVerifier
 
 
   e2e:

--- a/.github/workflows/plugin_verifier.yaml
+++ b/.github/workflows/plugin_verifier.yaml
@@ -1,0 +1,29 @@
+name: PluginVerifier
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  pluginVerifier:
+    strategy:
+      matrix:
+        ide: [ IU, IC, PY, PC, GO, RD ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove unnecessary files
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - uses: actions/checkout@v3
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 17
+      - name: Run plugin verifier
+        env:
+          CI_BUILD_PLUGIN: true
+          IDE: ${{ matrix.ide }}
+        run: |
+          ./gradlew runPluginVerifier

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.tasks.ListProductsReleasesTask
 import org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.nio.file.Paths
@@ -229,6 +230,7 @@ tasks {
     listProductsReleases {
         sinceBuild.set("232.*")
         types.set(listOf("IU", "IC", "PC", "CL", "PY", "RD", "GO"))
+        releaseChannels.set(setOf(ListProductsReleasesTask.Channel.RELEASE))
     }
 
     runPluginVerifier {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -232,7 +232,7 @@ tasks {
         System.getenv("IDE").let {
             types.set(listOf(it))
         }
-        releaseChannels.set(setOf(ListProductsReleasesTask.Channel.EAP))
+        releaseChannels.set(setOf(ListProductsReleasesTask.Channel.EAP, ListProductsReleasesTask.Channel.RELEASE))
     }
 
     runPluginVerifier {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -229,8 +229,10 @@ tasks {
 
     listProductsReleases {
         sinceBuild.set("232.*")
-        types.set(listOf("IU", "IC", "PC", "CL", "PY", "RD", "GO"))
-        releaseChannels.set(setOf(ListProductsReleasesTask.Channel.RELEASE))
+        System.getenv("IDE").let {
+            types.set(listOf(it))
+        }
+        releaseChannels.set(setOf(ListProductsReleasesTask.Channel.EAP))
     }
 
     runPluginVerifier {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -226,8 +226,12 @@ tasks {
         channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
     }
 
+    listProductsReleases {
+        sinceBuild.set("232.*")
+        types.set(listOf("IU", "IC", "PC", "CL", "PY", "RD", "GO"))
+    }
+
     runPluginVerifier {
-        ideVersions.set(listOf("IU-232.5150.116", "IU-222.4554.10"))
         failureLevel.set(EnumSet.of(FailureLevel.COMPATIBILITY_PROBLEMS, FailureLevel.INVALID_PLUGIN))
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -229,9 +229,10 @@ tasks {
 
     listProductsReleases {
         sinceBuild.set("232.*")
-        System.getenv("IDE").let {
+        System.getenv("IDE")?.let {
             types.set(listOf(it))
-        }
+        } ?: types.set(listOf("IU", "RD", "PY"))
+
         releaseChannels.set(setOf(ListProductsReleasesTask.Channel.EAP, ListProductsReleasesTask.Channel.RELEASE))
     }
 

--- a/changelog.d/91.internal.md
+++ b/changelog.d/91.internal.md
@@ -1,0 +1,1 @@
+Run plugin verifier for latest releases

--- a/changelog.d/91.internal.md
+++ b/changelog.d/91.internal.md
@@ -1,1 +1,1 @@
-Run plugin verifier for latest releases
+Run plugin verifier for latest releases by relying on `listProductsReleases` which finds the releases after build `232.*`, this is used by the pluginVerifier to run the tests on these releases.


### PR DESCRIPTION
closes #91

Run plugin verifier for latest releases by relying on `listProductsReleases` which finds the releases after build `232.*`, this is used by the pluginVerifier to run the tests on these releases.

releases after 232.*:

CL-2023.2
GO-2023.2
IC-2023.2.1
IU-2023.2.1
PC-2023.2.1
PY-2023.2.1
RD-2023.2

can be found in the listProductReleases file in `.build` on running `./gradlew listProductsReleases`

the plugin will be verified against EAP and RELEASE channels
