### PR TITLE
Cleanup external run config

### DIFF
--- a/changelog.d/122.fixed.md
+++ b/changelog.d/122.fixed.md
@@ -1,0 +1,1 @@
+mirrord environment variables are no longer persisted in Gradle run configurations.

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
@@ -1,19 +1,34 @@
 package com.metalbear.mirrord.products.idea
 
-import com.intellij.execution.Executor
 import com.intellij.execution.RunConfigurationExtension
 import com.intellij.execution.configurations.JavaParameters
 import com.intellij.execution.configurations.RunConfigurationBase
 import com.intellij.execution.configurations.RunnerSettings
+import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.target.createEnvironmentRequest
 import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.openapi.components.service
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemRunConfiguration
+import com.intellij.openapi.project.Project
 import com.metalbear.mirrord.*
+import java.util.concurrent.ConcurrentHashMap
 
 class IdeaRunConfigurationExtension : RunConfigurationExtension() {
+    /**
+     * mirrord env set in ExternalRunConfigurations. Used for cleanup the configuration after the execution has ended.
+     */
+    private val runningProcessEnvs = ConcurrentHashMap<Project, Set<String>>()
+
     override fun isApplicableFor(configuration: RunConfigurationBase<*>): Boolean {
-        return true
+        val applicable = !configuration.name.startsWith("Build ")
+
+        if (!applicable) {
+            MirrordLogger.logger.info("Configuration name %s ignored".format(configuration.name))
+        }
+
+        return applicable
     }
 
     override fun isEnabledFor(
@@ -33,65 +48,54 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
             }
     }
 
-    private fun <T : RunConfigurationBase<*>> patchEnv(configuration: T, params: JavaParameters) {
+    override fun <T : RunConfigurationBase<*>> updateJavaParameters(
+        configuration: T,
+        params: JavaParameters,
+        runnerSettings: RunnerSettings?
+    ) {
         val service = configuration.project.service<MirrordProjectService>()
 
-        MirrordLogger.logger.debug("Check if relevant")
-        if (configuration.name.startsWith("Build ")) {
-            MirrordLogger.logger.info("Configuration name %s ignored".format(configuration.name))
-            return
-        }
         MirrordLogger.logger.debug("wsl check")
         val wsl = when (val request = createEnvironmentRequest(configuration, configuration.project)) {
             is WslTargetEnvironmentRequest -> request.configuration.distribution!!
             else -> null
         }
 
-        MirrordLogger.logger.debug("getting env")
-        val currentEnv = HashMap<String, String>()
-        currentEnv.putAll(params.env)
-
-        val mirrordEnv = HashMap<String, String>()
-        MirrordLogger.logger.debug("calling start")
-        service.execManager.wrapper("idea").apply {
-            this.wsl = wsl
-            configFromEnv = getMirrordConfigPath(configuration, params)
-        }.start()?.first?.let { env ->
-            for (entry in env.entries.iterator()) {
-                mirrordEnv[entry.key] = entry.value
+        val mirrordEnv = service
+            .execManager
+            .wrapper("idea")
+            .apply {
+                this.wsl = wsl
+                configFromEnv = getMirrordConfigPath(configuration, params)
             }
-        }
+            .start()
+            ?.first
+            ?.let { it + mapOf(Pair("MIRRORD_DETECT_DEBUGGER_PORT", "javaagent")) }
+            .orEmpty()
 
-        // Help mirrord detect debugger port and exclude it.
-        mirrordEnv["MIRRORD_DETECT_DEBUGGER_PORT"] = "javaagent"
-
-        params.env = currentEnv + mirrordEnv
+        params.env = params.env + mirrordEnv
 
         // Gradle support (and external system configuration)
         if (configuration is ExternalSystemRunConfiguration) {
-            val ext = configuration as ExternalSystemRunConfiguration
-            val newEnv = ext.settings.env + mirrordEnv
-            ext.settings.env = newEnv
+            configuration.settings.env = configuration.settings.env + mirrordEnv
         }
         MirrordLogger.logger.debug("setting env and finishing")
+
+        runningProcessEnvs[configuration.project] = mirrordEnv.keys
     }
 
-    override fun <T : RunConfigurationBase<*>> updateJavaParameters(
-        configuration: T,
-        params: JavaParameters,
-        runnerSettings: RunnerSettings?,
-        executor: Executor
-    ) {
-        MirrordLogger.logger.debug("updateJavaParameters called")
-        patchEnv(configuration, params)
-    }
+    /**
+     * Remove mirrord env leftovers from the external system configurations.
+     */
+    override fun attachToProcess(configuration: RunConfigurationBase<*>, handler: ProcessHandler, runnerSettings: RunnerSettings?) {
+        if (configuration is ExternalSystemRunConfiguration) {
+            val envsToRemove = runningProcessEnvs.remove(configuration.project) ?: return
 
-    override fun <T : RunConfigurationBase<*>> updateJavaParameters(
-        configuration: T,
-        params: JavaParameters,
-        runnerSettings: RunnerSettings?
-    ) {
-        MirrordLogger.logger.debug("updateJavaParameters (with less parameters) called")
-        patchEnv(configuration, params)
+            handler.addProcessListener(object : ProcessListener {
+                override fun processTerminated(event: ProcessEvent) {
+                    configuration.settings.env.minusAssign(envsToRemove)
+                }
+            })
+        }
     }
 }


### PR DESCRIPTION
Closes #122 

We were polluting 2 kinds of run configurations: Gradle and NodeJS. NodeJS was fixed with #123 
Other kinds of run configs should be fine (tested)