### PR TITLE
SIP sidestepping for tomcat, using force accessing of fields

### DIFF
--- a/changelog.d/+tomcat-name.fixed.md
+++ b/changelog.d/+tomcat-name.fixed.md
@@ -1,0 +1,1 @@
+Tomcat support was only enabled when the configuration's name started with "Tomcat".

--- a/changelog.d/190.added.md
+++ b/changelog.d/190.added.md
@@ -1,0 +1,1 @@
+Support for running tomcat projects on macOS (sidestepping SIP).

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -96,7 +96,9 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         product: String,
         mirrordConfigFromEnv: String?
     ): Pair<Map<String, String>, String?>? {
+        MirrordLogger.logger.info("~~~MirrordExecManager.start")
         if (!service.enabled) {
+            MirrordLogger.logger.info("~~~MirrordExecManager.start: service not enabled, returning.")
             MirrordLogger.logger.debug("disabled, returning")
             return null
         }
@@ -105,28 +107,34 @@ class MirrordExecManager(private val service: MirrordProjectService) {
             throw MirrordError("can't use on Windows without WSL")
         }
 
+        MirrordLogger.logger.info("~~~MirrordExecManager.start: checking version.")
         MirrordLogger.logger.debug("version check trigger")
         service.versionCheck.checkVersion() // TODO makes an HTTP request, move to background
 
         val cli = cliPath(wslDistribution, product)
+        MirrordLogger.logger.info("~~~MirrordExecManager.start: mirrord cli path is $cli")
         // Find the mirrord config path, then call `mirrord verify-config {path}` so we can display warnings/errors
         // from the config without relying on mirrord-layer.
         val configPath = service.configApi.getConfigPath(mirrordConfigFromEnv)
+        MirrordLogger.logger.info("~~~MirrordExecManager.start: config path is $cli")
 
         val verifiedConfig = configPath?.let {
             val verifiedConfigOutput =
                 service.mirrordApi.verifyConfig(cli, wslDistribution?.getWslPath(it) ?: it, wslDistribution)
+            MirrordLogger.logger.info("~~~MirrordExecManager.start: verifiedConfigOutput: $verifiedConfigOutput")
             MirrordVerifiedConfig(verifiedConfigOutput, service.notifier).apply {
+                MirrordLogger.logger.info("~~~MirrordExecManager.start: MirrordVerifiedConfig: $it")
                 if (isError()) {
+                    MirrordLogger.logger.info("~~~MirrordExecManager.start: invalid config error")
                     throw InvalidConfigException(it, "Validation failed for config")
                 }
             }
         }
 
-        MirrordLogger.logger.debug("Verified Config: $verifiedConfig, Target selection.")
+        MirrordLogger.logger.info("Verified Config: $verifiedConfig, Target selection.")
 
         val target = if (configPath != null && !isTargetSet(verifiedConfig?.config)) {
-            MirrordLogger.logger.debug("target not selected, showing dialog")
+            MirrordLogger.logger.info("target not selected, showing dialog")
             chooseTarget(cli, wslDistribution, configPath).also {
                 if (it == MirrordExecDialog.targetlessTargetName) {
                     MirrordLogger.logger.info("No target specified - running targetless")
@@ -141,6 +149,7 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         } else {
             null
         }
+        MirrordLogger.logger.info("~~~MirrordExecManager.start: exec")
 
         val executionInfo = service.mirrordApi.exec(
             cli,
@@ -149,6 +158,8 @@ class MirrordExecManager(private val service: MirrordProjectService) {
             executable,
             wslDistribution
         )
+        MirrordLogger.logger.info("~~~MirrordExecManager.start: executionInfo: $executionInfo")
+        MirrordLogger.logger.info("~~~MirrordExecManager.start: patchedPath: ${executionInfo.patchedPath}")
 
         executionInfo.environment["MIRRORD_IGNORE_DEBUGGER_PORTS"] = "35000-65535"
         return Pair(executionInfo.environment, executionInfo.patchedPath)
@@ -163,13 +174,17 @@ class MirrordExecManager(private val service: MirrordProjectService) {
             return try {
                 manager.start(wsl, executable, product, configFromEnv)
             } catch (e: MirrordError) {
+                MirrordLogger.logger.info("~~~MirrordError: ", e)
                 e.showHelp(manager.service.project)
                 throw e
             } catch (e: ProcessCanceledException) {
+                MirrordLogger.logger.info("~~~ProcessCanceledException: ", e)
                 manager.service.notifier.notifySimple("mirrord was cancelled", NotificationType.WARNING)
                 throw e
             } catch (e: Throwable) {
+                MirrordLogger.logger.info("~~~Throwable: ", e)
                 val mirrordError = MirrordError(e.toString(), e)
+                MirrordLogger.logger.info("~~~MirrordError from Throwable: ", mirrordError)
                 mirrordError.showHelp(manager.service.project)
                 throw e
             }

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -50,16 +50,15 @@ class PatchedScriptInfo(
      * the patched parameters to that field, and return the changed script object.
      */
     override fun getScript(): ExecutableObject? {
-        MirrordLogger.logger.debug("~~~getScript override")
+        MirrordLogger.logger.debug("getScript override")
         val startupScript = super.getScript()
-        MirrordLogger.logger.info("~~~super.getScript: ${startupScript.toString()}")
-        MirrordLogger.logger.info("~~~setting params to: ${params.joinToString(" ")}")
+        MirrordLogger.logger.debug("setting params to: ${params.joinToString(" ")}")
         val cmdExecutableObject = startupScript as? CommandLineExecutableObject
         val cmd = cmdExecutableObject ?: return startupScript
         val myParamsField = CommandLineExecutableObject::class.java.getDeclaredField("myParameters")
         myParamsField.isAccessible = true
         myParamsField.set(cmd, params)
-        MirrordLogger.logger.info("~~~getScript after forced access")
+        MirrordLogger.logger.debug("getScript survived forced access")
         return startupScript
     }
 }
@@ -68,9 +67,7 @@ class PatchedScriptInfo(
  * Create script object that will return a script object of SIP-patched script instead of the original.
  */
 fun patchedScriptFromScript(scriptInfo: ScriptInfo, script: String, args: String?): PatchedScriptInfo {
-    MirrordLogger.logger.info("~~~patchedScriptFromScript")
-    MirrordLogger.logger.info("~~~script: $script")
-    MirrordLogger.logger.info("~~~args: $args")
+    MirrordLogger.logger.debug("patchedScriptFromScript - script: $script, args: $args")
     val argList = args?.split("(?<!\\\\) ".toRegex()) ?: emptyList()
     val params = listOf(script) + argList
     val parentField = ScriptInfo::class.java.getDeclaredField("myParent")
@@ -79,7 +76,7 @@ fun patchedScriptFromScript(scriptInfo: ScriptInfo, script: String, args: String
     startupNotShutdownField.isAccessible = true
     val parent = parentField.get(scriptInfo) as CommonStrategy
     val startupNotShutdown = startupNotShutdownField.get(scriptInfo) as Boolean
-    MirrordLogger.logger.info("~~~patchedScriptFromScript after forced accesses")
+    MirrordLogger.logger.debug("patchedScriptFromScript survived forced accesses")
     return PatchedScriptInfo(scriptInfo.scriptHelper, parent, startupNotShutdown, params.toTypedArray())
 }
 
@@ -91,20 +88,17 @@ class TomcatExecutionListener : ExecutionListener {
     private val savedEnvs: ConcurrentHashMap<String, SavedConfigData> = ConcurrentHashMap()
 
     private fun getConfig(env: ExecutionEnvironment): RunnerSpecificLocalConfigurationBit? {
-        MirrordLogger.logger.info("~~~getConfig")
-        MirrordLogger.logger.info("~~~getConfig - env: $env")
+        MirrordLogger.logger.debug("getConfig - env: $env")
         if (!env.toString().startsWith("Tomcat")) {
             return null
         }
 
         val settings = env.configurationSettings ?: return null
-        MirrordLogger.logger.info("~~~getConfig - settings: $settings")
+        MirrordLogger.logger.debug("getConfig - settings: $settings")
 
         return if (settings is RunnerSpecificLocalConfigurationBit) {
-            MirrordLogger.logger.info("~~~getConfig - settings is RunnerSpecificLocalConfigurationBit")
             settings
         } else {
-            MirrordLogger.logger.info("~~~getConfig - settings is null")
             null
         }
     }
@@ -115,40 +109,39 @@ class TomcatExecutionListener : ExecutionListener {
      * default script will be guessed based on the location of the tomcat installation, taken from [env].
      */
     private fun getStartScript(scriptInfo: ScriptInfo, env: ExecutionEnvironment): CommandLineWithArgs {
-        MirrordLogger.logger.info("~~~getStartScript")
+        MirrordLogger.logger.debug("getStartScript tomcat")
         return if (scriptInfo.USE_DEFAULT) {
-            MirrordLogger.logger.info("~~~using default")
+            MirrordLogger.logger.debug("using default tomcat script")
 //            val defaultScript = scriptInfo.script;
             val commandLine = scriptInfo.defaultScript.ifBlank {
-                MirrordLogger.logger.info("~~~default script was blank")
+                MirrordLogger.logger.debug("default script was blank")
                 // We return the default script if it's not blank. If it's blank we're guessing the path on our own,
                 // based on the tomcat installation location.
                 val tomcatLocation =
                     (((env.runProfile as CommonStrategy).applicationServer as ApplicationServerImpl).persistentData as TomcatPersistentData).HOME
                 val defaultScript = Paths.get(tomcatLocation, "bin/catalina.sh")
-                MirrordLogger.logger.info("~~~returning default script calculated from tomcat home: $defaultScript")
+                MirrordLogger.logger.debug("returning default script calculated from tomcat home: $defaultScript")
                 defaultScript.toString()
             }
-            MirrordLogger.logger.info("~~~command line is: $commandLine")
+            MirrordLogger.logger.debug("command line is: $commandLine")
             // Split on the first space that is not preceded by a backslash.
             // 4 backslashes in the string are 1 in the regex.
             val split = commandLine.split("(?<!\\\\) ".toRegex(), limit = 2)
             val command = split.first()
             val args = split.getOrNull(1)
-            MirrordLogger.logger.info("~~~command is: $command")
-            MirrordLogger.logger.info("~~~args are: $args")
+            MirrordLogger.logger.debug("command is: $command, args are: $args")
             CommandLineWithArgs(command, args)
         } else {
-            MirrordLogger.logger.info("~~~not default!")
-            MirrordLogger.logger.info("~~~script is ${scriptInfo.SCRIPT}, params are ${scriptInfo.PROGRAM_PARAMETERS}")
+            MirrordLogger.logger.debug("tomcat set to NOT use default!")
+            MirrordLogger.logger.debug("non-default script is ${scriptInfo.SCRIPT}, params are ${scriptInfo.PROGRAM_PARAMETERS}")
             CommandLineWithArgs(scriptInfo.SCRIPT, scriptInfo.PROGRAM_PARAMETERS)
         }
     }
 
     override fun processStartScheduled(executorId: String, env: ExecutionEnvironment) {
-        MirrordLogger.logger.info("~~~processStartScheduled")
+        MirrordLogger.logger.debug("processStartScheduled tomcat")
         getConfig(env)?.let { config ->
-            MirrordLogger.logger.info("~~~processStartScheduled: $env")
+            MirrordLogger.logger.debug("processStartScheduled: got tomcat config")
             val envVars = config.envVariables
 
             val service = env.project.service<MirrordProjectService>()
@@ -163,20 +156,19 @@ class TomcatExecutionListener : ExecutionListener {
             val (script, args) = getStartScript(startupInfo, env)
 
             try {
-                MirrordLogger.logger.info("~~~try")
                 service.execManager.wrapper("idea").apply {
                     this.wsl = wsl
                     this.executable = script
                     configFromEnv = envVars.find { e -> e.name == CONFIG_ENV_NAME }?.VALUE
                 }.start()?.let { (env, patchedPath) ->
-                    MirrordLogger.logger.info("~~~start - env: $env, patchedPath: $patchedPath")
+                    MirrordLogger.logger.debug("got execution info for tomcat - env: $env, patchedPath: $patchedPath")
                     // `MIRRORD_IGNORE_DEBUGGER_PORTS` should allow clean shutdown of the app
                     // even if `outgoing` feature is enabled.
                     val mirrordEnv = env + mapOf(Pair("MIRRORD_DETECT_DEBUGGER_PORT", "javaagent"), Pair("MIRRORD_IGNORE_DEBUGGER_PORTS", getTomcatServerPort()))
 
                     // If we're on macOS we're going to SIP-patch the script and change info, so save script info.
                     val originalScript = if (SystemInfo.isMac && !startupInfo.USE_DEFAULT) {
-                        MirrordLogger.logger.info("~~~not default, saving script")
+                        MirrordLogger.logger.debug("config uses non-default tomcat script. Saving path to restore later")
                         startupInfo.SCRIPT
                     } else {
                         null
@@ -187,25 +179,23 @@ class TomcatExecutionListener : ExecutionListener {
                     config.setEnvironmentVariables(envVars)
 
                     if (SystemInfo.isMac) {
-                        MirrordLogger.logger.info("~~~isMac, patching.")
+                        MirrordLogger.logger.debug("isMac, patching SIP.")
                         patchedPath?.let {
-                            MirrordLogger.logger.info("~~~patchedPath is not null: $it")
+                            MirrordLogger.logger.debug("patchedPath is not null: $it, meaning original was SIP")
                             if (config.startupInfo.USE_DEFAULT) {
-                                MirrordLogger.logger.info("~~~using default - patching by replacing config.startupInfo")
+                                MirrordLogger.logger.debug("using default - handling SIP by replacing config.startupInfo")
                                 val patchedStartupInfo = patchedScriptFromScript(startupInfo, it, args)
                                 val startupInfoField = RunnerSpecificLocalConfigurationBit::class.java.getDeclaredField("myStartupInfo")
                                 startupInfoField.isAccessible = true
                                 startupInfoField.set(config, patchedStartupInfo)
-                                MirrordLogger.logger.info("~~~using default - patched by replacing config.startupInfo")
                             } else {
-                                MirrordLogger.logger.info("~~~NOT using default - patching by replacing config.startupInfo")
+                                MirrordLogger.logger.debug("NOT using default - patching by changing the non-default script")
                                 config.startupInfo.SCRIPT = it
                             }
                         }
                     }
                 }
             } catch (e: Throwable) {
-                MirrordLogger.logger.info("~~~error thrown: ", e)
                 MirrordLogger.logger.debug("Running tomcat project failed: ", e)
                 // Error notifications were already fired.
                 // We can't abort the execution here, so we let the app run without mirrord.

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -124,7 +124,8 @@ class TomcatExecutionListener : ExecutionListener {
                         }
                     }
                 }
-            } catch (_: Throwable) {
+            } catch (e: Throwable) {
+                MirrordLogger.logger.debug("Running tomcat project failed: ", e);
                 // Error notifications were already fired.
                 // We can't abort the execution here, so we let the app run without mirrord.
                 service.notifier.notifySimple(

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -69,9 +69,9 @@ class TomcatExecutionListener : ExecutionListener {
         } else {
             scriptInfo.SCRIPT
         }
-        // TODO: this would be a wrong split (and brake everything) if there is a space in the executable's path.
-        //  E.g "/path/to/Tomcat\ Server/bin/whatever.sh"
-        val split = commandLine.split(" ", limit = 2)
+        // Split on the first space that is not preceded by a backslash.
+        // 4 backslashes in the string are 1 in the regex.
+        val split = commandLine.split("(?<!\\\\) ".toRegex(), limit = 2)
         val command = split.first()
         val args = split.getOrNull(1)
         return CommandLineWithArgs(command, args)

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -21,7 +21,6 @@ import com.metalbear.mirrord.MirrordProjectService
 import org.jetbrains.idea.tomcat.server.TomcatPersistentData
 import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
-import java.util.regex.Pattern
 
 private const val DEFAULT_TOMCAT_SERVER_PORT: String = "8005"
 
@@ -29,7 +28,7 @@ private fun getTomcatServerPort(): String {
     return System.getenv("MIRRORD_TOMCAT_SERVER_PORT") ?: DEFAULT_TOMCAT_SERVER_PORT
 }
 
-data class SavedStartupScriptInfo (val useDefault: Boolean, val script: String?, val args: String?)
+data class SavedStartupScriptInfo(val useDefault: Boolean, val script: String?, val args: String?)
 
 data class SavedConfigData(val envVars: List<EnvironmentVariable>, val scriptInfo: SavedStartupScriptInfo?)
 
@@ -52,7 +51,6 @@ class TomcatExecutionListener : ExecutionListener {
         }
     }
 
-
     /**
      * Returns a String with the path of the script that will be executed, based on the [scriptInfo].
      * If the info is not available, which by looking at [ScriptInfo] seems possible (though we don't know when), the
@@ -71,9 +69,9 @@ class TomcatExecutionListener : ExecutionListener {
         } else {
             scriptInfo.SCRIPT
         }
-        val split = commandLine.split(" ", limit = 2);
-        val command = split.first();
-        val args = split.getOrNull(1);
+        val split = commandLine.split(" ", limit = 2)
+        val command = split.first()
+        val args = split.getOrNull(1)
         return CommandLineWithArgs(command, args)
     }
 
@@ -89,8 +87,7 @@ class TomcatExecutionListener : ExecutionListener {
                 else -> null
             }
 
-
-            val startupInfo = config.startupInfo;
+            val startupInfo = config.startupInfo
             val (script, args) = getStartScript(startupInfo, env)
 
             try {
@@ -98,7 +95,7 @@ class TomcatExecutionListener : ExecutionListener {
                     this.wsl = wsl
                     this.executable = script
                     configFromEnv = envVars.find { e -> e.name == CONFIG_ENV_NAME }?.VALUE
-                }.start()?.let {(env, patchedPath) ->
+                }.start()?.let { (env, patchedPath) ->
                     // `MIRRORD_IGNORE_DEBUGGER_PORTS` should allow clean shutdown of the app
                     // even if `outgoing` feature is enabled.
                     val mirrordEnv = env + mapOf(Pair("MIRRORD_DETECT_DEBUGGER_PORT", "javaagent"), Pair("MIRRORD_IGNORE_DEBUGGER_PORTS", getTomcatServerPort()))
@@ -116,16 +113,16 @@ class TomcatExecutionListener : ExecutionListener {
 
                     if (SystemInfo.isMac) {
                         patchedPath?.let {
-                            config.startupInfo.USE_DEFAULT = false;
-                            config.startupInfo.SCRIPT = it;
+                            config.startupInfo.USE_DEFAULT = false
+                            config.startupInfo.SCRIPT = it
                             args?.let {
-                                config.startupInfo.PROGRAM_PARAMETERS = args;
+                                config.startupInfo.PROGRAM_PARAMETERS = args
                             }
                         }
                     }
                 }
             } catch (e: Throwable) {
-                MirrordLogger.logger.debug("Running tomcat project failed: ", e);
+                MirrordLogger.logger.debug("Running tomcat project failed: ", e)
                 // Error notifications were already fired.
                 // We can't abort the execution here, so we let the app run without mirrord.
                 service.notifier.notifySimple(

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -69,6 +69,8 @@ class TomcatExecutionListener : ExecutionListener {
         } else {
             scriptInfo.SCRIPT
         }
+        // TODO: this would be a wrong split (and brake everything) if there is a space in the executable's path.
+        //  E.g "/path/to/Tomcat\ Server/bin/whatever.sh"
         val split = commandLine.split(" ", limit = 2)
         val command = split.first()
         val args = split.getOrNull(1)

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -89,9 +89,6 @@ class TomcatExecutionListener : ExecutionListener {
 
     private fun getConfig(env: ExecutionEnvironment): RunnerSpecificLocalConfigurationBit? {
         MirrordLogger.logger.debug("getConfig - env: $env")
-        if (!env.toString().startsWith("Tomcat")) {
-            return null
-        }
 
         val settings = env.configurationSettings ?: return null
         MirrordLogger.logger.debug("getConfig - settings: $settings")

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -28,7 +28,7 @@ private fun getTomcatServerPort(): String {
     return System.getenv("MIRRORD_TOMCAT_SERVER_PORT") ?: DEFAULT_TOMCAT_SERVER_PORT
 }
 
-data class SavedStartupScriptInfo(val useDefault: Boolean, val script: String?, val args: String?)
+data class SavedStartupScriptInfo(val useDefault: Boolean, val script: String?, val args: String?, val vmArgs: String?)
 
 data class SavedConfigData(val envVars: List<EnvironmentVariable>, val scriptInfo: SavedStartupScriptInfo?)
 
@@ -104,7 +104,7 @@ class TomcatExecutionListener : ExecutionListener {
 
                     // If we're on macOS we're going to SIP-patch the script and change info, so save script info.
                     val savedScriptInfo = if (SystemInfo.isMac) {
-                        SavedStartupScriptInfo(startupInfo.USE_DEFAULT, startupInfo.SCRIPT, startupInfo.PROGRAM_PARAMETERS)
+                        SavedStartupScriptInfo(startupInfo.USE_DEFAULT, startupInfo.SCRIPT, startupInfo.PROGRAM_PARAMETERS, startupInfo.VM_PARAMETERS)
                     } else {
                         null
                     }
@@ -117,6 +117,8 @@ class TomcatExecutionListener : ExecutionListener {
                         patchedPath?.let {
                             config.startupInfo.USE_DEFAULT = false
                             config.startupInfo.SCRIPT = it
+                            config.startupInfo.VM_PARAMETERS = config.appendVMArguments(config.createJavaParameters())
+//                            config.startupInfo.VM_PARAMETERS = config.getEnvVarValues()
                             args?.let {
                                 config.startupInfo.PROGRAM_PARAMETERS = args
                             }
@@ -148,6 +150,9 @@ class TomcatExecutionListener : ExecutionListener {
                 }
                 it.args?.let { args ->
                     config.startupInfo.PROGRAM_PARAMETERS = args
+                }
+                it.vmArgs?.let { vmArgs ->
+                    config.startupInfo.VM_PARAMETERS = vmArgs
                 }
             }
         }


### PR DESCRIPTION
This is a very hacky way to solve that problem, but the only solution I got to work so far.
We force change a field accessibility and then set it.

So far the SIP-sidestepping works, and a browser window pops up. By default the url is localhost:8080, which works. We could think about trying to find out the remote external IP and port and change it to that, but I assume it's not required for now - the user can set the remote url in the launch configuration.

Stopping still requires pressing the button twice, but there is no error message.