### PR TITLE
Trim whitespace from user-provided mirrord cli version

### DIFF
--- a/changelog.d/+trim-version.fixed.md
+++ b/changelog.d/+trim-version.fixed.md
@@ -1,0 +1,1 @@
+Trim whitespace from user-provided mirrord cli version.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -79,7 +79,7 @@ class MirrordBinaryManager {
             val manager = service<MirrordBinaryManager>()
 
             val autoUpdate = MirrordSettingsState.instance.mirrordState.autoUpdate
-            val userSelectedMirrordVersion = MirrordSettingsState.instance.mirrordState.mirrordVersion
+            val userSelectedMirrordVersion = MirrordSettingsState.instance.mirrordState.mirrordVersion.trim()
             manager.latestSupportedVersion = manager.fetchLatestSupportedVersion(product, indicator)
 
             val version = when {


### PR DESCRIPTION
If a user accidentally includes a whitespace before the version (can happen e.g. when copying from a discord message and it's hard to notice):
![image](https://github.com/user-attachments/assets/7c1da294-a2d6-4e5b-8462-e235d7b41faf)

Parsing the version fails:
![image](https://github.com/user-attachments/assets/e96a9d37-c6eb-4f7a-a06b-2a4c9e18ec62)



Didn't test this solution yet because I have a problem in my setup and I cannot run the `runIde` task.