### PR TITLE
Fix Tomcat Plugin

### DIFF
--- a/changelog.d/230.fixed.md
+++ b/changelog.d/230.fixed.md
@@ -1,1 +1,1 @@
-Tomcat executions are now stopped when mirrord setup fails.
+Tomcat executions now get stopped when mirrord setup fails.

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -223,7 +223,7 @@ class TomcatExecutionListener : ExecutionListener {
                             val startupInfoField =
                                 RunnerSpecificLocalConfigurationBit::class.java.getDeclaredField("myStartupInfo")
                             startupInfoField.isAccessible = true
-                            startupInfoField.set(config, patchedStartupInfo)
+                            startupInfoField.set(config.first, patchedStartupInfo)
                         } else {
                             MirrordLogger.logger.debug("[${this.javaClass.name}] processStartScheduled: NOT using default - patching by changing the non-default script")
                             config.first.startupInfo.SCRIPT = it
@@ -255,7 +255,7 @@ class TomcatExecutionListener : ExecutionListener {
             MirrordLogger.logger.debug("[${this.javaClass.name}] restoreConfig: found saved script info")
             val startupInfoField = RunnerSpecificLocalConfigurationBit::class.java.getDeclaredField("myStartupInfo")
             startupInfoField.isAccessible = true
-            startupInfoField.set(config, savedScriptInfo)
+            startupInfoField.set(config.first, savedScriptInfo)
         }
 
         MirrordLogger.logger.debug("[${this.javaClass.name}] restoreConfig: removing before run task")


### PR DESCRIPTION
Fix #302 

I was not getting the exact same phenomenon as in the issue, but after this change the plugin works fine for Tomcat on macOS. I'm getting layer logs, I can get the weird broken Tomcat responses over an external port on the cluster, etc.

![image](https://github.com/user-attachments/assets/b414a951-131f-4037-97b6-0a6fedead740)
![image](https://github.com/user-attachments/assets/b0ba9a35-35bb-483a-bc58-61b8b345512d)
![image](https://github.com/user-attachments/assets/aad4fb25-560b-4a47-a07e-47d77aaccad6)

