### PR TITLE
Change verify config action to pass --ide, changing some target related errors to warnings.

### DIFF
--- a/changelog.d/1979.fixed.md
+++ b/changelog.d/1979.fixed.md
@@ -1,0 +1,1 @@
+Uses the `verify-config --ide` flag now to signal mirrord we're in an IDE context.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -184,7 +184,7 @@ class MirrordApi(private val service: MirrordProjectService) {
      * Reads the output (json) from stdout which contain either a success + warnings, or the errors from the verify
      * command.
      */
-    private class MirrordVerifyConfigTask(cli: String, path: String) : MirrordCliTask<String>(cli, "verify-config", "$path") {
+    private class MirrordVerifyConfigTask(cli: String, path: String) : MirrordCliTask<String>(cli, "verify-config", mapOf("--ide" to "", "--path" to "$path")) {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): String {
             setText("mirrord is verifying the config options...")
             process.waitFor()
@@ -270,8 +270,10 @@ class MirrordApi(private val service: MirrordProjectService) {
 
 /**
  * A mirrord CLI invocation.
+ *
+ * @param args: An extra list of arguments (used by `verify-config`).
  */
-private abstract class MirrordCliTask<T>(private val cli: String, private val command: String, private val args: String?) {
+private abstract class MirrordCliTask<T>(private val cli: String, private val command: String, private val args: Map<String, String>?) {
     var target: String? = null
     var configFile: String? = null
     var executable: String? = null
@@ -310,8 +312,11 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
                 addParameter(it)
             }
 
-            args?.let {
-                addParameter(it)
+            args?.let { argsMap ->
+                argsMap.forEach {
+                    addParameter(it.key)
+                    addParameter(it.value)
+                }
             }
 
             environment["MIRRORD_PROGRESS_MODE"] = "json"

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -184,7 +184,7 @@ class MirrordApi(private val service: MirrordProjectService) {
      * Reads the output (json) from stdout which contain either a success + warnings, or the errors from the verify
      * command.
      */
-    private class MirrordVerifyConfigTask(cli: String, path: String) : MirrordCliTask<String>(cli, "verify-config", mapOf("--ide" to "", "--path" to "$path")) {
+    private class MirrordVerifyConfigTask(cli: String, path: String) : MirrordCliTask<String>(cli, "verify-config", listOf("--ide", "--path", "$path")) {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): String {
             setText("mirrord is verifying the config options...")
             process.waitFor()
@@ -273,7 +273,7 @@ class MirrordApi(private val service: MirrordProjectService) {
  *
  * @param args: An extra list of arguments (used by `verify-config`).
  */
-private abstract class MirrordCliTask<T>(private val cli: String, private val command: String, private val args: Map<String, String>?) {
+private abstract class MirrordCliTask<T>(private val cli: String, private val command: String, private val args: List<String>?) {
     var target: String? = null
     var configFile: String? = null
     var executable: String? = null
@@ -312,12 +312,7 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
                 addParameter(it)
             }
 
-            args?.let { argsMap ->
-                argsMap.forEach {
-                    addParameter(it.key)
-                    addParameter(it.value)
-                }
-            }
+            args?.let { extraArgs -> extraArgs.forEach { addParameter(it) } }
 
             environment["MIRRORD_PROGRESS_MODE"] = "json"
         }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -184,7 +184,7 @@ class MirrordApi(private val service: MirrordProjectService) {
      * Reads the output (json) from stdout which contain either a success + warnings, or the errors from the verify
      * command.
      */
-    private class MirrordVerifyConfigTask(cli: String, path: String) : MirrordCliTask<String>(cli, "verify-config", listOf("--ide", "--path", "$path")) {
+    private class MirrordVerifyConfigTask(cli: String, path: String) : MirrordCliTask<String>(cli, "verify-config", listOf("--ide", "--path", path)) {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): String {
             setText("mirrord is verifying the config options...")
             process.waitFor()


### PR DESCRIPTION
- Issue: [#1979](https://github.com/metalbear-co/mirrord/issues/1979)

Uses `mirrord verify-config --ide --path` now.

intellij side of [#71](https://github.com/metalbear-co/mirrord-vscode/pull/71)