### PR TITLE
Compatibility with version 222

### DIFF
--- a/.github/workflows/plugin_verifier.yaml
+++ b/.github/workflows/plugin_verifier.yaml
@@ -1,6 +1,7 @@
 name: PluginVerifier
 
 on:
+  push:
   schedule:
     - cron: '0 0 * * *'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,11 @@ Then build the plugin:
 ./gradlew buildPlugin
 ```
 
+To run the IntelliJ plugin verifier:
+```bash
+./gradlew runPluginVerifier
+```
+
 ## Debugging the IntelliJ plugin
 
 To debug the IntelliJ plugin, first [build the plugin](#building-the-intellij-plugin).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -228,7 +228,7 @@ tasks {
     }
 
     listProductsReleases {
-        sinceBuild.set("232.*")
+        sinceBuild.set("222.*")
         System.getenv("IDE")?.let {
             types.set(listOf(it))
         } ?: types.set(listOf("IU", "RD", "PY"))


### PR DESCRIPTION
#129

- Make the plugin verifier run also with 222.
- Run the verifier on `push` (is that wanted? maybe there is a reason it wasn't like that so far...)
- TBC...