### PR TITLE
Fix the @ApiStatus.NonExtendable violation in the pitm fake JDK

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:6.1.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:6.1.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.0")
+    // BasePlatformTestCase is JUnit3; the other tests are JUnit5.
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:6.1.0")
     testImplementation("com.squareup.okhttp3:logging-interceptor:5.4.0")
     testImplementation("junit:junit:4.13.2")
 

--- a/changelog.d/+pitm-sdk-nonextendable.fixed.md
+++ b/changelog.d/+pitm-sdk-nonextendable.fixed.md
@@ -1,0 +1,1 @@
+Build the Windows pitm fake JDK with the platform's own `ProjectJdkImpl` instead of implementing the non-extendable `Sdk` interface, which JetBrains' Plugin Verifier rejects.

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/MirrordPitmJdk.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/MirrordPitmJdk.kt
@@ -1,20 +1,23 @@
 package com.metalbear.mirrord.products.idea
 
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.openapi.util.io.FileUtil
 import com.metalbear.mirrord.MirrordLogger
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Creates a fake JDK whose `bin/java.exe` is a copy of `mirrord.exe`, and wraps
- * a real [Sdk] so its `homePath` points at the fake directory.
+ * Creates a fake JDK whose `bin/java.exe` is a copy of `mirrord.exe`, and an
+ * [Sdk] whose `homePath` points at it.
  *
  * IntelliJ invokes `<sdk.homePath>/bin/java.exe` for Java run configurations.
  * With this fake JDK, it runs `mirrord.exe` instead. mirrord's `run_as_java_launcher`
- * detects `argv[0]` ends with `java.exe`, reads [REAL_JAVA_ENV] for the real
- * `java.exe` path, and executes the pitm flow.
+ * matches `argv[0]`'s basename against `java.exe`, reads [REAL_JAVA_ENV] for the
+ * real `java.exe` path, and executes the pitm flow.
  *
  * CLI source: https://github.com/metalbear-co/mirrord/blob/main/mirrord/cli/src/pitm.rs
  * Introduced in: https://github.com/metalbear-co/mirrord/pull/4191
