### PR TITLE
Fixed dropdown button on WSL, fixed some warnings related to deprecated classes

### DIFF
--- a/changelog.d/297.fixed.md
+++ b/changelog.d/297.fixed.md
@@ -1,0 +1,2 @@
+Fixed toolbar dropdown button in the context of remote development on WSL.
+g

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.startup.StartupActivity
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.system.CpuArch
@@ -41,8 +42,8 @@ class MirrordBinaryManager {
     /**
      * Schedules the update task at project startup.
      */
-    class DownloadInitializer : StartupActivity.Background {
-        override fun runActivity(project: Project) {
+    class DownloadInitializer : ProjectActivity {
+        override suspend fun execute(project: Project) {
             UpdateTask(project, null, null, false).queue()
         }
     }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordDropDown.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordDropDown.kt
@@ -1,30 +1,62 @@
 package com.metalbear.mirrord
 
 import com.intellij.ide.BrowserUtil
-import com.intellij.ide.DataManager
 import com.intellij.openapi.actionSystem.*
-import com.intellij.openapi.actionSystem.ex.ComboBoxAction
 import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.*
+import com.intellij.openapi.ui.popup.JBPopup
+import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.util.indexing.*
 import com.intellij.util.io.EnumeratorStringDescriptor
 import com.intellij.util.io.KeyDescriptor
+import com.intellij.util.ui.JBDimension
 import java.util.*
 import javax.swing.JComponent
 
 const val DISCORD_URL = "https://discord.gg/metalbear"
 const val MIRRORD_FOR_TEAMS_URL = "https://app.metalbear.co/"
 
+/**
+ * Copied from internal [com.intellij.execution.ui.TogglePopupAction].
+ */
+abstract class TogglePopupAction : ToggleAction() {
+    override fun isSelected(e: AnActionEvent): Boolean {
+        return Toggleable.isSelected(e.presentation)
+    }
+
+    override fun setSelected(e: AnActionEvent, state: Boolean) {
+        if (!state) return
+        val component = e.inputEvent?.component as? JComponent ?: return
+        val popup = createPopup(e) ?: return
+        popup.showUnderneathOf(component)
+    }
+
+    private fun createPopup(e: AnActionEvent): JBPopup? {
+        val presentation = e.presentation
+        val actionGroup = getActionGroup(e) ?: return null
+        val disposeCallback = { Toggleable.setSelected(presentation, false) }
+        val popup = createPopup(actionGroup, e, disposeCallback)
+        popup.setMinimumSize(JBDimension(270, 0))
+        return popup
+    }
+
+    open fun createPopup(actionGroup: ActionGroup,
+                         e: AnActionEvent,
+                         disposeCallback: () -> Unit) = JBPopupFactory.getInstance().createActionGroupPopup(
+        null, actionGroup, e.dataContext, false, false, false, disposeCallback, 30, null)
+
+    abstract fun getActionGroup(e: AnActionEvent): ActionGroup?
+}
+
 fun VirtualFile.relativePath(project: Project): String {
     return calcRelativeToProjectPath(this, project, includeFilePath = true, keepModuleAlwaysOnTheLeft = true)
 }
 
-class MirrordDropDown : ComboBoxAction(), DumbAware {
-
+class MirrordDropDown : TogglePopupAction(), DumbAware {
     private class ShowActiveConfigAction(val config: VirtualFile, project: Project) :
         AnAction("Active Config: ${config.relativePath(project)}") {
         override fun actionPerformed(e: AnActionEvent) {
@@ -41,7 +73,7 @@ class MirrordDropDown : ComboBoxAction(), DumbAware {
             val projectLocator = ProjectLocator.getInstance()
             val configs = FileBasedIndex
                 .getInstance()
-                .getAllKeys(MirrordConfigIndex.key, service.project)
+                .getAllKeys(MIRRORD_CONFIG_INDEX_KEY, service.project)
                 .mapNotNull { fileManager.findFileByUrl(it) }
                 .filter { !it.isDirectory }
                 .filter { projectLocator.getProjectsForFile(it).contains(service.project) }
@@ -119,10 +151,8 @@ class MirrordDropDown : ComboBoxAction(), DumbAware {
         }
     }
 
-    override fun getActionUpdateThread() = ActionUpdateThread.BGT
-
-    override fun createPopupActionGroup(button: JComponent, dataContext: DataContext): DefaultActionGroup {
-        val project = dataContext.getData(CommonDataKeys.PROJECT) ?: throw Error("mirrord requires an open project")
+    override fun getActionGroup(e: AnActionEvent): ActionGroup {
+        val project = e.project ?: throw Error("mirrord requires an open project")
         val service = project.service<MirrordProjectService>()
 
         return DefaultActionGroup().apply {
@@ -141,16 +171,9 @@ class MirrordDropDown : ComboBoxAction(), DumbAware {
         }
     }
 
-    @Deprecated(
-        "Deprecated in Java",
-        ReplaceWith(
-            "createPopupActionGroup(button, DataManager.getInstance().getDataContext(button))",
-            "com.intellij.ide.DataManager"
-        )
-    )
-    override fun createPopupActionGroup(button: JComponent): DefaultActionGroup {
-        return createPopupActionGroup(button, DataManager.getInstance().getDataContext(button))
-    }
+    override fun displayTextInToolbar(): Boolean = true
+
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         val projectOpen = e.project != null
@@ -164,18 +187,16 @@ class MirrordDropDown : ComboBoxAction(), DumbAware {
     }
 }
 
+private val MIRRORD_CONFIG_INDEX_KEY = ID.create<String, Void>("mirrordConfig")
+
 /**
  * An index for mirrord config files.
  * Indexes files with names ending with `mirrord.json`.
  */
 class MirrordConfigIndex : ScalarIndexExtension<String>() {
 
-    companion object {
-        val key = ID.create<String, Void>("mirrordConfig")
-    }
-
     override fun getName(): ID<String, Void> {
-        return key
+        return MIRRORD_CONFIG_INDEX_KEY
     }
 
     override fun getIndexer(): DataIndexer<String, Void, FileContent> {

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordEnabler.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordEnabler.kt
@@ -1,17 +1,13 @@
 package com.metalbear.mirrord
 
-import com.intellij.ide.ActivityTracker
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.DumbAware
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.startup.StartupActivity
-import com.metalbear.mirrord.MirrordSettingsState.Companion.instance
 import icons.MirrordIcons
 
-class MirrordEnabler : ToggleAction(), DumbAware, StartupActivity, StartupActivity.DumbAware {
+class MirrordEnabler : ToggleAction(), DumbAware {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun isSelected(e: AnActionEvent): Boolean {
@@ -31,12 +27,5 @@ class MirrordEnabler : ToggleAction(), DumbAware, StartupActivity, StartupActivi
         e.presentation.icon = if (state) MirrordIcons.enabled else MirrordIcons.disabled
 
         super.update(e)
-    }
-
-    override fun runActivity(project: Project) {
-        if (instance.mirrordState.enabledByDefault) {
-            project.service<MirrordProjectService>().enabled = true
-            ActivityTracker.getInstance().inc()
-        }
     }
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordProjectService.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordProjectService.kt
@@ -27,7 +27,7 @@ class MirrordProjectService(val project: Project) : Disposable {
     var activeConfig: VirtualFile? = null
 
     @Volatile
-    private var _enabled = false
+    private var _enabled = MirrordSettingsState.instance.mirrordState.enabledByDefault
 
     var enabled: Boolean
         get() = _enabled

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordUsageBanner.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordUsageBanner.kt
@@ -2,6 +2,7 @@ package com.metalbear.mirrord
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.startup.StartupActivity
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.ui.components.JBScrollPane
@@ -22,7 +23,7 @@ The dropdown menu next to the icon provides shortcuts for working with mirrord c
 
 private const val SHOW_AGAIN_AFTER_MS: Long = 30 * 60 * 1000
 
-class MirrordUsageBanner : StartupActivity, StartupActivity.DumbAware {
+class MirrordUsageBanner : ProjectActivity {
     /**
      * Timestamp in milliseconds.
      */
@@ -73,7 +74,7 @@ class MirrordUsageBanner : StartupActivity, StartupActivity.DumbAware {
         }
     }
 
-    override fun runActivity(project: Project) {
+    override suspend fun execute(project: Project) {
         val now = System.currentTimeMillis()
         lastShownAt?.let {
             if (now <= it + SHOW_AGAIN_AFTER_MS) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -24,7 +24,6 @@
     <extensions defaultExtensionNs="com.intellij">
         <applicationService
                 serviceImplementation="com.metalbear.mirrord.MirrordSettingsState"/>
-        <projectService serviceImplementation="com.metalbear.mirrord.MirrordProjectService"/>
     </extensions>
 
     <projectListeners>
@@ -42,7 +41,6 @@
         <fileBasedIndex implementation="com.metalbear.mirrord.MirrordConfigIndex"/>
 
         <postStartupActivity implementation="com.metalbear.mirrord.MirrordUsageBanner"/>
-        <postStartupActivity implementation="com.metalbear.mirrord.MirrordEnabler"/>
         <backgroundPostStartupActivity implementation="com.metalbear.mirrord.MirrordBinaryManager$DownloadInitializer"/>
     </extensions>
 
@@ -57,6 +55,8 @@
             <action id="MirrordConfigDropDown"
                     class="com.metalbear.mirrord.MirrordDropDown"
                     text="mirrord"
+                    description="Options for mirrord plugin"
+                    icon="AllIcons.Actions.More"
             />
             <separator/>
 


### PR DESCRIPTION
Isssue #297 

I failed to preserve the way the button looked, but at least now it's reliable. The button used to have an arrow down on the right, now it has three dots on the left. I can make it arrow down on the left, @eyalb181 wdyt?

https://github.com/user-attachments/assets/72657f67-8bcf-486d-aa65-749672916481

