### PR TITLE
Tomcat executions spawn 2 intproxies 

### DIFF
--- a/changelog.d/344.fixed.md
+++ b/changelog.d/344.fixed.md
@@ -1,0 +1,2 @@
+fix for multiple execution of service wrapper in TomcatBeforeRunTaskProvider, 
+now only one for debug session is executed

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -27,6 +27,8 @@ import java.util.concurrent.ConcurrentHashMap
 
 private const val DEFAULT_TOMCAT_SERVER_PORT: String = "8005"
 
+var TASK_RAN: Boolean = false
+
 private fun getTomcatServerPort(): String {
     return System.getenv("MIRRORD_TOMCAT_SERVER_PORT") ?: DEFAULT_TOMCAT_SERVER_PORT
 }
@@ -147,6 +149,7 @@ class TomcatExecutionListener : ExecutionListener {
      */
     override fun processStartScheduled(executorId: String, env: ExecutionEnvironment) {
         val service = env.project.service<MirrordProjectService>()
+        TASK_RAN = false
 
         MirrordLogger.logger.debug("[${this.javaClass.name}] processStartScheduled: $executorId $env")
 
@@ -181,6 +184,11 @@ class TomcatExecutionListener : ExecutionListener {
         }
 
         config.second.beforeRunTasks = config.second.beforeRunTasks + TomcatBeforeRunTaskProvider.TomcatBeforeRunTask {
+            if (TASK_RAN) {
+                return@TomcatBeforeRunTask
+            }
+            TASK_RAN = true
+
             val savedData = SavedConfigData()
             // Always inject `SavedConfigData` early.
             // This allows for removing `TomcatBeforeRunTask` from the run configuration,


### PR DESCRIPTION
Bugfix for the issue [where 2 intproxies spawns when tomcat is used as application web server](https://github.com/metalbear-co/mirrord-intellij/issues/344)