### PR TITLE
Fix duplicate env vars in Tomcat run configs

### DIFF
--- a/changelog.d/336.fixed.md
+++ b/changelog.d/336.fixed.md
@@ -1,0 +1,1 @@
+mirrord no longer injects duplicate environment variables into Tomcat run configurations.

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
@@ -83,8 +83,8 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
             if (configuration is ExternalSystemRunConfiguration) {
                 runningProcessEnvs[configuration.project] = configuration.settings.env.toMap()
                 val env = configuration.settings.env +
-                        mirrordEnv -
-                        executionInfo.envToUnset.orEmpty().toSet()
+                    mirrordEnv -
+                    executionInfo.envToUnset.orEmpty().toSet()
                 configuration.settings.env = env
             }
             MirrordLogger.logger.debug("setting env and finishing")

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -207,8 +207,8 @@ class TomcatExecutionListener : ExecutionListener {
 
                 MirrordLogger.logger.debug("[${this.javaClass.name}] processStartScheduled: adding ${mirrordEnv.size} environment variables")
                 val finalEnvVars = originalEnvVars.associateBy { it.NAME } +
-                        mirrordEnv.mapValues { (key, value) -> EnvironmentVariable(key, value, false) } -
-                        executionInfo.envToUnset.orEmpty().toSet()
+                    mirrordEnv.mapValues { (key, value) -> EnvironmentVariable(key, value, false) } -
+                    executionInfo.envToUnset.orEmpty().toSet()
                 config.first.setEnvironmentVariables(finalEnvVars.values.toList())
 
                 if (SystemInfo.isMac) {


### PR DESCRIPTION
Tomcat run configuration stores environment as a list. We were adding remote env to that list, without checking if the variable was already present. Tomcat plugin handles duplicate variables by concatenating their values, so the users were seeing weird env.