### PR TITLE
Fix warning message

### DIFF
--- a/changelog.d/211.fixed.md
+++ b/changelog.d/211.fixed.md
@@ -1,0 +1,1 @@
+Fixed warning notification when the plugin cannot display the target selection popup.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -55,14 +55,12 @@ class MirrordExecManager(private val service: MirrordProjectService) {
             service
                 .notifier
                 .notification(
-                    "mirrord plugin was unable to display the target selection dialog. " +
-                        "You can set it manually in the configuration file $config.",
+                    "mirrord plugin was unable to display the target selection dialog. You can set it manually in the configuration file.",
                     NotificationType.WARNING
                 )
                 .apply {
                     val configFile = try {
-                        val path = Path.of(config)
-                        VirtualFileManager.getInstance().findFileByNioPath(path)
+                        config?.let { Path.of(it) }?.let { VirtualFileManager.getInstance().findFileByNioPath(it) }
                     } catch (e: Exception) {
                         MirrordLogger.logger.debug("failed to find config under path $config", e)
                         null


### PR DESCRIPTION
Closes #211 

Entirely removed config path from the notification - the path might be long + the notification contains `Open` link anyway