### PR TITLE
Warn the user if we detect some left-over MIRRORD-ish env var (even when mirrord is disabled).

### DIFF
--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -182,6 +182,32 @@ class MirrordExecManager(private val service: MirrordProjectService) {
     }
 
     /**
+     * Checks for env vars that might've been left behind by some previous execution of mirrord.
+     *
+     * Sometimes a crash or under weird circumstances, the IDE doesn't clear the launch config env vars of the ones we've
+     * added, so this performs a check and spits out a warning to the user, even when mirrord is **disabled**!
+     *
+     * @param projectEnvVars Contains both system env vars, and (active) launch settings, see `Wrapper`.
+     * @return the suspicious env vars that we might've left behind.
+    */
+    private fun checkForSuspiciousEnvVars(
+        projectEnvVars: Map<String, String>?
+    ): Map<String, String>? {
+        val suspiciousEnvVars = "(?!MIRRORD_ACTIVE)(^MIRRORD_.+)|(.*libmirrord.+)".toRegex()
+        val suspiciousMap = projectEnvVars?.filterKeys { it.matches(suspiciousEnvVars) }
+        if (suspiciousMap?.isEmpty() == false) {
+            MirrordLogger.logger.debug("Detected env var that was probably left behind! The culprits are: $suspiciousMap")
+            throw MirrordError(
+                "Detected mirrord environment variables that were probably left behind by a previous execution!" +
+                        " Please check your project launch configuration and remove environment variables that start with `MIRRORD`." +
+                        "${suspiciousMap.keys}"
+            )
+        }
+        return suspiciousMap
+    }
+
+
+    /**
      * Starts mirrord, shows dialog for selecting pod if target is not set and returns env to set.
      *
      * @param projectEnvVars Contains both system env vars, and (active) launch settings, see `Wrapper`.
@@ -195,6 +221,8 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         product: String,
         projectEnvVars: Map<String, String>?
     ): MirrordExecution? {
+        checkForSuspiciousEnvVars(projectEnvVars)
+
         val mirrordApi = service.mirrordApi(projectEnvVars)
         val (configPath, target) = this.prepareStart(wslDistribution, product, projectEnvVars, mirrordApi) ?: return null
         val cli = cliPath(wslDistribution, product)


### PR DESCRIPTION
- Issue: https://github.com/metalbear-co/mirrord-intellij/issues/329