### PR TITLE
RubyMine: Allow asdf-managed ruby execution

### DIFF
--- a/changelog.d/+ruby-asdf.added.md
+++ b/changelog.d/+ruby-asdf.added.md
@@ -1,0 +1,1 @@
+Added support for running `asdf`-managed Ruby installs for `RubyMine`

--- a/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
+++ b/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
@@ -62,6 +62,9 @@ class RubyMineRunConfigurationExtension : RubyRunConfigurationExtension() {
                 executionInfo.patchedPath?.let {
                     cmdLine.exePath = it
                 }
+                // asdf-ruby compiles the ruby interpreter locally and so doesn't any special SIP handling because the
+                // binary isn't signed at all
+                val isAsdf = cmdLine.exePath.contains("/.asdf/")
                 // TODO: would be nice to have a more robust RVM detection mechanism.
                 val isRvm = cmdLine.exePath.contains("/.rvm/rubies/")
                 if (isRvm) {
@@ -70,9 +73,9 @@ class RubyMineRunConfigurationExtension : RubyRunConfigurationExtension() {
                     path.writeText("DYLD_INSERT_LIBRARIES=${currentEnv["DYLD_INSERT_LIBRARIES"]} ${cmdLine.exePath} $@")
                     cmdLine.exePath = path.pathString
                     path.toFile().setExecutable(true)
-                } else {
+                } else if (!isAsdf) {
                     val e = MirrordError(
-                        "At the moment, only RVM Rubies are supported by mirrord on RubyMine on macOS, due to SIP.",
+                        "At the moment, only RVM and ASDF ruby installs are supported by mirrord on RubyMine on macOS, due to SIP.",
                         "Support for other Rubies is tracked on " +
                             "https://github.com/metalbear-co/mirrord-intellij/issues/134."
                     )


### PR DESCRIPTION
# Summary

RubyMine's macOS path only supported RVM-managed rubies. Any other interpreter was rejected up front with an error saying that only RVM was supported.

This PR adds asdf as a supported Ruby manager, but does not send it through the temporary `mirrord-ruby-launcher` wrapper that the RVM path uses. As far as I can tell, that wrapper is there to sidestep SIP for the RVM case, but asdf-ruby installs are built locally in the user's machine and so aren't SIP-protected at all. In testing, routing asdf through the wrapper made the launch fail with exit code 127 (??), so I think the correct behavior here is to accept asdf and run it directly with mirrord's environment.

# Notes

To be honest I'm totally lost on this.

There are a few related issues/PRs:
- https://github.com/metalbear-co/mirrord-intellij/issues/134
- https://github.com/metalbear-co/mirrord-intellij/pull/137
- https://github.com/metalbear-co/mirrord-intellij/pull/139

But these have basically zero context and don't provide much information on why the "mirrord-ruby-launcher" code was needed.

I think all of the context/discussion for this happened on Discord, which I don't have access to :(
