### PR TITLE
Remove leading space in Ruby help message.

### DIFF
--- a/changelog.d/+leading-space-ruby-error.fixed.md
+++ b/changelog.d/+leading-space-ruby-error.fixed.md
@@ -1,0 +1,1 @@
+Remove leading space from non-RVM Ruby help message.

--- a/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
+++ b/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
@@ -57,24 +57,24 @@ class RubyMineRunConfigurationExtension : RubyRunConfigurationExtension() {
                 cmdLine.exePath = patched
             }
 
-            // TODO: would be nice to have a more robust RVM detection mechanism.
-            val isRvm = cmdLine.exePath.contains("/.rvm/rubies/")
-            if (isMac && !isRvm) {
-                val e = MirrordError(
-                    "At the moment, only RVM Rubies are supported by mirrord on RubyMine on macOS, due to SIP.",
-                    " Support for other Rubies is tracked on " +
-                        "https://github.com/metalbear-co/mirrord-intellij/issues/134."
-                )
-                e.showHelp(configuration.project)
-                throw e
-            }
-
-            if (isMac && isRvm) {
-                val path = createTempFile("mirrord-ruby-launcher-", ".sh")
-                // Using patched exe inside the launcher script.
-                path.writeText("DYLD_INSERT_LIBRARIES=${currentEnv["DYLD_INSERT_LIBRARIES"]} ${cmdLine.exePath} $@")
-                cmdLine.exePath = path.pathString
-                path.toFile().setExecutable(true)
+            if (isMac) {
+                // TODO: would be nice to have a more robust RVM detection mechanism.
+                val isRvm = cmdLine.exePath.contains("/.rvm/rubies/")
+                if (isRvm) {
+                    val path = createTempFile("mirrord-ruby-launcher-", ".sh")
+                    // Using patched exe inside the launcher script.
+                    path.writeText("DYLD_INSERT_LIBRARIES=${currentEnv["DYLD_INSERT_LIBRARIES"]} ${cmdLine.exePath} $@")
+                    cmdLine.exePath = path.pathString
+                    path.toFile().setExecutable(true)
+                } else {
+                    val e = MirrordError(
+                        "At the moment, only RVM Rubies are supported by mirrord on RubyMine on macOS, due to SIP.",
+                        "Support for other Rubies is tracked on " +
+                            "https://github.com/metalbear-co/mirrord-intellij/issues/134."
+                    )
+                    e.showHelp(configuration.project)
+                    throw e
+                }
             }
         }
     }


### PR DESCRIPTION
I noticed I accidentally left a leading space in the help message for when running with a non-RVM ruby.
While at it I also simplified the redundant `isMac ...` `if`s I wrote. 