### PR TITLE
Fix targetless selection

### DIFF
--- a/changelog.d/+targetless-selection.fixed.md
+++ b/changelog.d/+targetless-selection.fixed.md
@@ -1,1 +1,1 @@
-Fixed a bug with selecting `targetless` option from the target selection dialog.g
+Fixed a bug with selecting `targetless` option from the target selection dialog.

--- a/changelog.d/+targetless-selection.fixed.md
+++ b/changelog.d/+targetless-selection.fixed.md
@@ -1,0 +1,1 @@
+Fixed a bug with selecting `targetless` option from the target selection dialog.g

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.util.alsoIfNull
 import java.nio.file.Path
 
 /**
@@ -133,8 +134,9 @@ class MirrordExecManager(private val service: MirrordProjectService) {
 
         val target = if (configPath != null && !isTargetSet(verifiedConfig?.config)) {
             MirrordLogger.logger.debug("target not selected, showing dialog")
-            chooseTarget(cli, wslDistribution, configPath).also {
-                if (it == MirrordExecDialog.targetlessTargetName) {
+            chooseTarget(cli, wslDistribution, configPath)
+                .takeUnless { it == MirrordExecDialog.targetlessTargetName }
+                .alsoIfNull {
                     MirrordLogger.logger.info("No target specified - running targetless")
                     service.notifier.notification(
                         "No target specified, mirrord running targetless.",
@@ -143,7 +145,6 @@ class MirrordExecManager(private val service: MirrordProjectService) {
                         .withDontShowAgain(MirrordSettingsState.NotificationId.RUNNING_TARGETLESS)
                         .fire()
                 }
-            }
         } else {
             null
         }


### PR DESCRIPTION
Selecting `targetless` in the target selection dialog is bugged - mirrord CLI is given string `No Target ("targetless")` as the target. This string comes from the UI and should be filtered out.