@@ -34,17 +37,23 @@ object MirrordPitmJdk {
     private val fakeJavaExe: File = File(fakeJdkDir, "bin/java.exe")
 
     /**
-     * Copies [mirrordExe] to the fake JDK's `bin/java.exe` and returns a
-     * delegating [Sdk] that reports the fake directory as its home path. All
-     * other [Sdk] methods pass through to [realJdk].
+     * [ProjectJdkImpl]'s constructor registers the instance with the application's
+     * `VirtualFilePointerManager`, which outlives every run, so instances are
+     * reused instead of built per launch.
+     */
+    private val fakeSdkCache = ConcurrentHashMap<String, Sdk>()
+
+    /**
+     * Copies [mirrordExe] to the fake JDK's `bin/java.exe` and returns an [Sdk]
+     * that reports the fake directory as its home path.
      *
      * The copy is skipped when the fake `java.exe` already exists and has the
      * same size and MD5 as the source — this avoids rewriting on every run
      * when the binary hasn't changed, while still picking up auto-updates.
      *
-     * @return the wrapping [Sdk], or `null` if the fake could not be prepared
-     *         (e.g. `realJdk.homePath` is null, source `mirrordExe` doesn't
-     *         exist, or the copy failed).
+     * @return the fake [Sdk], or `null` if it could not be prepared (e.g.
+     *         `realJdk.homePath` is null, source `mirrordExe` doesn't exist, or
+     *         the copy failed). The caller then falls back to the non-pitm path.
      */
     fun wrap(realJdk: Sdk, mirrordExe: File): Sdk? {
         val realHome = realJdk.homePath ?: run {
@@ -91,9 +100,28 @@ object MirrordPitmJdk {
                 "realHome=$realHome, fakeHome=${fakeJdkDir.absolutePath}"
         )
 
-        return object : Sdk by realJdk {
-            override fun getHomePath(): String = fakeJdkDir.absolutePath
-            override fun getHomeDirectory() = null
+        return fakeSdkFor(realJdk)
+    }
+
+    /**
+     * Builds the fake [Sdk] with the platform's own [ProjectJdkImpl] rather than
+     * implementing [Sdk] — the interface is `@ApiStatus.NonExtendable`, so a
+     * hand-rolled implementation fails JetBrains' Plugin Verifier.
+     *
+     * [realJdk]'s `sdkType` is carried over because `JdkCommandLineSetup` refuses
+     * to launch anything whose type isn't a `JavaSdkType`, and its `versionString`
+     * because the debugger's async-stack-traces agent and the Java 18+ console
+     * encoding flags are skipped without one.
+     */
+    private fun fakeSdkFor(realJdk: Sdk): Sdk {
+        val key = "${realJdk.sdkType.name} ${realJdk.name} ${realJdk.versionString}"
+        return fakeSdkCache.computeIfAbsent(key) {
+            ProjectJdkImpl(
+                realJdk.name,
+                realJdk.sdkType,
+                FileUtil.toSystemIndependentName(fakeJdkDir.absolutePath),
+                realJdk.versionString
+            )
         }
     }
 

--- a/src/test/kotlin/com/metalbear/mirrord/products/idea/MirrordPitmJdkTest.kt
+++ b/src/test/kotlin/com/metalbear/mirrord/products/idea/MirrordPitmJdkTest.kt
@@ -1,0 +1,83 @@
+package com.metalbear.mirrord.products.idea
+
+import com.intellij.execution.configurations.JavaParameters
+import com.intellij.openapi.projectRoots.JavaSdk
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import java.io.File
+
+/**
+ * Drives the real `JavaParameters` → `GeneralCommandLine` conversion, so it proves
+ * the platform actually launches the fake `java.exe` rather than re-asserting what
+ * [MirrordPitmJdk] already returned.
+ *
+ * Windows-native only, like the pitm path itself.
+ */
+class MirrordPitmJdkTest : BasePlatformTestCase() {
+
+    private fun realJdk() = JavaSdk.getInstance().createJdk(
+        "mirrord-test-real",
+        System.getProperty("java.home"),
+        false
+    )
+
+    /** Stand-in for mirrord.exe. [MirrordPitmJdk.wrap] only copies its bytes, never runs it. */
+    private fun fakeMirrordExe(): File =
+        File.createTempFile("mirrord-test-", ".exe").apply {
+            writeBytes(ByteArray(2048) { 0x4D })
+            deleteOnExit()
+        }
+
+    fun testWrappedSdkMakesThePlatformLaunchFakeJavaExe() {
+        if (!SystemInfo.isWindows) return
+
+        val realJdk = realJdk()
+        val mirrordExe = fakeMirrordExe()
+
+        val wrapped = MirrordPitmJdk.wrap(realJdk, mirrordExe)
+        assertNotNull("wrap() returned null; fake JDK could not be prepared", wrapped)
+        wrapped!!
+
+        val fakeJavaExe = File(wrapped.homePath!!, "bin/java.exe")
+        assertTrue("fake bin/java.exe missing", fakeJavaExe.isFile)
+        assertEquals("fake java.exe is not the mirrord binary", mirrordExe.length(), fakeJavaExe.length())
+
+        // JdkCommandLineSetup rejects a non-JavaSdkType, and skips the debugger's
+        // async-stack-traces agent when the version is unknown.
+        assertEquals(realJdk.sdkType, wrapped.sdkType)
+        assertEquals(realJdk.versionString, wrapped.versionString)
+
+        val commandLine = JavaParameters().apply {
+            jdk = wrapped
+            mainClass = "com.example.Main"
+            classPath.add(File(System.getProperty("java.home"), "lib").absolutePath)
+        }.toCommandLine()
+
+        assertEquals(
+            "platform did not launch the fake java.exe",
+            fakeJavaExe.canonicalPath,
+            File(commandLine.exePath).canonicalPath
+        )
+    }
+
+    /** The delegating object it replaced returned null here, which makes getJdkPath() throw. */
+    fun testWrappedSdkExposesAHomeDirectory() {
+        if (!SystemInfo.isWindows) return
+
+        val wrapped = MirrordPitmJdk.wrap(realJdk(), fakeMirrordExe())
+        assertNotNull(wrapped)
+        assertNotNull("homePath must not be null; getConvertedHomePath asserts on it", wrapped!!.homePath)
+    }
+
+    /** ProjectJdkImpl registers itself with VirtualFilePointerManager, so instances are reused. */
+    fun testRepeatedWrapsReuseOneSdkInstance() {
+        if (!SystemInfo.isWindows) return
+
+        val realJdk = realJdk()
+        val first = MirrordPitmJdk.wrap(realJdk, fakeMirrordExe())
+        val second = MirrordPitmJdk.wrap(realJdk, fakeMirrordExe())
+
+        assertNotNull(first)
+        assertSame("each wrap() leaked a new ProjectJdkImpl", first, second)
+    }
+}


### PR DESCRIPTION
# Fix the `@ApiStatus.NonExtendable` violation in the pitm fake JDK

> **Context:** the fake JDK, `mirrord pitm`, and the full Windows-native launch matrix were
> introduced in **https://github.com/metalbear-co/mirrord-intellij/pull/425**. That PR's summary
> explains why each launch scenario uses the strategy it does, and is the recommended read before
> this one — everything below assumes its "IDEA non-Gradle (Run & Debug) → Fake JDK" row.

## Summary

JetBrains' Plugin Verifier reports exactly one non-extendable API violation against the published
plugin. `MirrordPitmJdk.wrap` (added in #425) implements `com.intellij.openapi.projectRoots.Sdk` by
delegation:

```kotlin
return object : Sdk by realJdk {
    override fun getHomePath(): String = fakeJdkDir.absolutePath
    override fun getHomeDirectory() = null
}
```

`Sdk` is annotated `@ApiStatus.NonExtendable`, so implementing it — even by delegation — is illegal:

> Non-extendable interface `com.intellij.openapi.projectRoots.Sdk` is implemented by
> `com.metalbear.mirrord.products.idea.MirrordPitmJdk.wrap$1`. This interface is marked with
> `@org.jetbrains.annotations.ApiStatus.NonExtendable`, which indicates that the interface is not
> supposed to be extended.

This PR builds the same fake JDK's `Sdk` with the platform's own `ProjectJdkImpl` constructor
instead. **The pitm mechanism itself is unchanged** — same fake dir, same `mirrord.exe` copied to
`bin/java.exe`, same `MIRRORD_PITM_REAL_JAVA` / `MIRRORD_CHILD_ENV`, same `run_as_java_launcher`
entry. **No mirrord CLI changes.** Only *who constructs the `Sdk`* changes.

```kotlin
ProjectJdkImpl(
    realJdk.name,
    realJdk.sdkType,
    FileUtil.toSystemIndependentName(fakeJdkDir.absolutePath),
    realJdk.versionString
)
```

Scope is one launch path. Per #425's matrix, only **IDEA non-Gradle (Run & Debug)** uses the fake
JDK; Gradle Run (init script), Gradle Debug (JDWP + `mirrord attach`), and Rider Run/Debug
(`patchCommandLine` / attach) are untouched.

## Why the fake JDK stays

<details>
<summary>The homePath swap is the only lever, and mirrord doesn't require the <code>java.exe</code> name</summary>

1. **`patchCommandLine` never fires for Java run configs** — only `updateJavaParameters` does (unlike
   Rider/C#, where `RiderPatchCommandLineExtension` uses it directly). So `JavaParameters` is the
   only hook.
2. **The exe comes from the SDK's `homePath`.** `SimpleJavaParameters.toCommandLine()` →
   `JdkUtil.setupJVMCommandLine` → `JdkCommandLineSetup.setupJavaExePath`:
   ```kotlin
   val type = jdk.sdkType
   if (type !is JavaSdkType) throw CantRunException(...)
   commandLine.setExePath((type as JavaSdkType).getVMExecutablePath(jdk))
   ```
   and `JavaSdkImpl.getVMExecutablePath(sdk)` = `getConvertedHomePath(sdk) + "bin" + File.separator + "java.exe"`.
   ⇒ **`homePath` is the only thing that controls the launched executable**, and `sdkType` must stay a
   `JavaSdkType` or the launch throws.
3. **mirrord imposes no naming requirement.** `run_as_java_launcher` hand-builds `PitmArgs` and calls
   the same `pitm_command` that `mirrord pitm -- <exe> <args>` reaches — the Gradle init script
   (`spec.args 'pitm', '--', realJava, '@'+argfile`) and Rider (`addParameters("pitm", "--", exe)`)
   already prove that in production. The `java.exe` name is required **only** because IntelliJ
   hard-codes `<homePath>/bin/java.exe`.

So the violation was never about *what* the fake JDK does — only about *how the `Sdk` was built*.
</details>

## Why `ProjectJdkImpl` and not the alternatives

<details>
<summary>Every other route needs a write lock, and <code>updateJavaParameters</code> runs under a read action</summary>

Setting an `Sdk`'s `homePath` always goes through `SdkModificator` → `commitChanges()`, which is
`@RequiresWriteLock` and runtime-enforced (`ProjectJdkImpl.commitChanges` calls
`ThreadingAssertions.assertWriteAccess()`). But `updateJavaParameters` runs **inside a read action**:

```java
// BaseJavaApplicationCommandLineState
protected void setupJavaParameters(@NotNull JavaParameters params) throws ExecutionException {
    ReadAction.run(() -> JavaRunConfigurationExtensionManager.getInstance()
      .updateJavaParameters(getConfiguration(), params, getRunnerSettings(), ...));
}
// JavaCommandLineState.getJavaParameters(): isReadActionRequired() defaults true -> ReadAction.compute(...)
```

A write action inside a read action throws. `applyChangesWithoutWriteAction()` would dodge it but is
`@ApiStatus.Internal` — trading a NonExtendable violation for an Internal one.

`ProjectJdkImpl`'s 4-arg constructor is the only public route that sets a home path without a
modificator. Verified with `javap` on **2024.1 and 2025.2.3**: the class has no class-level
annotation block, and the constructor is `ACC_PUBLIC` with no annotations — so it trips neither
`NON_EXTENDABLE_API_USAGES` nor `INTERNAL_API_USAGES`. The verifier report confirms this: it never
mentions `ProjectJdkImpl`.

It also isn't an oversight on JetBrains' side. On `intellij-community` `master`, the **adjacent 5-arg
overload is explicitly `@ApiStatus.Internal` while the 4-arg one used here is deliberately left
un-annotated**:

```java
public ProjectJdkImpl(@NotNull String name, @NotNull SdkTypeId sdkType, String homePath, String version) {  // ← used here

@ApiStatus.Internal
public ProjectJdkImpl(@NotNull String name, @NotNull SdkTypeId sdkType, String homePath, String version,
                      /* ... */) {
```

| Alternative | Verdict |
|---|---|
| `JavaSdk.createJdk(name, fakeHome, isJre)` | ❌ Probes the home for a version; `JdkVersionDetectorImpl` falls back `detectFromRelease` → `detectFromJar` → `detectFromOutput`, which **executes `<home>/bin/java.exe -version`** and blocks on it — i.e. runs **mirrord.exe** inside the read action. Copying the real `release` file in short-circuits it, but `getInfo` then caches the version **by home path** for the app's lifetime → stale version after switching JDKs. Also rewrites `sdkType` to `JavaSdk`. |
| `ProjectJdkTable.createSdk` + `SdkModificator` | ❌ `createSdk` is public and un-annotated, but yields `homePath == null`, so it still needs `commitChanges()` → read-action wall. |
| Custom `SdkType : JavaSdkType` | ❌ Same wall for `homePath`, **and** would need a mirrord change: `getVMExecutablePath` returns only a path, so `pitm --` can't be passed, and `run_as_java_launcher` matches argv[0] basename *exactly*. |
| `SdkConfigurationUtil.createAndAddSDK` | ❌ EDT + `WriteAction.compute`, and **publishes the fake JDK into the user's global SDK list**. |
| `SimpleJavaSdkType.createJdk` | ❌ Its `getVMExecutablePath` returns `bin/java` **without `.exe`** — broken on the only platform this path serves. |
| `mirrord attach` for the Run path | ❌ Reintroduces the race window pitm exists to close. |
</details>

## Two silent bugs fixed on the way

Carrying `sdkType` and `versionString` over verbatim (instead of overriding two methods on a
delegate) closes two latent issues in the delegating object:

- **`getHomeDirectory() = null`** — `JavaParameters.getJdkPath()` reads `jdk.getHomeDirectory()` and
  throws `CantRunException` when it's null. The override was never needed; nothing in the launch path
  consults it.
- **A droppable `versionString`** — `RemoteConnectionBuilder` skips the debugger's async-stack-traces
  `-javaagent:debugger-agent.jar` when `JavaSdk.getVersion(jdk)` is null, and `JdkCommandLineSetup`
  skips `-Dsun.stdout.encoding` / `-Dsun.stderr.encoding` on Java 18+ (console mojibake). Both
  degrade **silently**.

`ProjectJdkImpl`'s constructor registers the instance with the application's
`VirtualFilePointerManager`, which outlives every run, so instances are cached rather than built
per launch.

## Verification

<details open>
<summary>Plugin Verifier A/B against GoLand 2025.1 — the IDE that triggered the report</summary>

| Run | **non-extendable** | compat | sched-removal | deprecated | experimental | internal |
|---|---|---|---|---|---|---|
| before (`object : Sdk by realJdk`) | **1** ← `Sdk is implemented by MirrordPitmJdk.wrap$1` | 10 | 1 | 7 | 21 | 10 |
| after (`ProjectJdkImpl`) | **0** | 10 | 1 | 7 | 21 | 10 |
| after (re-run, clean branch) | **0** | 10 | 1 | 7 | 21 | 10 |
| after, IU 2024.1 | **0** | 1 | 1 | 8 | 21 | 8 |

Every other count is identical before/after — the violation is the only thing that moves. The 10
internal-API usages are all pre-existing and unrelated (`ToolWindowFactory`,
`PluginManagerConfigurable`, PyCharm's `PythonCommandLineTargetEnvironmentProvider`);
`ProjectJdkImpl` is not among them.
</details>

<details>
<summary>Automated test — drives the real command-line construction</summary>

`MirrordPitmJdkTest` goes through the actual `JavaParameters.toCommandLine()` → `JdkCommandLineSetup`
path rather than re-asserting what `wrap()` returned:

- `testWrappedSdkMakesThePlatformLaunchFakeJavaExe` — resulting `exePath` **is** `<fakeHome>/bin/java.exe`,
  and `sdkType` / `versionString` survive the swap.
- `testWrappedSdkExposesAHomeDirectory` — pins the `getHomeDirectory()` fix.
- `testRepeatedWrapsReuseOneSdkInstance` — pins instance reuse.

Windows-gated (like the pitm path itself), so it no-ops on Linux CI. `BasePlatformTestCase` is JUnit3
and the task runs `useJUnitPlatform()`, hence the vintage engine; both existing tests are JUnit5, so
this only enables the new one.
</details>

<details>
<summary>Live IDE run (IntelliJ IDEA 2025.2.3, Windows-native)</summary>

```
updateJavaParameters: platform gating winNative=true wsl=null isDebug=false
updateJavaParameters: branch=NON_GRADLE_WIN, attempting wrapJdkWithPitm
MirrordPitmJdk: wrapping Sdk ms-25, realHome=.../jdk-25.0.0.36-hotspot, fakeHome=...\.mirrord\binaries\idea
wrapJdkWithPitm: SUCCESS realJava=.../bin/java.exe childEnvPayload.len=7784 params.env 0 → 2 (+REAL_JAVA, +CHILD_ENV)
updateJavaParameters: pitm JDK wrap succeeded
```

Reproduced across both Run (`isDebug=false`) and Debug (`isDebug=true`,
`runnerSettings=GenericDebuggerRunnerSettings`), with no `CantRunException` / `ExecutionException`
anywhere in `idea.log` — which is the signal that matters here, since a malformed `Sdk` (wrong
`sdkType`, null `homePath`) would make `JdkCommandLineSetup` throw at launch.
</details>

## Notes / follow-ups (not in this PR)

- **`pluginVerification` currently verifies nothing.** There is no `ides {}` block, so `verifyPlugin`
  has no IDE to run against — which is why this violation shipped despite
  `failureLevel` already containing `COMPATIBILITY_PROBLEMS`. Adding one surfaces 10 pre-existing
  `COMPATIBILITY_PROBLEMS` that fail the build, and they're structural: GoLand can't resolve the
  Tomcat/JavaEE classes, IU can't resolve `com.jetbrains.rider`. For a multi-product composed plugin
  **no single IDE is ever clean**, so gating needs `failureLevel` without `COMPATIBILITY_PROBLEMS`:
  ```kotlin
  pluginVerification {
      failureLevel = EnumSet.of(
          VerifyPluginTask.FailureLevel.INVALID_PLUGIN,
          VerifyPluginTask.FailureLevel.NON_EXTENDABLE_API_USAGES,
      )
      ides { create(IntelliJPlatformType.GoLand, "2025.1") }   // DSL is `create`, not `ide`, in 2.14.0
  }
  ```
  Left out deliberately — it's a CI policy call.
- **`run_as_java_launcher` matches the basename exactly against `java.exe`**, so **`javaw.exe` does
  not match**. Latent, pre-existing, unrelated to this violation. The KDoc claiming it "detects
  `argv[0]` ends with `java.exe`" was inaccurate and is corrected here.
- **`ShortenCommandLine.getDefaultMethodForJdkLevel` probes `<home>/lib/jrt-fs.jar`**; the sparse fake
  home means `MANIFEST` (classpath jar) rather than `ARGS_FILE`. Pre-existing, and normally evaluated
  before the swap. An empty `lib/jrt-fs.jar` marker would fix it if it ever bites.
