### PR TITLE
Fix freezes again

### DIFF
--- a/changelog.d/214.fixed.md
+++ b/changelog.d/214.fixed.md
@@ -1,0 +1,1 @@
+Fixed spawning CLI tasks on a pooled thread under a read lock. Fixes issues with IntelliJ UI freezing in some scenarios.


### PR DESCRIPTION
Closes #214 

Update around spawning CLI tasks: we sometimes spawned a background task from a pooled thread under a read lock. This was causing a deadlock, since spawning a background task is scheduled to happen on EDT (UI update). Now, when this situation is detected, we run the computation silently on a pooled thread (no UI update). Timeout still applies.