### PR TITLE
Document gif conversion for usage gif

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,4 +75,11 @@ go to [localhost:8082](http://localhost:8082) and choose the elements you want t
 - To run the tests locally from scratch run, `./gradlew test` which download the latest stable pycharm IDE. 
 
 
+## Converting screen recordings to gifs
+
+On our plugin page (generated from README.md), we have a gif showing the usage of the plugin.
+On MacOS, this is how I was able to convert the screen recording to a gif that's not weird:
+```
+ffmpeg -i path-to-screen-recording.mov -r 16 -lavfi '[0]split[a][b];[a]palettegen[p];[b][p]paletteuse' usage.gif && gifsicle -O3 usage.gif -o usage.gif
+```
 

--- a/changelog.d/+document-gif.internal.md
+++ b/changelog.d/+document-gif.internal.md
@@ -1,0 +1,1 @@
+Add to the contribution guide documentation of how to convert videos to non-weird gifs, for the usage gif.


### PR DESCRIPTION
It's apparently not trivial to convert a screen recording to a gif that doesn't have a weird pattern on it,
so I thought we might want to have the command that finally worked somewhere for future reference.