### PR TITLE
Enable mirrord from run configuration

### DIFF
--- a/changelog.d/231.added.md
+++ b/changelog.d/231.added.md
@@ -1,0 +1,1 @@
+Users can now specify MIRRORD_ACTIVE=1 in run configuration's environment variable to explicitly enable mirrord regardless of the button status

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -100,7 +100,8 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         projectEnvVars: Map<String, String>?
     ): Pair<Map<String, String>, String?>? {
         MirrordLogger.logger.debug("MirrordExecManager.start")
-        if (!service.enabled) {
+        val explicitlyEnabled = projectEnvVars?.any { (key, value) -> key == "MIRRORD_ACTIVE" && value == "1" } ?: false
+        if (!service.enabled && !explicitlyEnabled) {
             MirrordLogger.logger.debug("disabled, returning")
             return null
         }


### PR DESCRIPTION
Users can now specify MIRRORD_ACTIVE=1 in run configuration's environment variable to explicitly enable mirrord regardless of the button status
Closes #231