### PR TITLE
Show responsive dialogs when running `mirrord ...` commands

### DIFF
--- a/changelog.d/109.added.md
+++ b/changelog.d/109.added.md
@@ -1,0 +1,4 @@
+A modal progress indicator is now shown when the plugin runs `mirrord ls` and `mirrord ext` commands.
+The dialog allows the user to cancel execution.
+
+Execution with mirrord is cancelled when the user cancels target selection.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -151,6 +151,7 @@ class MirrordApi(private val service: MirrordProjectService) {
             this.process?.destroy()
         }
     }
+
     /**
      * Runs `mirrord ls` to get the list of available targets.
      *

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -154,6 +154,7 @@ class MirrordApi(private val service: MirrordProjectService) {
 
     /**
      * Runs `mirrord ls` to get the list of available targets.
+     * Displays a modal progress dialog.
      *
      * @return list of pods
      */
@@ -270,6 +271,12 @@ class MirrordApi(private val service: MirrordProjectService) {
         }
     }
 
+    /**
+     * Runs `mirrord ext` command to get the environment.
+     * Displays a modal progress dialog.
+     *
+     * @return environment for the user's application
+     */
     fun exec(
         cli: String,
         target: String?,

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -113,6 +113,7 @@ class MirrordApi(private val service: MirrordProjectService) {
                 .start()
             this.process = process
 
+            indicator.text = "mirrord is listing targets..."
             var finished = false
             while (!finished) {
                 indicator.checkCanceled()

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -16,9 +16,9 @@ import java.nio.file.Path
  */
 class MirrordExecManager(private val service: MirrordProjectService) {
     /** Attempts to show the target selection dialog and allow user to select the mirrord target.
-     * If the dialog cannot be safely displayed (platform threading rules) returns null.
      *
-     * @return target chosen by the user (or special constant for targetless mofr)
+     * @return target chosen by the user (or special constant for targetless mode)
+     * @throws ProcessCanceledException if the dialog cannot be displayed
      */
     private fun chooseTarget(
         cli: String,
@@ -84,10 +84,11 @@ class MirrordExecManager(private val service: MirrordProjectService) {
     }
 
     /**
-     * Starts mirrord, shows dialog for selecting pod if target not set and returns env to set.
+     * Starts mirrord, shows dialog for selecting pod if target is not set and returns env to set.
      *
      * @return extra environment variables to set for the executed process and path to the patched executable.
-     * null if mirrord service is disabled or the user cancelled
+     * null if mirrord service is disabled
+     * @throws ProcessCanceledException if the user cancelled
      */
     private fun start(
         wslDistribution: WSLDistribution?,

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -1,6 +1,5 @@
 package com.metalbear.mirrord
 
-import com.intellij.execution.ExecutionException
 import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager


### PR DESCRIPTION
Closes #109 

Now the progress of `mirrord ext` is visible to the user and the UI is not frozen (the user can cancel).

* If the cli is used from the background thread, a progress indicator is shown.
* If the cli is used from the dispatch thread, a modal dialog is shown.
* In either case, the `Cancel` button is always responsive (processing of the `mirrord ...` output is done in a separate thread, cancellation is polled with 200ms interval)

[Screencast from 25.08.2023 18:16:20.webm](https://github.com/metalbear-co/mirrord-intellij/assets/34063647/d0d72859-ed91-4d98-b544-e891ee063a8b)
