### PR TITLE
Restore tomcat scriptinfo object in order to show normal script path

### DIFF
--- a/changelog.d/+patched-path.fixed.md
+++ b/changelog.d/+patched-path.fixed.md
@@ -1,0 +1,1 @@
+SIP-patched script path was being used also when mirrord was disabled - cosmetic effect only.


### PR DESCRIPTION
When running tomcat without mirrord after running tomcat with mirrored the script path stayed the patched script's path.
This had no effect on usability.

By restoring the ScriptInfo object that was present before our change the normal path is shown when mirrord is disabled.