### PR TITLE
`mirrord ext` errors fixed

### DIFF
--- a/changelog.d/+mirrord-ext-errors.fixed.md
+++ b/changelog.d/+mirrord-ext-errors.fixed.md
@@ -1,0 +1,1 @@
+Fixed a bug with handling `mirrord ext` errors.


### PR DESCRIPTION
Restored parsing `mirrord ext` stderr after process failure. Changed the way we use IntelliJ API (`executeOnBackgroundThread(Callable<T>)` is broken)