### PR TITLE
Pass config env vars to mirrord verify-config.

### DIFF
--- a/changelog.d/167.fixed.md
+++ b/changelog.d/167.fixed.md
@@ -1,0 +1,1 @@
+Passes the launch env vars section to mirrord verify-config, and mirrord, resolving config options that were set as env vars.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -4,8 +4,6 @@ package com.metalbear.mirrord
 
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
-import com.intellij.execution.CommonProgramRunConfigurationParameters
-import com.intellij.execution.RunManager
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.wsl.WSLCommandLineOptions
 import com.intellij.execution.wsl.WSLDistribution
@@ -215,17 +213,6 @@ class MirrordApi(private val service: MirrordProjectService, private val project
 
         service.notifier.notification("Enjoying mirrord? Don't forget to leave a review! Also consider giving us some feedback, we'd highly appreciate it!", NotificationType.INFORMATION).withLink("Review", "https://plugins.jetbrains.com/plugin/19772-mirrord/reviews").withLink("Feedback", FEEDBACK_URL).withDontShowAgain(MirrordSettingsState.NotificationId.PLUGIN_REVIEW).fire()
     }
-}
-
-/**
- * Gets the env vars set by the user for the current run (there might be more than 1 run configuration).
- *
- * @param project: Contains the `selectedConfiguration`, which holds the active env vars.
- * @return A `Map` with the launch env vars, that can be put into the `environment` when running mirrord.
- */
-fun getEnvVarsFromActiveLaunchSettings(project: Project): Map<String, String>? {
-    val runConfig = RunManager.getInstance(project).selectedConfiguration?.configuration
-    return if (runConfig is CommonProgramRunConfigurationParameters) runConfig.envs else null
 }
 
 /**

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -110,10 +110,10 @@ class MirrordApi(private val service: MirrordProjectService) {
                 when {
                     message.name == "mirrord preparing to launch" && message.type == MessageType.FinishedTask -> {
                         val success = message.success
-                                ?: throw MirrordError("invalid message received from the mirrord binary")
+                            ?: throw MirrordError("invalid message received from the mirrord binary")
                         if (success) {
                             val innerMessage = message.message
-                                    ?: throw MirrordError("invalid message received from the mirrord binary")
+                                ?: throw MirrordError("invalid message received from the mirrord binary")
                             val executionInfo = parser.parse(innerMessage, MirrordExecution::class.java)
                             setText("mirrord is running")
                             return executionInfo
@@ -282,7 +282,7 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
             environment["MIRRORD_PROGRESS_MODE"] = "json"
 
             for (entry in environment.entries) {
-                MirrordLogger.logger.info("environment var ${entry}")
+                MirrordLogger.logger.info("environment var $entry")
             }
         }
     }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -279,8 +279,6 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
 
             args?.let { extraArgs -> extraArgs.forEach { addParameter(it) } }
 
-            // TODO(alex): This is the only env var we get!
-
             environment["MIRRORD_PROGRESS_MODE"] = "json"
 
             for (entry in environment.entries) {

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -74,7 +74,7 @@ class MirrordApi(private val service: MirrordProjectService) {
             val pods = SafeParser().parse(data, Array<String>::class.java).toMutableList()
 
             if (pods.isEmpty()) {
-                project.service<MirrordProjectService>().notifier.notifySimple("No mirrord target available in the configured namespace. " + "You can run targetless, or set a different target namespace or kubeconfig in the mirrord configuration file.", NotificationType.INFORMATION)
+                project.service<MirrordProjectService>().notifier.notifySimple("No mirrord target available in the configured namespace. You can run targetless, or set a different target namespace or kubeconfig in the mirrord configuration file.", NotificationType.INFORMATION)
             }
 
             return pods

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -58,7 +58,9 @@ private const val FEEDBACK_COUNTER_REVIEW_AFTER = 100
  * Interact with mirrord CLI using this API.
  */
 class MirrordApi(private val service: MirrordProjectService) {
-    private class MirrordLsTask(cli: String) : MirrordCliTask<List<String>>(cli, "ls", null) {
+    private val envFromRunSettings: Map<String, String>? = getEnvVarsFromActiveLaunchSettings(this.service.project)
+
+    private class MirrordLsTask(cli: String, envFromRunSettings: Map<String, String>?) : MirrordCliTask<List<String>>(cli, "ls", null, envFromRunSettings) {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): List<String> {
             setText("mirrord is listing targets...")
 
@@ -88,7 +90,7 @@ class MirrordApi(private val service: MirrordProjectService) {
      * @return list of pods
      */
     fun listPods(cli: String, configFile: String?, wslDistribution: WSLDistribution?): List<String> {
-        val task = MirrordLsTask(cli).apply {
+        val task = MirrordLsTask(cli, envFromRunSettings).apply {
             this.configFile = configFile
             this.wslDistribution = wslDistribution
             this.output = "json"
@@ -97,7 +99,7 @@ class MirrordApi(private val service: MirrordProjectService) {
         return task.run(service.project)
     }
 
-    private class MirrordExtTask(cli: String) : MirrordCliTask<MirrordExecution>(cli, "ext", null) {
+    private class MirrordExtTask(cli: String, envFromRunSettings: Map<String, String>?) : MirrordCliTask<MirrordExecution>(cli, "ext", null, envFromRunSettings) {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): MirrordExecution {
             val parser = SafeParser()
             val bufferedReader = process.inputStream.reader().buffered()
@@ -150,7 +152,7 @@ class MirrordApi(private val service: MirrordProjectService) {
      * Reads the output (json) from stdout which contain either a success + warnings, or the errors from the verify
      * command.
      */
-    private class MirrordVerifyConfigTask(cli: String, path: String) : MirrordCliTask<String>(cli, "verify-config", listOf("--ide", path)) {
+    private class MirrordVerifyConfigTask(cli: String, path: String, envFromRunSettings: Map<String, String>?) : MirrordCliTask<String>(cli, "verify-config", listOf("--ide", path), envFromRunSettings) {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): String {
             setText("mirrord is verifying the config options...")
             process.waitFor()
@@ -175,7 +177,7 @@ class MirrordApi(private val service: MirrordProjectService) {
      * @return String containing a json with either a success + warnings, or the verified config errors.
      */
     fun verifyConfig(cli: String, configFilePath: String): String {
-        return MirrordVerifyConfigTask(cli, configFilePath).run(service.project)
+        return MirrordVerifyConfigTask(cli, configFilePath, envFromRunSettings).run(service.project)
     }
 
     /**
@@ -187,7 +189,7 @@ class MirrordApi(private val service: MirrordProjectService) {
     fun exec(cli: String, target: String?, configFile: String?, executable: String?, wslDistribution: WSLDistribution?): MirrordExecution {
         bumpFeedbackCounter()
 
-        val task = MirrordExtTask(cli).apply {
+        val task = MirrordExtTask(cli, envFromRunSettings).apply {
             this.target = target
             this.configFile = configFile
             this.executable = executable
@@ -233,7 +235,7 @@ fun getEnvVarsFromActiveLaunchSettings(project: Project): Map<String, String>? {
  *
  * @param args: An extra list of arguments (used by `verify-config`).
  */
-private abstract class MirrordCliTask<T>(private val cli: String, private val command: String, private val args: List<String>?) {
+private abstract class MirrordCliTask<T>(private val cli: String, private val command: String, private val args: List<String>?, private val envFromRunSettings: Map<String, String>?) {
     var target: String? = null
     var configFile: String? = null
     var executable: String? = null
@@ -246,8 +248,8 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
     private fun prepareCommandLine(project: Project): GeneralCommandLine {
         return GeneralCommandLine(cli, command).apply {
             // Merge our `environment` vars with what's set in the current launch run configuration.
-            getEnvVarsFromActiveLaunchSettings(project)?.let {
-                environment.putAll(it)
+            if (envFromRunSettings != null) {
+                environment.putAll(envFromRunSettings)
             }
 
             target?.let {

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -280,10 +280,6 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
             args?.let { extraArgs -> extraArgs.forEach { addParameter(it) } }
 
             environment["MIRRORD_PROGRESS_MODE"] = "json"
-
-            for (entry in environment.entries) {
-                MirrordLogger.logger.info("environment var $entry")
-            }
         }
     }
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -76,7 +76,8 @@ class MirrordBinaryManager {
 
             val manager = service<MirrordBinaryManager>()
 
-            val autoUpdate = MirrordSettingsState.instance.mirrordState.autoUpdate
+//            val autoUpdate = MirrordSettingsState.instance.mirrordState.autoUpdate
+            val autoUpdate = false
             val userSelectedMirrordVersion = MirrordSettingsState.instance.mirrordState.mirrordVersion
 
             val version = when {
@@ -285,7 +286,8 @@ class MirrordBinaryManager {
             MirrordLogger.logger.debug("failed to find mirrord in path", e)
         }
 
-        return null
+        MirrordLogger.logger.debug("no mirrord found on path")
+        return MirrordBinary("/home/meowjesty/dev/metalbear/mirrord/target/debug/mirrord")
     }
 
     /**

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -54,10 +54,10 @@ class MirrordBinaryManager {
      *                    Should be false if wslDistribution is unknown
      */
     private class UpdateTask(
-            private val project: Project,
-            private val product: String?,
-            private val wslDistribution: WSLDistribution?,
-            private val checkInPath: Boolean
+        private val project: Project,
+        private val product: String?,
+        private val wslDistribution: WSLDistribution?,
+        private val checkInPath: Boolean
     ) : Task.Backgroundable(project, "mirrord", true), DumbAware {
         companion object State {
             /**
@@ -86,10 +86,10 @@ class MirrordBinaryManager {
                         userSelectedMirrordVersion
                     } else {
                         project
-                                .service<MirrordProjectService>()
-                                .notifier
-                                .notification("mirrord version format is invalid!", NotificationType.WARNING)
-                                .fire()
+                            .service<MirrordProjectService>()
+                            .notifier
+                            .notification("mirrord version format is invalid!", NotificationType.WARNING)
+                            .fire()
                         return
                     }
                 }
@@ -112,8 +112,8 @@ class MirrordBinaryManager {
             }
 
             manager.latestSupportedVersion = version
-                    // auto update -> false -> mirrordVersion is empty -> no cli found locally -> fetch latest version
-                    ?: manager.fetchLatestSupportedVersion(product, indicator)
+                // auto update -> false -> mirrordVersion is empty -> no cli found locally -> fetch latest version
+                ?: manager.fetchLatestSupportedVersion(product, indicator)
 
             if (downloadInProgress.compareAndExchange(false, true)) {
                 return
@@ -127,8 +127,8 @@ class MirrordBinaryManager {
             MirrordLogger.logger.debug("binary update task failed", error)
 
             project.service<MirrordProjectService>()
-                    .notifier
-                    .notifyRichError("failed to update the mirrord binary: ${error.message ?: error.toString()}")
+                .notifier
+                .notifyRichError("failed to update the mirrord binary: ${error.message ?: error.toString()}")
         }
 
         override fun onFinished() {
@@ -140,12 +140,12 @@ class MirrordBinaryManager {
         override fun onSuccess() {
             downloadingVersion?.let {
                 project
-                        .service<MirrordProjectService>()
-                        .notifier
-                        .notifySimple(
-                                "downloaded mirrord binary version $downloadingVersion",
-                                NotificationType.INFORMATION
-                        )
+                    .service<MirrordProjectService>()
+                    .notifier
+                    .notifySimple(
+                        "downloaded mirrord binary version $downloadingVersion",
+                        NotificationType.INFORMATION
+                    )
             }
         }
 
@@ -160,8 +160,8 @@ class MirrordBinaryManager {
 
     private fun fetchLatestSupportedVersion(product: String?, indicator: ProgressIndicator): String {
         val pluginVersion = if (
-                System.getenv("CI_BUILD_PLUGIN") == "true" ||
-                System.getenv("PLUGIN_TESTING_ENVIRONMENT") == "true"
+            System.getenv("CI_BUILD_PLUGIN") == "true" ||
+            System.getenv("PLUGIN_TESTING_ENVIRONMENT") == "true"
         ) {
             "test"
         } else {
@@ -171,18 +171,18 @@ class MirrordBinaryManager {
         indicator.text = "mirrord is checking the latest supported binary version..."
 
         val url = StringBuilder(VERSION_ENDPOINT)
-                .append("?source=3")
-                .append("&version=")
-                .append(URLEncoder.encode(pluginVersion, Charset.defaultCharset()))
-                .append("&platform=")
-                .append(URLEncoder.encode(SystemInfo.OS_NAME, Charset.defaultCharset()))
-                .toString()
+            .append("?source=3")
+            .append("&version=")
+            .append(URLEncoder.encode(pluginVersion, Charset.defaultCharset()))
+            .append("&platform=")
+            .append(URLEncoder.encode(SystemInfo.OS_NAME, Charset.defaultCharset()))
+            .toString()
 
         val client = HttpClient.newHttpClient()
         val builder = HttpRequest
-                .newBuilder(URI(url))
-                .timeout(Duration.ofSeconds(10L))
-                .GET()
+            .newBuilder(URI(url))
+            .timeout(Duration.ofSeconds(10L))
+            .GET()
 
         product?.let { builder.header("user-agent", it) }
 
@@ -334,18 +334,18 @@ class MirrordBinaryManager {
             } ?: "using a possibly outdated local installation with version ${it.version}"
 
             project
-                    .service<MirrordProjectService>()
-                    .notifier
-                    .notification(message, NotificationType.WARNING)
-                    .withDontShowAgain(MirrordSettingsState.NotificationId.POSSIBLY_OUTDATED_BINARY_USED)
-                    .fire()
+                .service<MirrordProjectService>()
+                .notifier
+                .notification(message, NotificationType.WARNING)
+                .withDontShowAgain(MirrordSettingsState.NotificationId.POSSIBLY_OUTDATED_BINARY_USED)
+                .fire()
 
             return it.command
         }
 
         throw MirrordError(
-                "no local installation of mirrord binary was found",
-                "mirrord binary will be downloaded in the background"
+            "no local installation of mirrord binary was found",
+            "mirrord binary will be downloaded in the background"
         )
     }
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -54,10 +54,10 @@ class MirrordBinaryManager {
      *                    Should be false if wslDistribution is unknown
      */
     private class UpdateTask(
-        private val project: Project,
-        private val product: String?,
-        private val wslDistribution: WSLDistribution?,
-        private val checkInPath: Boolean
+            private val project: Project,
+            private val product: String?,
+            private val wslDistribution: WSLDistribution?,
+            private val checkInPath: Boolean
     ) : Task.Backgroundable(project, "mirrord", true), DumbAware {
         companion object State {
             /**
@@ -76,8 +76,7 @@ class MirrordBinaryManager {
 
             val manager = service<MirrordBinaryManager>()
 
-//            val autoUpdate = MirrordSettingsState.instance.mirrordState.autoUpdate
-            val autoUpdate = false
+            val autoUpdate = MirrordSettingsState.instance.mirrordState.autoUpdate
             val userSelectedMirrordVersion = MirrordSettingsState.instance.mirrordState.mirrordVersion
 
             val version = when {
@@ -87,10 +86,10 @@ class MirrordBinaryManager {
                         userSelectedMirrordVersion
                     } else {
                         project
-                            .service<MirrordProjectService>()
-                            .notifier
-                            .notification("mirrord version format is invalid!", NotificationType.WARNING)
-                            .fire()
+                                .service<MirrordProjectService>()
+                                .notifier
+                                .notification("mirrord version format is invalid!", NotificationType.WARNING)
+                                .fire()
                         return
                     }
                 }
@@ -113,8 +112,8 @@ class MirrordBinaryManager {
             }
 
             manager.latestSupportedVersion = version
-                // auto update -> false -> mirrordVersion is empty -> no cli found locally -> fetch latest version
-                ?: manager.fetchLatestSupportedVersion(product, indicator)
+                    // auto update -> false -> mirrordVersion is empty -> no cli found locally -> fetch latest version
+                    ?: manager.fetchLatestSupportedVersion(product, indicator)
 
             if (downloadInProgress.compareAndExchange(false, true)) {
                 return
@@ -128,8 +127,8 @@ class MirrordBinaryManager {
             MirrordLogger.logger.debug("binary update task failed", error)
 
             project.service<MirrordProjectService>()
-                .notifier
-                .notifyRichError("failed to update the mirrord binary: ${error.message ?: error.toString()}")
+                    .notifier
+                    .notifyRichError("failed to update the mirrord binary: ${error.message ?: error.toString()}")
         }
 
         override fun onFinished() {
@@ -141,12 +140,12 @@ class MirrordBinaryManager {
         override fun onSuccess() {
             downloadingVersion?.let {
                 project
-                    .service<MirrordProjectService>()
-                    .notifier
-                    .notifySimple(
-                        "downloaded mirrord binary version $downloadingVersion",
-                        NotificationType.INFORMATION
-                    )
+                        .service<MirrordProjectService>()
+                        .notifier
+                        .notifySimple(
+                                "downloaded mirrord binary version $downloadingVersion",
+                                NotificationType.INFORMATION
+                        )
             }
         }
 
@@ -161,8 +160,8 @@ class MirrordBinaryManager {
 
     private fun fetchLatestSupportedVersion(product: String?, indicator: ProgressIndicator): String {
         val pluginVersion = if (
-            System.getenv("CI_BUILD_PLUGIN") == "true" ||
-            System.getenv("PLUGIN_TESTING_ENVIRONMENT") == "true"
+                System.getenv("CI_BUILD_PLUGIN") == "true" ||
+                System.getenv("PLUGIN_TESTING_ENVIRONMENT") == "true"
         ) {
             "test"
         } else {
@@ -172,18 +171,18 @@ class MirrordBinaryManager {
         indicator.text = "mirrord is checking the latest supported binary version..."
 
         val url = StringBuilder(VERSION_ENDPOINT)
-            .append("?source=3")
-            .append("&version=")
-            .append(URLEncoder.encode(pluginVersion, Charset.defaultCharset()))
-            .append("&platform=")
-            .append(URLEncoder.encode(SystemInfo.OS_NAME, Charset.defaultCharset()))
-            .toString()
+                .append("?source=3")
+                .append("&version=")
+                .append(URLEncoder.encode(pluginVersion, Charset.defaultCharset()))
+                .append("&platform=")
+                .append(URLEncoder.encode(SystemInfo.OS_NAME, Charset.defaultCharset()))
+                .toString()
 
         val client = HttpClient.newHttpClient()
         val builder = HttpRequest
-            .newBuilder(URI(url))
-            .timeout(Duration.ofSeconds(10L))
-            .GET()
+                .newBuilder(URI(url))
+                .timeout(Duration.ofSeconds(10L))
+                .GET()
 
         product?.let { builder.header("user-agent", it) }
 
@@ -261,7 +260,7 @@ class MirrordBinaryManager {
     /**
      * @return executable found with `which mirrord`
      */
-    private fun findBinaryInPath(requiredVersion: String?, wslDistribution: WSLDistribution?): MirrordBinary? {
+    private fun findBinaryInPath(requiredVersion: String?, wslDistribution: WSLDistribution?): MirrordBinary {
         try {
             val output = if (wslDistribution == null) {
                 val child = Runtime.getRuntime().exec(arrayOf("which", "mirrord"))
@@ -335,18 +334,18 @@ class MirrordBinaryManager {
             } ?: "using a possibly outdated local installation with version ${it.version}"
 
             project
-                .service<MirrordProjectService>()
-                .notifier
-                .notification(message, NotificationType.WARNING)
-                .withDontShowAgain(MirrordSettingsState.NotificationId.POSSIBLY_OUTDATED_BINARY_USED)
-                .fire()
+                    .service<MirrordProjectService>()
+                    .notifier
+                    .notification(message, NotificationType.WARNING)
+                    .withDontShowAgain(MirrordSettingsState.NotificationId.POSSIBLY_OUTDATED_BINARY_USED)
+                    .fire()
 
             return it.command
         }
 
         throw MirrordError(
-            "no local installation of mirrord binary was found",
-            "mirrord binary will be downloaded in the background"
+                "no local installation of mirrord binary was found",
+                "mirrord binary will be downloaded in the background"
         )
     }
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -280,6 +280,8 @@ class MirrordBinaryManager {
             val binary = MirrordBinary(output)
             if (requiredVersion == null || requiredVersion == binary.version) {
                 return binary
+            } else {
+                return null
             }
         } catch (e: Exception) {
             MirrordLogger.logger.debug("failed to find mirrord in path", e)

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -260,7 +260,7 @@ class MirrordBinaryManager {
     /**
      * @return executable found with `which mirrord`
      */
-    private fun findBinaryInPath(requiredVersion: String?, wslDistribution: WSLDistribution?): MirrordBinary {
+    private fun findBinaryInPath(requiredVersion: String?, wslDistribution: WSLDistribution?): MirrordBinary? {
         try {
             val output = if (wslDistribution == null) {
                 val child = Runtime.getRuntime().exec(arrayOf("which", "mirrord"))
@@ -283,10 +283,8 @@ class MirrordBinaryManager {
             }
         } catch (e: Exception) {
             MirrordLogger.logger.debug("failed to find mirrord in path", e)
+            return null
         }
-
-        MirrordLogger.logger.debug("no mirrord found on path")
-        return MirrordBinary("/home/meowjesty/dev/metalbear/mirrord/target/debug/mirrord")
     }
 
     /**

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -278,10 +278,10 @@ class MirrordBinaryManager {
             }
 
             val binary = MirrordBinary(output)
-            if (requiredVersion == null || requiredVersion == binary.version) {
-                return binary
+            return if (requiredVersion == null || requiredVersion == binary.version) {
+                binary
             } else {
-                return null
+                null
             }
         } catch (e: Exception) {
             MirrordLogger.logger.debug("failed to find mirrord in path", e)

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -21,16 +21,16 @@ class MirrordExecManager(private val service: MirrordProjectService) {
      * @throws ProcessCanceledException if the dialog cannot be displayed
      */
     private fun chooseTarget(
-        cli: String,
-        wslDistribution: WSLDistribution?,
-        config: String?
+            cli: String,
+            wslDistribution: WSLDistribution?,
+            config: String?
     ): String {
         MirrordLogger.logger.debug("choose target called")
 
         val pods = service.mirrordApi.listPods(
-            cli,
-            config,
-            wslDistribution
+                cli,
+                config,
+                wslDistribution
         )
 
         val application = ApplicationManager.getApplication()
@@ -50,27 +50,27 @@ class MirrordExecManager(private val service: MirrordProjectService) {
             MirrordLogger.logger.debug("read lock detected, aborting target selection")
 
             service
-                .notifier
-                .notification(
-                    "mirrord plugin was unable to display the target selection dialog. " +
-                        "You can set it manually in the configuration file $config.",
-                    NotificationType.WARNING
-                )
-                .apply {
-                    val configFile = try {
-                        val path = Path.of(config)
-                        VirtualFileManager.getInstance().findFileByNioPath(path)
-                    } catch (e: Exception) {
-                        MirrordLogger.logger.debug("failed to find config under path $config", e)
-                        null
-                    }
+                    .notifier
+                    .notification(
+                            "mirrord plugin was unable to display the target selection dialog. " +
+                                    "You can set it manually in the configuration file $config.",
+                            NotificationType.WARNING
+                    )
+                    .apply {
+                        val configFile = try {
+                            val path = Path.of(config)
+                            VirtualFileManager.getInstance().findFileByNioPath(path)
+                        } catch (e: Exception) {
+                            MirrordLogger.logger.debug("failed to find config under path $config", e)
+                            null
+                        }
 
-                    configFile?.let {
-                        withOpenFile(it)
+                        configFile?.let {
+                            withOpenFile(it)
+                        }
                     }
-                }
-                .withLink("Config doc", "https://mirrord.dev/docs/overview/configuration/#root-target")
-                .fire()
+                    .withLink("Config doc", "https://mirrord.dev/docs/overview/configuration/#root-target")
+                    .fire()
 
             null
         }
@@ -91,10 +91,10 @@ class MirrordExecManager(private val service: MirrordProjectService) {
      * @throws ProcessCanceledException if the user cancelled
      */
     private fun start(
-        wslDistribution: WSLDistribution?,
-        executable: String?,
-        product: String,
-        mirrordConfigFromEnv: String?
+            wslDistribution: WSLDistribution?,
+            executable: String?,
+            product: String,
+            mirrordConfigFromEnv: String?
     ): Pair<Map<String, String>, String?>? {
         if (!service.enabled) {
             MirrordLogger.logger.debug("disabled, returning")
@@ -106,7 +106,7 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         }
 
         MirrordLogger.logger.debug("version check trigger")
-        // service.versionCheck.checkVersion() // TODO makes an HTTP request, move to background
+        service.versionCheck.checkVersion() // TODO makes an HTTP request, move to background
 
         val cli = cliPath(wslDistribution, product)
         val config = service.configApi.getConfigPath(mirrordConfigFromEnv)
@@ -135,21 +135,21 @@ class MirrordExecManager(private val service: MirrordProjectService) {
             if (target == MirrordExecDialog.targetlessTargetName) {
                 MirrordLogger.logger.info("No target specified - running targetless")
                 service.notifier.notification(
-                    "No target specified, mirrord running targetless.",
-                    NotificationType.INFORMATION
+                        "No target specified, mirrord running targetless.",
+                        NotificationType.INFORMATION
                 )
-                    .withDontShowAgain(MirrordSettingsState.NotificationId.RUNNING_TARGETLESS)
-                    .fire()
+                        .withDontShowAgain(MirrordSettingsState.NotificationId.RUNNING_TARGETLESS)
+                        .fire()
                 target = null
             }
         }
 
         val executionInfo = service.mirrordApi.exec(
-            cli,
-            target,
-            config,
-            executable,
-            wslDistribution
+                cli,
+                target,
+                config,
+                executable,
+                wslDistribution
         )
 
         executionInfo.environment["MIRRORD_IGNORE_DEBUGGER_PORTS"] = "35000-65535"

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -181,6 +181,8 @@ class MirrordExecManager(private val service: MirrordProjectService) {
             extraEnvVars?.plus(envRunSettings ?: emptyMap()) ?: envRunSettings
         }
 
+        //val extraEnv = params.env + (configuration as ExternalSystemRunConfiguration).settings.env
+
         var wsl: WSLDistribution? = null
         var executable: String? = null
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -174,9 +174,6 @@ class MirrordExecManager(private val service: MirrordProjectService) {
      * Helps to handle special cases and differences between the IDEs or language runners (like npm).
      */
     class Wrapper(private val manager: MirrordExecManager, private val product: String, private val extraEnvVars: Map<String, String>?) {
-
-        //val extraEnv = params.env + (configuration as ExternalSystemRunConfiguration).settings.env
-
         var wsl: WSLDistribution? = null
         var executable: String? = null
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -93,10 +93,10 @@ class MirrordExecManager(private val service: MirrordProjectService) {
      * @throws ProcessCanceledException if the user cancelled
      */
     private fun start(
-            wslDistribution: WSLDistribution?,
-            executable: String?,
-            product: String,
-            projectEnvVars: Map<String, String>?
+        wslDistribution: WSLDistribution?,
+        executable: String?,
+        product: String,
+        projectEnvVars: Map<String, String>?
     ): Pair<Map<String, String>, String?>? {
         if (!service.enabled) {
             MirrordLogger.logger.debug("disabled, returning")

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -21,16 +21,16 @@ class MirrordExecManager(private val service: MirrordProjectService) {
      * @throws ProcessCanceledException if the dialog cannot be displayed
      */
     private fun chooseTarget(
-            cli: String,
-            wslDistribution: WSLDistribution?,
-            config: String?
+        cli: String,
+        wslDistribution: WSLDistribution?,
+        config: String?
     ): String {
         MirrordLogger.logger.debug("choose target called")
 
         val pods = service.mirrordApi.listPods(
-                cli,
-                config,
-                wslDistribution
+            cli,
+            config,
+            wslDistribution
         )
 
         val application = ApplicationManager.getApplication()
@@ -50,27 +50,27 @@ class MirrordExecManager(private val service: MirrordProjectService) {
             MirrordLogger.logger.debug("read lock detected, aborting target selection")
 
             service
-                    .notifier
-                    .notification(
-                            "mirrord plugin was unable to display the target selection dialog. " +
-                                    "You can set it manually in the configuration file $config.",
-                            NotificationType.WARNING
-                    )
-                    .apply {
-                        val configFile = try {
-                            val path = Path.of(config)
-                            VirtualFileManager.getInstance().findFileByNioPath(path)
-                        } catch (e: Exception) {
-                            MirrordLogger.logger.debug("failed to find config under path $config", e)
-                            null
-                        }
-
-                        configFile?.let {
-                            withOpenFile(it)
-                        }
+                .notifier
+                .notification(
+                    "mirrord plugin was unable to display the target selection dialog. " +
+                        "You can set it manually in the configuration file $config.",
+                    NotificationType.WARNING
+                )
+                .apply {
+                    val configFile = try {
+                        val path = Path.of(config)
+                        VirtualFileManager.getInstance().findFileByNioPath(path)
+                    } catch (e: Exception) {
+                        MirrordLogger.logger.debug("failed to find config under path $config", e)
+                        null
                     }
-                    .withLink("Config doc", "https://mirrord.dev/docs/overview/configuration/#root-target")
-                    .fire()
+
+                    configFile?.let {
+                        withOpenFile(it)
+                    }
+                }
+                .withLink("Config doc", "https://mirrord.dev/docs/overview/configuration/#root-target")
+                .fire()
 
             null
         }
@@ -91,10 +91,10 @@ class MirrordExecManager(private val service: MirrordProjectService) {
      * @throws ProcessCanceledException if the user cancelled
      */
     private fun start(
-            wslDistribution: WSLDistribution?,
-            executable: String?,
-            product: String,
-            mirrordConfigFromEnv: String?
+        wslDistribution: WSLDistribution?,
+        executable: String?,
+        product: String,
+        mirrordConfigFromEnv: String?
     ): Pair<Map<String, String>, String?>? {
         if (!service.enabled) {
             MirrordLogger.logger.debug("disabled, returning")
@@ -135,21 +135,21 @@ class MirrordExecManager(private val service: MirrordProjectService) {
             if (target == MirrordExecDialog.targetlessTargetName) {
                 MirrordLogger.logger.info("No target specified - running targetless")
                 service.notifier.notification(
-                        "No target specified, mirrord running targetless.",
-                        NotificationType.INFORMATION
+                    "No target specified, mirrord running targetless.",
+                    NotificationType.INFORMATION
                 )
-                        .withDontShowAgain(MirrordSettingsState.NotificationId.RUNNING_TARGETLESS)
-                        .fire()
+                    .withDontShowAgain(MirrordSettingsState.NotificationId.RUNNING_TARGETLESS)
+                    .fire()
                 target = null
             }
         }
 
         val executionInfo = service.mirrordApi.exec(
-                cli,
-                target,
-                config,
-                executable,
-                wslDistribution
+            cli,
+            target,
+            config,
+            executable,
+            wslDistribution
         )
 
         executionInfo.environment["MIRRORD_IGNORE_DEBUGGER_PORTS"] = "35000-65535"

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -106,7 +106,7 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         }
 
         MirrordLogger.logger.debug("version check trigger")
-        service.versionCheck.checkVersion() // TODO makes an HTTP request, move to background
+        // service.versionCheck.checkVersion() // TODO makes an HTTP request, move to background
 
         val cli = cliPath(wslDistribution, product)
         val config = service.configApi.getConfigPath(mirrordConfigFromEnv)

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VirtualFileManager
-import com.intellij.util.alsoIfNull
 import java.nio.file.Path
 
 /**
@@ -94,10 +93,10 @@ class MirrordExecManager(private val service: MirrordProjectService) {
      * @throws ProcessCanceledException if the user cancelled
      */
     private fun start(
-            wslDistribution: WSLDistribution?,
-            executable: String?,
-            product: String,
-            envFromRunSettings: Map<String, String>?
+        wslDistribution: WSLDistribution?,
+        executable: String?,
+        product: String,
+        envFromRunSettings: Map<String, String>?
     ): Pair<Map<String, String>, String?>? {
         if (!service.enabled) {
             MirrordLogger.logger.debug("disabled, returning")
@@ -195,7 +194,6 @@ class MirrordExecManager(private val service: MirrordProjectService) {
                 throw e
             }
         }
-
     }
 
     /**

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNpmExecutionListener.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNpmExecutionListener.kt
@@ -43,7 +43,6 @@ class MirrordNpmExecutionListener : ExecutionListener {
             service.execManager.wrapper("JS").apply {
                 wsl = wslDistribution
                 executable = executablePath
-                configFromEnv = runSettings.envs[CONFIG_ENV_NAME]
             }.start()?.let { (newEnv, patchedPath) ->
                 runSettings.envs = executionGuard.originEnv + newEnv
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNpmExecutionListener.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNpmExecutionListener.kt
@@ -40,7 +40,7 @@ class MirrordNpmExecutionListener : ExecutionListener {
 
             executionGuard.originEnv = LinkedHashMap(runSettings.envs)
 
-            service.execManager.wrapper("JS").apply {
+            service.execManager.wrapper("JS", executionGuard.originEnv).apply {
                 wsl = wslDistribution
                 executable = executablePath
             }.start()?.let { (newEnv, patchedPath) ->

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordProjectService.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordProjectService.kt
@@ -17,7 +17,7 @@ class MirrordProjectService(val project: Project) : Disposable {
 
     val versionCheck: MirrordVersionCheck = MirrordVersionCheck(this)
 
-    val mirrordApi: MirrordApi = MirrordApi(this)
+    val mirrordApi: MirrordApi = MirrordApi(this, null)
 
     val notifier: MirrordNotifier = MirrordNotifier(this)
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordProjectService.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordProjectService.kt
@@ -17,9 +17,7 @@ class MirrordProjectService(val project: Project) : Disposable {
 
     val versionCheck: MirrordVersionCheck = MirrordVersionCheck(this)
 
-    val mirrordApi: MirrordApi = MirrordApi(this, null)
-
-    fun mirrordApi(environment: Map<String, String>) : MirrordApi {
+    fun mirrordApi(environment: Map<String, String>?) : MirrordApi {
         return MirrordApi(this, environment)
     }
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordProjectService.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordProjectService.kt
@@ -17,7 +17,7 @@ class MirrordProjectService(val project: Project) : Disposable {
 
     val versionCheck: MirrordVersionCheck = MirrordVersionCheck(this)
 
-    fun mirrordApi(environment: Map<String, String>?) : MirrordApi {
+    fun mirrordApi(environment: Map<String, String>?): MirrordApi {
         return MirrordApi(this, environment)
     }
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordProjectService.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordProjectService.kt
@@ -19,6 +19,10 @@ class MirrordProjectService(val project: Project) : Disposable {
 
     val mirrordApi: MirrordApi = MirrordApi(this, null)
 
+    fun mirrordApi(environment: Map<String, String>) : MirrordApi {
+        return MirrordApi(this, environment)
+    }
+
     val notifier: MirrordNotifier = MirrordNotifier(this)
 
     @Volatile

--- a/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
+++ b/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
@@ -48,9 +48,8 @@ class GolandRunConfigurationExtension : GoRunConfigurationExtension() {
                 }
             }
 
-            service.execManager.wrapper("goland").apply {
+            service.execManager.wrapper("goland", configuration.getCustomEnvironment()).apply {
                 this.wsl = wsl
-                configFromEnv = configuration.getCustomEnvironment()[CONFIG_ENV_NAME]
             }.start()?.first?.let { env ->
                 val withLaunchEnvVars = getEnvVarsFromActiveLaunchSettings(service.project)?.let { launchEnvVars ->
                     env + launchEnvVars

--- a/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
+++ b/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.util.SystemInfo
 import com.metalbear.mirrord.CONFIG_ENV_NAME
 import com.metalbear.mirrord.MirrordPathManager
 import com.metalbear.mirrord.MirrordProjectService
+import com.metalbear.mirrord.getEnvVarsFromActiveLaunchSettings
 import java.nio.file.Paths
 
 class GolandRunConfigurationExtension : GoRunConfigurationExtension() {
@@ -51,7 +52,11 @@ class GolandRunConfigurationExtension : GoRunConfigurationExtension() {
                 this.wsl = wsl
                 configFromEnv = configuration.getCustomEnvironment()[CONFIG_ENV_NAME]
             }.start()?.first?.let { env ->
-                for (entry in env.entries.iterator()) {
+                val withLaunchEnvVars = getEnvVarsFromActiveLaunchSettings(service.project)?.let { launchEnvVars ->
+                    env + launchEnvVars
+                } ?: env
+
+                for (entry in withLaunchEnvVars.entries.iterator()) {
                     cmdLine.addEnvironmentVariable(entry.key, entry.value)
                 }
                 cmdLine.addEnvironmentVariable("MIRRORD_SKIP_PROCESSES", "dlv;debugserver;go")

--- a/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
+++ b/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
@@ -10,7 +10,6 @@ import com.intellij.execution.target.TargetedCommandLineBuilder
 import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.openapi.components.service
 import com.intellij.openapi.util.SystemInfo
-import com.metalbear.mirrord.CONFIG_ENV_NAME
 import com.metalbear.mirrord.MirrordPathManager
 import com.metalbear.mirrord.MirrordProjectService
 import com.metalbear.mirrord.getEnvVarsFromActiveLaunchSettings

--- a/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
+++ b/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
@@ -12,7 +12,6 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.util.SystemInfo
 import com.metalbear.mirrord.MirrordPathManager
 import com.metalbear.mirrord.MirrordProjectService
-import com.metalbear.mirrord.getEnvVarsFromActiveLaunchSettings
 import java.nio.file.Paths
 
 class GolandRunConfigurationExtension : GoRunConfigurationExtension() {
@@ -50,11 +49,7 @@ class GolandRunConfigurationExtension : GoRunConfigurationExtension() {
             service.execManager.wrapper("goland", configuration.getCustomEnvironment()).apply {
                 this.wsl = wsl
             }.start()?.first?.let { env ->
-                val withLaunchEnvVars = getEnvVarsFromActiveLaunchSettings(service.project)?.let { launchEnvVars ->
-                    env + launchEnvVars
-                } ?: env
-
-                for (entry in withLaunchEnvVars.entries.iterator()) {
+                for (entry in env.entries.iterator()) {
                     cmdLine.addEnvironmentVariable(entry.key, entry.value)
                 }
                 cmdLine.addEnvironmentVariable("MIRRORD_SKIP_PROCESSES", "dlv;debugserver;go")

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
@@ -65,7 +65,8 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
             else -> null
         }
 
-        val mirrordEnv = service.execManager.wrapper("idea", null).apply {
+        val extraEnv = params.env + (configuration as ExternalSystemRunConfiguration).settings.env
+        val mirrordEnv = service.execManager.wrapper("idea", extraEnv).apply {
             this.wsl = wsl
         }.start()?.first?.let { it + mapOf(Pair("MIRRORD_DETECT_DEBUGGER_PORT", "javaagent")) }.orEmpty()
 

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
@@ -65,7 +65,6 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
 
         val mirrordEnv = service.execManager.wrapper("idea").apply {
             this.wsl = wsl
-            configFromEnv = getMirrordConfigPath(configuration, params)
         }.start()?.first?.let { it + mapOf(Pair("MIRRORD_DETECT_DEBUGGER_PORT", "javaagent")) }.orEmpty()
 
         params.env = params.env + mirrordEnv

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
@@ -63,7 +63,7 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
             else -> null
         }
 
-        val mirrordEnv = service.execManager.wrapper("idea").apply {
+        val mirrordEnv = service.execManager.wrapper("idea", null).apply {
             this.wsl = wsl
         }.start()?.first?.let { it + mapOf(Pair("MIRRORD_DETECT_DEBUGGER_PORT", "javaagent")) }.orEmpty()
 

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
@@ -65,7 +65,13 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
             else -> null
         }
 
-        val extraEnv = params.env + (configuration as ExternalSystemRunConfiguration).settings.env
+        val extraEnv = if (configuration is ExternalSystemRunConfiguration) {
+            val extraEnv = params.env + configuration.settings.env
+            extraEnv
+        } else {
+            params.env
+        }
+
         val mirrordEnv = service.execManager.wrapper("idea", extraEnv).apply {
             this.wsl = wsl
         }.start()?.first?.let { it + mapOf(Pair("MIRRORD_DETECT_DEBUGGER_PORT", "javaagent")) }.orEmpty()

--- a/modules/products/nodejs/src/main/kotlin/com/metalbear/mirrord/products/nodejs/NodeRunConfigurationExtension.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/metalbear/mirrord/products/nodejs/NodeRunConfigurationExtension.kt
@@ -9,7 +9,6 @@ import com.intellij.javascript.nodejs.execution.runConfiguration.NodeRunConfigur
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.SettingsEditor
 import com.jetbrains.nodejs.run.NodeJsRunConfiguration
-import com.metalbear.mirrord.CONFIG_ENV_NAME
 import com.metalbear.mirrord.MirrordProjectService
 import javax.swing.JPanel
 
@@ -40,15 +39,14 @@ class NodeRunConfigurationExtension : AbstractNodeRunConfigurationExtension() {
 
                 // following try-catch is to maintain backward compatibility with older versions of webstorm
                 val extraEnvVars = try {
-                            targetRun.envData.envs
-                        } catch (e: NoSuchMethodError) {
-                            val config = configuration as NodeJsRunConfiguration
-                            config.envs
-                        }
+                    targetRun.envData.envs
+                } catch (e: NoSuchMethodError) {
+                    val config = configuration as NodeJsRunConfiguration
+                    config.envs
+                }
 
                 service.execManager.wrapper("nodejs", extraEnvVars).apply {
                     this.wsl = wsl
-
                 }.start()?.first?.forEach { (key, value) ->
                     targetRun.commandLineBuilder.addEnvironmentVariable(key, value)
                 }

--- a/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonCommandLineProvider.kt
+++ b/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonCommandLineProvider.kt
@@ -8,7 +8,6 @@ import com.jetbrains.python.run.PythonExecution
 import com.jetbrains.python.run.PythonRunParams
 import com.jetbrains.python.run.target.HelpersAwareTargetEnvironmentRequest
 import com.jetbrains.python.run.target.PythonCommandLineTargetEnvironmentProvider
-import com.metalbear.mirrord.CONFIG_ENV_NAME
 import com.metalbear.mirrord.MirrordProjectService
 
 class PythonCommandLineProvider : PythonCommandLineTargetEnvironmentProvider {

--- a/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonCommandLineProvider.kt
+++ b/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonCommandLineProvider.kt
@@ -29,9 +29,8 @@ class PythonCommandLineProvider : PythonCommandLineTargetEnvironmentProvider {
                 }
             }
 
-            service.execManager.wrapper("pycharm").apply {
+            service.execManager.wrapper("pycharm", runParams.getEnvs()).apply {
                 this.wsl = wsl
-                configFromEnv = runParams.getEnvs()[CONFIG_ENV_NAME]
             }.start()?.first?.let { env ->
                 for (entry in env.entries.iterator()) {
                     pythonExecution.addEnvironmentVariable(entry.key, entry.value)

--- a/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonRunConfigurationExtension.kt
+++ b/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonRunConfigurationExtension.kt
@@ -7,7 +7,6 @@ import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.openapi.components.service
 import com.jetbrains.python.run.AbstractPythonRunConfiguration
 import com.jetbrains.python.run.PythonRunConfigurationExtension
-import com.metalbear.mirrord.CONFIG_ENV_NAME
 import com.metalbear.mirrord.MirrordProjectService
 
 class PythonRunConfigurationExtension : PythonRunConfigurationExtension() {

--- a/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonRunConfigurationExtension.kt
+++ b/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonRunConfigurationExtension.kt
@@ -37,9 +37,8 @@ class PythonRunConfigurationExtension : PythonRunConfigurationExtension() {
 
         val currentEnv = cmdLine.environment
 
-        service.execManager.wrapper("pycharm").apply {
+        service.execManager.wrapper("pycharm", currentEnv).apply {
             this.wsl = wsl
-            configFromEnv = currentEnv[CONFIG_ENV_NAME]
         }.start()?.first?.let { env ->
             for (entry in env.entries.iterator()) {
                 currentEnv[entry.key] = entry.value

--- a/modules/products/rider/src/main/kotlin/com/metalbear/mirrord/products/rider/RiderPatchCommandLineExtension.kt
+++ b/modules/products/rider/src/main/kotlin/com/metalbear/mirrord/products/rider/RiderPatchCommandLineExtension.kt
@@ -32,10 +32,8 @@ class RiderPatchCommandLineExtension : PatchCommandLineExtension {
             }
         }
 
-        service.execManager.wrapper("rider").apply {
+        service.execManager.wrapper("rider", commandLine.environment).apply {
             this.wsl = wsl
-            configFromEnv =
-                commandLine.environment[CONFIG_ENV_NAME] ?: RiderLaunchSettingsExtension.configFromEnvs.remove(project)
         }.start()?.first?.let { env ->
             for (entry in env.entries.iterator()) {
                 commandLine.withEnvironment(entry.key, entry.value)

--- a/modules/products/rider/src/main/kotlin/com/metalbear/mirrord/products/rider/RiderPatchCommandLineExtension.kt
+++ b/modules/products/rider/src/main/kotlin/com/metalbear/mirrord/products/rider/RiderPatchCommandLineExtension.kt
@@ -16,7 +16,6 @@ import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rider.run.PatchCommandLineExtension
 import com.jetbrains.rider.run.WorkerRunInfo
 import com.jetbrains.rider.runtime.DotNetRuntime
-import com.metalbear.mirrord.CONFIG_ENV_NAME
 import com.metalbear.mirrord.MirrordProjectService
 import org.jetbrains.concurrency.Promise
 import org.jetbrains.concurrency.resolvedPromise

--- a/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
+++ b/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
@@ -8,7 +8,6 @@ import com.intellij.execution.target.createEnvironmentRequest
 import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.openapi.components.service
 import com.intellij.openapi.util.SystemInfo
-import com.metalbear.mirrord.CONFIG_ENV_NAME
 import com.metalbear.mirrord.MirrordError
 import com.metalbear.mirrord.MirrordProjectService
 import org.jetbrains.plugins.ruby.ruby.run.configuration.AbstractRubyRunConfiguration

--- a/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
+++ b/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
@@ -44,12 +44,11 @@ class RubyMineRunConfigurationExtension : RubyRunConfigurationExtension() {
         }
 
         val currentEnv = cmdLine.environment
-        service.execManager.wrapper("rubymine").apply {
+        service.execManager.wrapper("rubymine", configuration.envs).apply {
             this.wsl = wsl
             if (isMac) {
                 this.executable = cmdLine.exePath
             }
-            configFromEnv = configuration.envs[CONFIG_ENV_NAME]
         }.start()?.let { (mirrordEnv, patched) ->
             // this is the env the Ruby app and the layer see, at least with RVM.
             cmdLine.withEnvironment(mirrordEnv)

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -13,7 +13,6 @@ import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.service
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordProjectService
-import com.metalbear.mirrord.getEnvVarsFromActiveLaunchSettings
 import java.util.concurrent.ConcurrentHashMap
 
 private const val DEFAULT_TOMCAT_SERVER_PORT: String = "8005"
@@ -42,6 +41,7 @@ class TomcatExecutionListener : ExecutionListener {
     override fun processStartScheduled(executorId: String, env: ExecutionEnvironment) {
         getConfig(env)?.let { config ->
             val envVars = config.envVariables
+            val envVarsMap = envVars.map { it.NAME to it.VALUE }.toMap()
 
             val service = env.project.service<MirrordProjectService>()
 
@@ -52,8 +52,7 @@ class TomcatExecutionListener : ExecutionListener {
             }
 
             try {
-                val extraEnvVars = getEnvVarsFromActiveLaunchSettings(env.project)
-                service.execManager.wrapper("idea", extraEnvVars).apply {
+                service.execManager.wrapper("idea", envVarsMap).apply {
                     this.wsl = wsl
                     // configFromEnv = envVars.find { e -> e.name == CONFIG_ENV_NAME }?.VALUE
                 }.start()?.first?.let {

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -11,7 +11,6 @@ import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.javaee.appServers.run.configuration.RunnerSpecificLocalConfigurationBit
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.service
-import com.metalbear.mirrord.CONFIG_ENV_NAME
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordProjectService
 import com.metalbear.mirrord.getEnvVarsFromActiveLaunchSettings
@@ -45,7 +44,6 @@ class TomcatExecutionListener : ExecutionListener {
             val envVars = config.envVariables
 
             val service = env.project.service<MirrordProjectService>()
-            env.project
 
             MirrordLogger.logger.debug("wsl check")
             val wsl = when (val request = createEnvironmentRequest(env.runProfile, env.project)) {
@@ -53,11 +51,11 @@ class TomcatExecutionListener : ExecutionListener {
                 else -> null
             }
 
-            val envVarsFromRunSettings = getEnvVarsFromActiveLaunchSettings(env.project)
             try {
-                service.execManager.wrapper("idea", envVarsFromRunSettings).apply {
+                val extraEnvVars = getEnvVarsFromActiveLaunchSettings(env.project)
+                service.execManager.wrapper("idea", extraEnvVars).apply {
                     this.wsl = wsl
-                    configFromEnv = envVars.find { e -> e.name == CONFIG_ENV_NAME }?.VALUE
+                    // configFromEnv = envVars.find { e -> e.name == CONFIG_ENV_NAME }?.VALUE
                 }.start()?.first?.let {
                     // `MIRRORD_IGNORE_DEBUGGER_PORTS` should allow clean shutdown of the app
                     // even if `outgoing` feature is enabled.

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.components.service
 import com.metalbear.mirrord.CONFIG_ENV_NAME
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordProjectService
+import com.metalbear.mirrord.getEnvVarsFromActiveLaunchSettings
 import java.util.concurrent.ConcurrentHashMap
 
 private const val DEFAULT_TOMCAT_SERVER_PORT: String = "8005"
@@ -44,6 +45,7 @@ class TomcatExecutionListener : ExecutionListener {
             val envVars = config.envVariables
 
             val service = env.project.service<MirrordProjectService>()
+            env.project
 
             MirrordLogger.logger.debug("wsl check")
             val wsl = when (val request = createEnvironmentRequest(env.runProfile, env.project)) {
@@ -51,8 +53,9 @@ class TomcatExecutionListener : ExecutionListener {
                 else -> null
             }
 
+            val envVarsFromRunSettings = getEnvVarsFromActiveLaunchSettings(env.project)
             try {
-                service.execManager.wrapper("idea").apply {
+                service.execManager.wrapper("idea", envVarsFromRunSettings).apply {
                     this.wsl = wsl
                     configFromEnv = envVars.find { e -> e.name == CONFIG_ENV_NAME }?.VALUE
                 }.start()?.first?.let {

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -18,7 +18,6 @@ import com.intellij.javaee.appServers.run.localRun.ScriptInfo
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.service
 import com.intellij.openapi.util.SystemInfo
-import com.metalbear.mirrord.CONFIG_ENV_NAME
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordProjectService
 import org.jetbrains.idea.tomcat.server.TomcatPersistentData


### PR DESCRIPTION
- Issue: #167  

Passes the launch env vars section to `mirrord verify-config`, and `mirrord`, resolving config options that were set as env vars.

- vscode PR: [#74](https://github.com/metalbear-co/mirrord-vscode/pull/74)