### PR TITLE
Rubymine on macOS

### DIFF
--- a/changelog.d/134.fixed.md
+++ b/changelog.d/134.fixed.md
@@ -1,0 +1,1 @@
+The plugin now works on RubyMine on macOS when using an RVM ruby binary as interpreter.

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
@@ -62,9 +62,9 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
         }
 
         val mirrordEnv = service.execManager.wrapper("idea").apply {
-                this.wsl = wsl
-                configFromEnv = getMirrordConfigPath(configuration, params)
-            }.start()?.first?.let { it + mapOf(Pair("MIRRORD_DETECT_DEBUGGER_PORT", "javaagent")) }.orEmpty()
+            this.wsl = wsl
+            configFromEnv = getMirrordConfigPath(configuration, params)
+        }.start()?.first?.let { it + mapOf(Pair("MIRRORD_DETECT_DEBUGGER_PORT", "javaagent")) }.orEmpty()
 
         params.env = params.env + mirrordEnv
 

--- a/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
+++ b/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
@@ -9,6 +9,7 @@ import com.metalbear.mirrord.CONFIG_ENV_NAME
 import com.metalbear.mirrord.MirrordProjectService
 import org.jetbrains.plugins.ruby.ruby.run.configuration.AbstractRubyRunConfiguration
 import org.jetbrains.plugins.ruby.ruby.run.configuration.RubyRunConfigurationExtension
+import java.io.File
 import kotlin.io.path.*
 
 class RubyMineRunConfigurationExtension : RubyRunConfigurationExtension() {
@@ -38,8 +39,8 @@ class RubyMineRunConfigurationExtension : RubyRunConfigurationExtension() {
             is WslTargetEnvironmentRequest -> request.configuration.distribution!!
             else -> null
         }
-        val path = createTempFile("mirrord-ruby-launcher-", ".sh")
-        path.writeText("#!/bin/sh\n")
+//        val path = createTempFile("mirrord-ruby-launcher-", ".sh")
+//        path.writeText("#!/bin/sh\n")
 
         val currentEnv = configuration.envs
 
@@ -49,12 +50,15 @@ class RubyMineRunConfigurationExtension : RubyRunConfigurationExtension() {
         }.start()?.first?.let { env ->
             for (entry in env.entries.iterator()) {
                 currentEnv[entry.key] = entry.value
+                cmdLine.environment[entry.key] = entry.value
             }
         }
-        path.appendLines(currentEnv.entries.map { entry -> "export ${entry.key}=${entry.value}" })
-        path.appendText(cmdLine.exePath)
-        cmdLine.exePath = path.pathString
-        path.toFile().setExecutable(true)
-        println(path.readText())
+//        path.appendLines(currentEnv.entries.map { entry -> "export ${entry.key}=${entry.value}" })
+//        path.appendText(cmdLine.exePath)
+//        cmdLine.exePath = path.pathString
+        File("/Users/tal/RubymineProjects/first/runruby.sh").writeText("DYLD_INSERT_LIBRARIES=${currentEnv["DYLD_INSERT_LIBRARIES"]} ${cmdLine.exePath} $@")
+        cmdLine.exePath = "/Users/tal/RubymineProjects/first/runruby.sh"
+//        path.toFile().setExecutable(true)
+//        println(path.readText())
     }
 }

--- a/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
+++ b/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
@@ -10,7 +10,6 @@ import com.metalbear.mirrord.CONFIG_ENV_NAME
 import com.metalbear.mirrord.MirrordProjectService
 import org.jetbrains.plugins.ruby.ruby.run.configuration.AbstractRubyRunConfiguration
 import org.jetbrains.plugins.ruby.ruby.run.configuration.RubyRunConfigurationExtension
-import java.io.File
 import kotlin.io.path.*
 
 class RubyMineRunConfigurationExtension : RubyRunConfigurationExtension() {

--- a/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
+++ b/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
@@ -30,17 +30,12 @@ class RubyMineRunConfigurationExtension : RubyRunConfigurationExtension() {
         cmdLine: GeneralCommandLine,
         runnerId: String
     ) {
-        println("############# patchCommandLine #################")
-        println(cmdLine)
-        println(runnerSettings)
         val service = configuration.project.service<MirrordProjectService>()
 
         val wsl = when (val request = createEnvironmentRequest(configuration, configuration.project)) {
             is WslTargetEnvironmentRequest -> request.configuration.distribution!!
             else -> null
         }
-//        val path = createTempFile("mirrord-ruby-launcher-", ".sh")
-//        path.writeText("#!/bin/sh\n")
 
         val currentEnv = configuration.envs
 
@@ -53,12 +48,10 @@ class RubyMineRunConfigurationExtension : RubyRunConfigurationExtension() {
                 cmdLine.environment[entry.key] = entry.value
             }
         }
-//        path.appendLines(currentEnv.entries.map { entry -> "export ${entry.key}=${entry.value}" })
-//        path.appendText(cmdLine.exePath)
-//        cmdLine.exePath = path.pathString
-        File("/Users/tal/RubymineProjects/first/runruby.sh").writeText("DYLD_INSERT_LIBRARIES=${currentEnv["DYLD_INSERT_LIBRARIES"]} ${cmdLine.exePath} $@")
-        cmdLine.exePath = "/Users/tal/RubymineProjects/first/runruby.sh"
-//        path.toFile().setExecutable(true)
-//        println(path.readText())
+
+        val path = createTempFile("mirrord-ruby-launcher-", ".sh")
+        path.writeText("DYLD_INSERT_LIBRARIES=${currentEnv["DYLD_INSERT_LIBRARIES"]} ${cmdLine.exePath} $@")
+        cmdLine.exePath = path.pathString
+        path.toFile().setExecutable(true)
     }
 }


### PR DESCRIPTION
Addresses #134 (at least partially).
- running with an `rvm` interpreter works now (rvm was the first priority).

Running with a plain ruby executable without any version manager (`/usr/bin/ruby`) does not work yet on macOS, either on `main` or on this branch. 