### PR TITLE
Use mirrord verify-config command in the extension.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
 root = true
 
 [*.{kt,kts}]
-ktlint_disabled_rules = no-wildcard-imports
+ktlint_disabled_rules=no-wildcard-imports

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,16 @@
 root = true
 
-[*.{kt,kts}]
-ktlint_disabled_rules=no-wildcard-imports
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,16 +1,4 @@
 root = true
 
-[*]
-
-# Change these settings to your own preference
-indent_style = space
-indent_size = 2
-
-# We recommend you to keep these unchanged
-end_of_line = lf
-charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[*.md]
-trim_trailing_whitespace = false
+[*.{kt,kts}]
+ktlint_disabled_rules = no-wildcard-imports

--- a/changelog.d/99.added.md
+++ b/changelog.d/99.added.md
@@ -1,0 +1,1 @@
+Use mirrord verify-config to validate a config file before proceeding with mirrord execution.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -208,9 +208,9 @@ class MirrordApi(private val service: MirrordProjectService) {
      */
     fun verifyConfig(
         cli: String,
-        configFilePath: String?
+        configFilePath: String
     ): String {
-        return MirrordVerifyConfigTask(cli, configFilePath!!).run(service.project)
+        return MirrordVerifyConfigTask(cli, configFilePath).run(service.project)
     }
 
     /**

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -102,7 +102,7 @@ class MirrordApi(private val service: MirrordProjectService) {
             if (pods.isEmpty()) {
                 project.service<MirrordProjectService>().notifier.notifySimple(
                     "No mirrord target available in the configured namespace. " +
-                            "You can run targetless, or set a different target namespace or kubeconfig in the mirrord configuration file.",
+                        "You can run targetless, or set a different target namespace or kubeconfig in the mirrord configuration file.",
                     NotificationType.INFORMATION
                 )
             }
@@ -208,11 +208,10 @@ class MirrordApi(private val service: MirrordProjectService) {
      */
     fun verifyConfig(
         cli: String,
-        configFilePath: String?,
+        configFilePath: String?
     ): String {
         return MirrordVerifyConfigTask(cli, configFilePath!!).run(service.project)
     }
-
 
     /**
      * Runs `mirrord ext` command to get the environment.
@@ -260,8 +259,8 @@ class MirrordApi(private val service: MirrordProjectService) {
             NotificationType.INFORMATION
         )
             .withLink(
-                    "Review",
-                    "https://plugins.jetbrains.com/plugin/19772-mirrord/reviews"
+                "Review",
+                "https://plugins.jetbrains.com/plugin/19772-mirrord/reviews"
             )
             .withLink("Feedback", FEEDBACK_URL)
             .withDontShowAgain(MirrordSettingsState.NotificationId.PLUGIN_REVIEW)
@@ -446,10 +445,10 @@ private class MirrordWarningHandler(private val service: MirrordProjectService) 
     }
 
     private val filters: List<WarningFilter> = listOf(
-            WarningFilter(
-                    { message -> message.contains("Agent version") && message.contains("does not match the local mirrord version") },
-                    MirrordSettingsState.NotificationId.AGENT_VERSION_MISMATCH
-            )
+        WarningFilter(
+            { message -> message.contains("Agent version") && message.contains("does not match the local mirrord version") },
+            MirrordSettingsState.NotificationId.AGENT_VERSION_MISMATCH
+        )
     )
 
     /**

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -82,7 +82,7 @@ private const val FEEDBACK_COUNTER_REVIEW_AFTER = 100
  * Interact with mirrord CLI using this API.
  */
 class MirrordApi(private val service: MirrordProjectService) {
-    private class MirrordLsTask(cli: String) : MirrordCliTask<List<String>>(cli, "ls") {
+    private class MirrordLsTask(cli: String) : MirrordCliTask<List<String>>(cli, "ls", null) {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): List<String> {
             setText("mirrord is listing targets...")
 
@@ -131,7 +131,7 @@ class MirrordApi(private val service: MirrordProjectService) {
         return task.run(service.project)
     }
 
-    private class MirrordExtTask(cli: String) : MirrordCliTask<MirrordExecution>(cli, "ext") {
+    private class MirrordExtTask(cli: String) : MirrordCliTask<MirrordExecution>(cli, "ext", null) {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): MirrordExecution {
             val parser = SafeParser()
             val bufferedReader = process.inputStream.reader().buffered()
@@ -184,7 +184,7 @@ class MirrordApi(private val service: MirrordProjectService) {
      * Reads the output (json) from stdout which contain either a success + warnings, or the errors from the verify
      * command.
      */
-    private class MirrordVerifyConfigTask(cli: String, path: String) : MirrordCliTask<String>(cli, "verify-config $path") {
+    private class MirrordVerifyConfigTask(cli: String, path: String) : MirrordCliTask<String>(cli, "verify-config", "$path") {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): String {
             setText("mirrord is verifying the config options...")
             process.waitFor()
@@ -271,7 +271,7 @@ class MirrordApi(private val service: MirrordProjectService) {
 /**
  * A mirrord CLI invocation.
  */
-private abstract class MirrordCliTask<T>(private val cli: String, private val command: String) {
+private abstract class MirrordCliTask<T>(private val cli: String, private val command: String, private val args: String?) {
     var target: String? = null
     var configFile: String? = null
     var executable: String? = null
@@ -307,6 +307,10 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
 
             output?.let {
                 addParameter("-o")
+                addParameter(it)
+            }
+
+            args?.let {
                 addParameter(it)
             }
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -15,7 +15,11 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
-import java.util.concurrent.*
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 enum class MessageType {
     NewTask,

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -29,26 +29,26 @@ enum class MessageType {
 
 // I don't know how to do tags like Rust so this format is for parsing both kind of messages ;_;
 data class Message(
-        val type: MessageType,
-        val name: String,
-        val parent: String?,
-        val success: Boolean?,
-        val message: String?
+    val type: MessageType,
+    val name: String,
+    val parent: String?,
+    val success: Boolean?,
+    val message: String?
 )
 
 data class Error(
-        val message: String,
-        val severity: String,
-        val causes: List<String>,
-        val help: String,
-        val labels: List<String>,
-        val related: List<String>
+    val message: String,
+    val severity: String,
+    val causes: List<String>,
+    val help: String,
+    val labels: List<String>,
+    val related: List<String>
 )
 
 data class MirrordExecution(
-        val environment: MutableMap<String, String>,
-        @SerializedName("patched_path")
-        val patchedPath: String?
+    val environment: MutableMap<String, String>,
+    @SerializedName("patched_path")
+    val patchedPath: String?
 )
 
 /**
@@ -66,8 +66,8 @@ private class SafeParser {
         } catch (e: Throwable) {
             MirrordLogger.logger.debug("failed to parse mirrord binary message", e)
             throw MirrordError(
-                    "failed to parse a message from the mirrord binary, try updating to the latest version",
-                    e
+                "failed to parse a message from the mirrord binary, try updating to the latest version",
+                e
             )
         }
     }
@@ -96,14 +96,14 @@ class MirrordApi(private val service: MirrordProjectService) {
             MirrordLogger.logger.debug("parsing mirrord ls output: $data")
 
             val pods = SafeParser()
-                    .parse(data, Array<String>::class.java)
-                    .toMutableList()
+                .parse(data, Array<String>::class.java)
+                .toMutableList()
 
             if (pods.isEmpty()) {
                 project.service<MirrordProjectService>().notifier.notifySimple(
-                        "No mirrord target available in the configured namespace. " +
-                                "You can run targetless, or set a different target namespace or kubeconfig in the mirrord configuration file.",
-                        NotificationType.INFORMATION
+                    "No mirrord target available in the configured namespace. " +
+                            "You can run targetless, or set a different target namespace or kubeconfig in the mirrord configuration file.",
+                    NotificationType.INFORMATION
                 )
             }
 
@@ -118,9 +118,9 @@ class MirrordApi(private val service: MirrordProjectService) {
      * @return list of pods
      */
     fun listPods(
-            cli: String,
-            configFile: String?,
-            wslDistribution: WSLDistribution?
+        cli: String,
+        configFile: String?,
+        wslDistribution: WSLDistribution?
     ): List<String> {
         val task = MirrordLsTask(cli).apply {
             this.configFile = configFile
@@ -144,10 +144,10 @@ class MirrordApi(private val service: MirrordProjectService) {
                 when {
                     message.name == "mirrord preparing to launch" && message.type == MessageType.FinishedTask -> {
                         val success = message.success
-                                ?: throw MirrordError("invalid message received from the mirrord binary")
+                            ?: throw MirrordError("invalid message received from the mirrord binary")
                         if (success) {
                             val innerMessage = message.message
-                                    ?: throw MirrordError("invalid message received from the mirrord binary")
+                                ?: throw MirrordError("invalid message received from the mirrord binary")
                             val executionInfo = parser.parse(innerMessage, MirrordExecution::class.java)
                             setText("mirrord is running")
                             return executionInfo
@@ -207,8 +207,8 @@ class MirrordApi(private val service: MirrordProjectService) {
      * @return String containing a json with either a success + warnings, or the verified config errors.
      */
     fun verifyConfig(
-            cli: String,
-            configFilePath: String?,
+        cli: String,
+        configFilePath: String?,
     ): String {
         return MirrordVerifyConfigTask(cli, configFilePath!!).run(service.project)
     }
@@ -221,11 +221,11 @@ class MirrordApi(private val service: MirrordProjectService) {
      * @return environment for the user's application
      */
     fun exec(
-            cli: String,
-            target: String?,
-            configFile: String?,
-            executable: String?,
-            wslDistribution: WSLDistribution?
+        cli: String,
+        target: String?,
+        configFile: String?,
+        executable: String?,
+        wslDistribution: WSLDistribution?
     ): MirrordExecution {
         bumpFeedbackCounter()
 
@@ -256,16 +256,16 @@ class MirrordApi(private val service: MirrordProjectService) {
         }
 
         service.notifier.notification(
-                "Enjoying mirrord? Don't forget to leave a review! Also consider giving us some feedback, we'd highly appreciate it!",
-                NotificationType.INFORMATION
+            "Enjoying mirrord? Don't forget to leave a review! Also consider giving us some feedback, we'd highly appreciate it!",
+            NotificationType.INFORMATION
         )
-                .withLink(
-                        "Review",
-                        "https://plugins.jetbrains.com/plugin/19772-mirrord/reviews"
-                )
-                .withLink("Feedback", FEEDBACK_URL)
-                .withDontShowAgain(MirrordSettingsState.NotificationId.PLUGIN_REVIEW)
-                .fire()
+            .withLink(
+                    "Review",
+                    "https://plugins.jetbrains.com/plugin/19772-mirrord/reviews"
+            )
+            .withLink("Feedback", FEEDBACK_URL)
+            .withDontShowAgain(MirrordSettingsState.NotificationId.PLUGIN_REVIEW)
+            .fire()
     }
 }
 
@@ -371,10 +371,10 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
         MirrordLogger.logger.info("running mirrord task with following command line: ${commandLine.commandLineString}")
 
         val process = commandLine
-                .toProcessBuilder()
-                .redirectOutput(ProcessBuilder.Redirect.PIPE)
-                .redirectError(ProcessBuilder.Redirect.PIPE)
-                .start()
+            .toProcessBuilder()
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .redirectError(ProcessBuilder.Redirect.PIPE)
+            .start()
 
         return if (ApplicationManager.getApplication().isDispatchThread) {
             // Modal dialog with progress is very visible and can be canceled by the user,

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigAPI.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigAPI.kt
@@ -4,6 +4,7 @@ import com.google.gson.Gson
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.asSafely
 
 data class Target(val namespace: String?, val path: Any?)
 
@@ -38,19 +39,28 @@ class InvalidConfigException(path: String, reason: String) : MirrordError("faile
 fun isTargetSet(config: String?): Boolean {
     val gson = Gson()
 
-    try {
-        val parsed = gson.fromJson(config, ConfigData::class.java)
-        return parsed?.target?.path != null
-    } catch (_: Exception) {
+    // TODO(alex): Improve this!
+    // Do we always have `path`?
+    val path = gson.fromJson(config, Map::class.java).let { verified ->
+       verified["path"].toString()
     }
 
-    try {
-        val parsed = gson.fromJson(config, ConfigDataSimple::class.java)
-        return parsed?.target != null
-    } catch (_: Exception) {
-    }
+    // lol
+    return path != "null"
 
-    throw InvalidConfigException(config!!, "invalid config")
+//    try {
+//        val parsed = gson.fromJson(config, ConfigData::class.java)
+//        return parsed?.target?.path != null
+//    } catch (_: Exception) {
+//    }
+//
+//    try {
+//        val parsed = gson.fromJson(config, ConfigDataSimple::class.java)
+//        return parsed?.target != null
+//    } catch (_: Exception) {
+//    }
+//
+//    throw InvalidConfigException(config!!, "invalid config")
 }
 
 class InvalidProjectException(project: Project, reason: String) : MirrordError("${project.name} - $reason")

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigAPI.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigAPI.kt
@@ -4,13 +4,6 @@ import com.google.gson.Gson
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.util.asSafely
-
-data class Target(val namespace: String?, val path: Any?)
-
-data class ConfigData(val target: Target?)
-
-data class ConfigDataSimple(val target: String?)
 
 /**
  * For detecting mirrord config specified in run configuration.
@@ -39,28 +32,11 @@ class InvalidConfigException(path: String, reason: String) : MirrordError("faile
 fun isTargetSet(config: String?): Boolean {
     val gson = Gson()
 
-    // TODO(alex): Improve this!
-    // Do we always have `path`?
-    val path = gson.fromJson(config, Map::class.java).let { verified ->
-       verified["path"].toString()
-    }
+    // `path` will be either a normal string, or the string `"null"` due to `toString`.
+    val path = gson.fromJson(config, Map::class.java).let { verified -> verified["path"].toString() }
 
     // lol
     return path != "null"
-
-//    try {
-//        val parsed = gson.fromJson(config, ConfigData::class.java)
-//        return parsed?.target?.path != null
-//    } catch (_: Exception) {
-//    }
-//
-//    try {
-//        val parsed = gson.fromJson(config, ConfigDataSimple::class.java)
-//        return parsed?.target != null
-//    } catch (_: Exception) {
-//    }
-//
-//    throw InvalidConfigException(config!!, "invalid config")
 }
 
 class InvalidProjectException(project: Project, reason: String) : MirrordError("${project.name} - $reason")

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigAPI.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigAPI.kt
@@ -4,9 +4,6 @@ import com.google.gson.Gson
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.VirtualFileManager
-import java.nio.file.InvalidPathException
-import java.nio.file.Path
 
 data class Target(val namespace: String?, val path: Any?)
 
@@ -38,30 +35,22 @@ class InvalidConfigException(path: String, reason: String) : MirrordError("faile
  * Searches mirrord config for target.
  * @throws InvalidConfigException if config cannot be found or parsed.
  */
-fun isTargetSet(configPath: String): Boolean {
-    val file = try {
-        VirtualFileManager.getInstance().findFileByNioPath(Path.of(configPath))
-            ?: throw InvalidConfigException(configPath, "file not found")
-    } catch (_: InvalidPathException) {
-        throw InvalidConfigException(configPath, "invalid path")
-    }
-
-    val contents = String(file.contentsToByteArray())
+fun isTargetSet(config: String?): Boolean {
     val gson = Gson()
 
     try {
-        val parsed = gson.fromJson(contents, ConfigData::class.java)
+        val parsed = gson.fromJson(config, ConfigData::class.java)
         return parsed?.target?.path != null
     } catch (_: Exception) {
     }
 
     try {
-        val parsed = gson.fromJson(contents, ConfigDataSimple::class.java)
+        val parsed = gson.fromJson(config, ConfigDataSimple::class.java)
         return parsed?.target != null
     } catch (_: Exception) {
     }
 
-    throw InvalidConfigException(configPath, "invalid config")
+    throw InvalidConfigException(config!!, "invalid config")
 }
 
 class InvalidProjectException(project: Project, reason: String) : MirrordError("${project.name} - $reason")

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -145,7 +145,6 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         }
 
         MirrordLogger.logger.debug("target selection")
-        service.notifier.notifySimple("verified ${verifiedConfig?.config}", NotificationType.INFORMATION)
 
         var target: String? = null
         val isTargetSet = (config != null && isTargetSet(verifiedConfig?.config))

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -116,9 +116,9 @@ class MirrordExecManager(private val service: MirrordProjectService) {
 
         val cli = cliPath(wslDistribution, product)
         val config = service.configApi.getConfigPath(mirrordConfigFromEnv)
-        // TODO(alex): Have a new type `MirrordConfig`, that does the above call `getConfigPath`
-        // then calls `verify-config` to see if there are any errors, and produces a `MirrordConfig`
-        // at the end.
+
+        // Find the mirrord config path, then call `mirrord verify-config {path}` so we can display warnings/errors
+        // from the config without relying on mirrord-layer.
         val configPath = service.configApi.getConfigPath(mirrordConfigFromEnv)
         val verifiedConfigOutput = service.mirrordApi.verifyConfig(cli, configPath)
         val verifiedConfig = MirrordVerifiedConfig(verifiedConfigOutput, service.notifier)

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -10,9 +10,24 @@ import com.intellij.openapi.vfs.VirtualFileManager
 import java.nio.file.Path
 
 /**
- * How to build this plugin:
+ * # Guide on how to build and run the plugin
+ *
+ * To build just the mirrord plugin, do:
  *
  * `./gradlew buildPlugin`
+ *
+ * If you want to also run tests + lint + build the plugin:
+ *
+ * `./gradlew build`
+ *
+ * The minimum java version required is 17, if you get some `inputReader` error while building the plugin, that's
+ * probably why (outdated java version), or you may need to clean the project (search for Intellij `Invalidate cache`
+ * option).
+ *
+ * With the plugin built, you'll now have a folder `mirrord-intellij/build/distributions` that contains the
+ * `mirrord-x.y.z.zip` plugin. To install it, go on the `Plugins` option in Intellij, remove the mirrord plugin (if you
+ * already had it installed), then click on the "Settings icon" and select "Install from disk". Pick the
+ * `mirrord-x.y.z.zip` you just built, and that's it (you'll probably have to restart the IDE).
  */
 
 /**

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -58,8 +58,8 @@ class MirrordExecManager(private val service: MirrordProjectService) {
             service
                 .notifier
                 .notification(
-                    "mirrord plugin was unable to display the target selection dialog. " +
-                            "You can set it manually in the configuration file $config.",
+                "mirrord plugin was unable to display the target selection dialog. " +
+                        "You can set it manually in the configuration file $config.",
                     NotificationType.WARNING
                 )
                 .apply {

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -145,6 +145,7 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         }
 
         MirrordLogger.logger.debug("target selection")
+        service.notifier.notifySimple("verified ${verifiedConfig?.config}", NotificationType.INFORMATION)
 
         var target: String? = null
         val isTargetSet = (config != null && isTargetSet(verifiedConfig?.config))

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -58,7 +58,7 @@ class MirrordExecManager(private val service: MirrordProjectService) {
             service
                 .notifier
                 .notification(
-                "mirrord plugin was unable to display the target selection dialog. " +
+                    "mirrord plugin was unable to display the target selection dialog. " +
                         "You can set it manually in the configuration file $config.",
                     NotificationType.WARNING
                 )

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -10,27 +10,6 @@ import com.intellij.openapi.vfs.VirtualFileManager
 import java.nio.file.Path
 
 /**
- * # Guide on how to build and run the plugin
- *
- * To build just the mirrord plugin, do:
- *
- * `./gradlew buildPlugin`
- *
- * If you want to also run tests + lint + build the plugin:
- *
- * `./gradlew build`
- *
- * The minimum java version required is 17, if you get some `inputReader` error while building the plugin, that's
- * probably why (outdated java version), or you may need to clean the project (search for Intellij `Invalidate cache`
- * option).
- *
- * With the plugin built, you'll now have a folder `mirrord-intellij/build/distributions` that contains the
- * `mirrord-x.y.z.zip` plugin. To install it, go on the `Plugins` option in Intellij, remove the mirrord plugin (if you
- * already had it installed), then click on the "Settings icon" and select "Install from disk". Pick the
- * `mirrord-x.y.z.zip` you just built, and that's it (you'll probably have to restart the IDE).
- */
-
-/**
  * Functions to be called when one of our entry points to the program is called - when process is
  * launched, when go entrypoint, etc. It will check to see if it already occurred for current run and
  * if it did, it will do nothing

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -135,16 +135,19 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         // Find the mirrord config path, then call `mirrord verify-config {path}` so we can display warnings/errors
         // from the config without relying on mirrord-layer.
         val configPath = service.configApi.getConfigPath(mirrordConfigFromEnv)
-        val verifiedConfigOutput = service.mirrordApi.verifyConfig(cli, configPath)
-        val verifiedConfig = MirrordVerifiedConfig(verifiedConfigOutput, service.notifier)
-        if (verifiedConfig.isError()) {
-            return null
+        var verifiedConfig: MirrordVerifiedConfig? = null
+        if (configPath != null) {
+            val verifiedConfigOutput = service.mirrordApi.verifyConfig(cli, configPath)
+            val verified = MirrordVerifiedConfig(verifiedConfigOutput, service.notifier).also { verifiedConfig = it }
+            if (verified.isError()) {
+                throw InvalidConfigException(configPath, "validation failed for config")
+            }
         }
 
         MirrordLogger.logger.debug("target selection")
 
         var target: String? = null
-        val isTargetSet = (config != null && isTargetSet(verifiedConfig.config))
+        val isTargetSet = (config != null && isTargetSet(verifiedConfig?.config))
 
         if (!isTargetSet) {
             MirrordLogger.logger.debug("target not selected, showing dialog")

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -148,6 +148,7 @@ class MirrordExecManager(private val service: MirrordProjectService) {
 
         var target: String? = null
         val isTargetSet = (config != null && isTargetSet(verifiedConfig?.config))
+        MirrordLogger.logger.debug("$verifiedConfig")
 
         if (!isTargetSet) {
             MirrordLogger.logger.debug("target not selected, showing dialog")

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordVerifiedConfig.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordVerifiedConfig.kt
@@ -1,0 +1,58 @@
+package com.metalbear.mirrord
+
+import com.google.gson.Gson
+import com.intellij.notification.NotificationType
+import com.intellij.util.asSafely
+
+/**
+ * Type for dealing with the output from `mirrord verify-config`.
+ *
+ * It parses the output from the command and displays warnings/errors.
+ *
+ * The command outputs either a `type = "Success"` or `type = "Fail"`.
+ */
+class MirrordVerifiedConfig(private val verified: String, private val notifier: MirrordNotifier) {
+    /**
+     * The warnings when the output is `type = "Success"`, but some options might be conflicting.
+     */
+    private val warnings: List<String>?
+
+    /**
+     * The errors when the output is `type = "Fail"`.
+     */
+    private val errors: List<String>?
+
+    /**
+     * `verify-config` also outputs the `MirrordConfig` that was set, when `type = "Success"`.
+     */
+    val config: String?
+
+    init {
+        val gson = Gson()
+
+        gson.fromJson(this.verified, Map::class.java).let { verified ->
+            val type = verified["type"].toString()
+            println("type $type")
+
+            val warnings = verified["warnings"].asSafely<List<String>>().also { warnings ->
+                warnings?.forEach { this.notifier.notifySimple(it, NotificationType.WARNING) }
+            }
+            println("warnings $warnings")
+            this.warnings = warnings
+
+            val errors = verified["errors"].asSafely<List<String>>().also { errors ->
+                errors?.forEach { this.notifier.notifySimple(it, NotificationType.ERROR) }
+            }
+            println("errors $errors")
+            this.errors = errors
+
+            val innerConfig = verified["config"].toString()
+            println("config $innerConfig")
+            this.config = innerConfig
+        }
+    }
+
+    fun isError(): Boolean {
+        return !this.errors.isNullOrEmpty()
+    }
+}

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordVerifiedConfig.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordVerifiedConfig.kt
@@ -26,8 +26,6 @@ class MirrordVerifiedConfig(private val verified: String, private val notifier: 
         val gson = Gson()
 
         this.config = gson.fromJson(this.verified, Map::class.java).let { verified ->
-            val type = verified["type"].asSafely<String>()
-
             verified["warnings"].asSafely<List<String>>().also { warnings ->
                 warnings?.forEach { this.notifier.notifySimple(it, NotificationType.WARNING) }
             }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordVerifiedConfig.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordVerifiedConfig.kt
@@ -13,11 +13,6 @@ import com.intellij.util.asSafely
  */
 class MirrordVerifiedConfig(private val verified: String, private val notifier: MirrordNotifier) {
     /**
-     * The warnings when the output is `type = "Success"`, but some options might be conflicting.
-     */
-    private val warnings: List<String>?
-
-    /**
      * The errors when the output is `type = "Fail"`.
      */
     private val errors: List<String>?
@@ -33,10 +28,9 @@ class MirrordVerifiedConfig(private val verified: String, private val notifier: 
         this.config = gson.fromJson(this.verified, Map::class.java).let { verified ->
             val type = verified["type"].asSafely<String>()
 
-            val warnings = verified["warnings"].asSafely<List<String>>().also { warnings ->
+            verified["warnings"].asSafely<List<String>>().also { warnings ->
                 warnings?.forEach { this.notifier.notifySimple(it, NotificationType.WARNING) }
             }
-            this.warnings = warnings
 
             val errors = verified["errors"].asSafely<List<String>>().also { errors ->
                 errors?.forEach { this.notifier.notifySimple(it, NotificationType.ERROR) }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordVerifiedConfig.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordVerifiedConfig.kt
@@ -30,26 +30,22 @@ class MirrordVerifiedConfig(private val verified: String, private val notifier: 
     init {
         val gson = Gson()
 
-        gson.fromJson(this.verified, Map::class.java).let { verified ->
-            val type = verified["type"].toString()
-            println("type $type")
+        this.config = gson.fromJson(this.verified, Map::class.java).let { verified ->
+            val type = verified["type"].asSafely<String>()
 
             val warnings = verified["warnings"].asSafely<List<String>>().also { warnings ->
                 warnings?.forEach { this.notifier.notifySimple(it, NotificationType.WARNING) }
             }
-            println("warnings $warnings")
             this.warnings = warnings
 
             val errors = verified["errors"].asSafely<List<String>>().also { errors ->
                 errors?.forEach { this.notifier.notifySimple(it, NotificationType.ERROR) }
             }
-            println("errors $errors")
             this.errors = errors
 
-            val innerConfig = verified["config"].toString()
-            println("config $innerConfig")
-            this.config = innerConfig
+            verified["config"].toString()
         }
+        MirrordLogger.logger.debug("verified config ${this.config}")
     }
 
     fun isError(): Boolean {


### PR DESCRIPTION
- Issue: #99 

Adds a task (`mirrord verify-config`) that is run when starting mirrord to check if the config file is valid, displaying warnings and errors (if any).

intellij side of [mirrord-vscode #66](https://github.com/metalbear-co/mirrord-vscode/pull/66)
