### PR TITLE
mirrord binary download improvements

### DIFF
--- a/.github/workflows/reusable_e2e.yaml
+++ b/.github/workflows/reusable_e2e.yaml
@@ -74,7 +74,7 @@ jobs:
         if: ${{ inputs.mirrord_release_branch }}
         run: |
           chmod u+x mirrord
-          echo "${GITHUB_WORKSPACE}" >> "$GITHUB_PATH"
+          echo "${GITHUB_WORKSPACE}" >> $GITHUB_PATH
 
       - name: get the latest mirrord binary
         if: ${{ !inputs.mirrord_release_branch }}
@@ -112,7 +112,7 @@ jobs:
             ./gradlew test
 
       - name: Save the failure video
-        if: ${{ failure() }}
+        if: ${{ always() }}
         run: |
           mv video build/reports
       - name: Save fails report

--- a/.github/workflows/reusable_e2e.yaml
+++ b/.github/workflows/reusable_e2e.yaml
@@ -112,6 +112,7 @@ jobs:
             ./gradlew test
 
       - name: Save the failure video
+        continue-on-error: true
         if: ${{ always() }}
         run: |
           mv video build/reports

--- a/changelog.d/+auto-update-and-ci.internal.md
+++ b/changelog.d/+auto-update-and-ci.internal.md
@@ -1,0 +1,1 @@
+Remove quotes around GITHUB_PATH in e2e and add "CI_BUILD_PLUGIN" check to e2e for releases

--- a/changelog.d/+provide-video.internal.md
+++ b/changelog.d/+provide-video.internal.md
@@ -1,0 +1,1 @@
+Always provide video for CI run

--- a/changelog.d/+remove-quotes.internal.md
+++ b/changelog.d/+remove-quotes.internal.md
@@ -1,1 +1,0 @@
-Remove quotes around GITHUB_PATH in e2e

--- a/changelog.d/+remove-quotes.internal.md
+++ b/changelog.d/+remove-quotes.internal.md
@@ -1,0 +1,1 @@
+Remove quotes around GITHUB_PATH in e2e

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -1,5 +1,6 @@
 package com.metalbear.mirrord
 
+import com.github.zafarkhaja.semver.Version
 import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.Service
@@ -35,6 +36,7 @@ private const val DOWNLOAD_ENDPOINT = "https://github.com/metalbear-co/mirrord/r
 class MirrordBinaryManager {
     @Volatile
     private var latestSupportedVersion: String? = null
+    private var downloadVersion: String? = null
 
     /**
      * Schedules the update task at project startup.
@@ -78,20 +80,22 @@ class MirrordBinaryManager {
 
             val autoUpdate = MirrordSettingsState.instance.mirrordState.autoUpdate
             val userSelectedMirrordVersion = MirrordSettingsState.instance.mirrordState.mirrordVersion
+            manager.latestSupportedVersion = manager.fetchLatestSupportedVersion(product, indicator)
 
             val version = when {
                 // auto update -> false -> use mirrordVersion if it's not empty
-                !autoUpdate && userSelectedMirrordVersion.isNotEmpty() -> {
-                    if (checkVersionFormat(userSelectedMirrordVersion)) {
-                        userSelectedMirrordVersion
-                    } else {
+                !autoUpdate && (userSelectedMirrordVersion.isNotEmpty()) -> {
+                    try {
+                        Version.valueOf(userSelectedMirrordVersion)
+                    } catch (e: Exception) {
                         project
                             .service<MirrordProjectService>()
                             .notifier
-                            .notification("mirrord version format is invalid!", NotificationType.WARNING)
+                            .notification("mirrord version format is invalid! ${e.message}", NotificationType.WARNING)
                             .fire()
                         return
                     }
+                    userSelectedMirrordVersion
                 }
                 // auto update -> false -> mirrordVersion is empty -> needs check in the path
                 // if not in path -> fetch latest version
@@ -111,7 +115,7 @@ class MirrordBinaryManager {
                 return
             }
 
-            manager.latestSupportedVersion = version
+            manager.downloadVersion = version
                 // auto update -> false -> mirrordVersion is empty -> no cli found locally -> fetch latest version
                 ?: manager.fetchLatestSupportedVersion(product, indicator)
 
@@ -147,14 +151,6 @@ class MirrordBinaryManager {
                         NotificationType.INFORMATION
                     )
             }
-        }
-
-        /**
-         * checks if the passed version string matches *.*.* format (numbers only)
-         * @param version version string to check
-         * */
-        fun checkVersionFormat(version: String): Boolean {
-            return version.matches(Regex("^[0-9]+\\.[0-9]+\\.[0-9]+$"))
         }
     }
 
@@ -192,7 +188,7 @@ class MirrordBinaryManager {
     }
 
     private fun updateBinary(indicator: ProgressIndicator) {
-        val version = latestSupportedVersion ?: return
+        val version = downloadVersion ?: return
 
         val url = if (SystemInfo.isMac) {
             "$DOWNLOAD_ENDPOINT/$version/mirrord_mac_universal"
@@ -278,7 +274,14 @@ class MirrordBinaryManager {
             }
 
             val binary = MirrordBinary(output)
-            if (requiredVersion == null || requiredVersion == binary.version) {
+
+            val isRequiredVersion = try {
+                Version.valueOf(requiredVersion).greaterThan(Version.valueOf(binary.version))
+            } catch (e: Exception) {
+                false
+            }
+            // for release CI, the tag can be greater than the latest release
+            if (requiredVersion == null || isRequiredVersion) {
                 return binary
             }
         } catch (e: Exception) {

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -276,7 +276,11 @@ class MirrordBinaryManager {
             val binary = MirrordBinary(output)
 
             val isRequiredVersion = try {
-                Version.valueOf(requiredVersion).greaterThan(Version.valueOf(binary.version))
+                if (System.getenv("CI_BUILD_PLUGIN") == "true") {
+                    Version.valueOf(binary.version).greaterThanOrEqualTo(Version.valueOf(requiredVersion))
+                } else {
+                    Version.valueOf(binary.version).equals(Version.valueOf(requiredVersion))
+                }
             } catch (e: Exception) {
                 false
             }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -91,7 +91,7 @@ class MirrordBinaryManager {
                         project
                             .service<MirrordProjectService>()
                             .notifier
-                            .notification("mirrord version format is invalid! ${e.message}", NotificationType.WARNING)
+                            .notification("mirrord version format is invalid!", NotificationType.WARNING)
                             .fire()
                         return
                     }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -116,7 +116,7 @@ class MirrordBinaryManager {
             }
 
             manager.downloadVersion = version
-                    // auto update -> false -> mirrordVersion is empty -> no cli found locally -> latest version
+                // auto update -> false -> mirrordVersion is empty -> no cli found locally -> latest version
                 ?: manager.latestSupportedVersion
 
             if (downloadInProgress.compareAndExchange(false, true)) {

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -276,6 +276,7 @@ class MirrordBinaryManager {
             val binary = MirrordBinary(output)
 
             val isRequiredVersion = try {
+                // for release CI, the tag can be greater than the latest release
                 if (System.getenv("CI_BUILD_PLUGIN") == "true") {
                     Version.valueOf(binary.version).greaterThanOrEqualTo(Version.valueOf(requiredVersion))
                 } else {
@@ -284,7 +285,6 @@ class MirrordBinaryManager {
             } catch (e: Exception) {
                 false
             }
-            // for release CI, the tag can be greater than the latest release
             if (requiredVersion == null || isRequiredVersion) {
                 return binary
             }


### PR DESCRIPTION
This PR:
- removes quotes around GITHUB_PATH could be a potential error
- adds a check for CI builds to choose the release builds as their tag is greater than the latest release