### PR TITLE
Add configurable mirrord task timeout setting

### DIFF
--- a/changelog.d/+configurable-task-timeout.added.md
+++ b/changelog.d/+configurable-task-timeout.added.md
@@ -1,0 +1,1 @@
+Added a setting to configure the mirrord task timeout (in minutes), defaulting to 2 minutes.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -859,6 +859,7 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
     fun run(project: Project): T {
         val commandLine = prepareCommandLine(project)
         val logsService = project.service<MirrordLogsService>()
+        val taskTimeoutMinutes = MirrordSettingsState.instance.mirrordState.taskTimeoutMinutes.toLong()
 
         MirrordLogger.logger.info("running mirrord task with following command line: ${commandLine.commandLineString}")
 
@@ -911,7 +912,7 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
             })
 
             try {
-                env.get(2, TimeUnit.MINUTES)
+                env.get(taskTimeoutMinutes, TimeUnit.MINUTES)
             } catch (e: ExecutionException) {
                 throw e.cause ?: e
             } catch (e: CancellationException) {
@@ -928,7 +929,7 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
             // (to update the UI with a progress indicator).
             // EDT thread requires a write lock, so using a background task here would cause a deadlock.
             try {
-                computeWithResponsiveCancel(project, process, TimeoutProgressChecker(2, TimeUnit.MINUTES))
+                computeWithResponsiveCancel(project, process, TimeoutProgressChecker(taskTimeoutMinutes, TimeUnit.MINUTES))
             } catch (e: ProcessCanceledException) {
                 // In this case, process is canceled only after a timeout.
                 process.destroy()

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsComponent.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsComponent.kt
@@ -31,6 +31,12 @@ class MirrordSettingsComponent {
         this
     }
 
+    private val taskTimeoutLabel = JBLabel("mirrord task timeout (minutes):")
+    private val taskTimeout = with(JBTextField("", 5)) {
+        toolTipText = "how long to wait for a mirrord task (e.g. starting the agent) before timing out"
+        this
+    }
+
     private val autoUpdate = JBCheckBox("Auto update mirrord binary")
         .apply {
             addItemListener { e ->
@@ -51,6 +57,7 @@ class MirrordSettingsComponent {
         .addComponent(usageBannerEnabled)
         .addComponent(enabledOnStartup)
         .addComponent(versionCheckEnabled)
+        .addLabeledComponent(taskTimeoutLabel, taskTimeout)
         .addSeparator()
         .addComponent(autoUpdatePanel)
         .addSeparator()
@@ -108,5 +115,15 @@ class MirrordSettingsComponent {
         get() = mirrordBinaryPath.text
         set(value) {
             mirrordBinaryPath.text = value.trim()
+        }
+
+    /**
+     * The configured task timeout in minutes. Falls back to the default if the field is empty
+     * or not a positive integer.
+     */
+    var taskTimeoutMinutesStatus: Int
+        get() = taskTimeout.text.trim().toIntOrNull()?.takeIf { it > 0 } ?: DEFAULT_TASK_TIMEOUT_MINUTES
+        set(value) {
+            taskTimeout.text = value.toString()
         }
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsConfigurable.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsConfigurable.kt
@@ -21,7 +21,8 @@ class MirrordSettingsConfigurable : Configurable {
                 (autoUpdateEnabledStatus != settings.autoUpdate) ||
                 (mirrordVersionStatus != settings.mirrordVersion) ||
                 (mirrordBinaryPathStatus != settings.mirrordBinaryPath) ||
-                (enabledOnStartupStatus != settings.enabledByDefault)
+                (enabledOnStartupStatus != settings.enabledByDefault) ||
+                (taskTimeoutMinutesStatus != settings.taskTimeoutMinutes)
         }
     }
 
@@ -35,6 +36,7 @@ class MirrordSettingsConfigurable : Configurable {
             settings.mirrordVersion = mirrordVersionStatus
             settings.mirrordBinaryPath = mirrordBinaryPathStatus
             settings.enabledByDefault = enabledOnStartupStatus
+            settings.taskTimeoutMinutes = taskTimeoutMinutesStatus
         }
     }
 
@@ -48,6 +50,7 @@ class MirrordSettingsConfigurable : Configurable {
             notificationsDisabledStatus = settings.disabledNotifications.orEmpty()
             usageBannerEnabledStatus = settings.showUsageBanner
             enabledOnStartupStatus = settings.enabledByDefault
+            taskTimeoutMinutesStatus = settings.taskTimeoutMinutes
         }
     }
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsState.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsState.kt
@@ -6,6 +6,12 @@ import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
 
+/**
+ * Default timeout (in minutes) for a mirrord task, i.e. the `mirrord ext` execution that
+ * spins up the agent and returns the patched environment.
+ */
+const val DEFAULT_TASK_TIMEOUT_MINUTES: Int = 2
+
 @State(name = "MirrordSettingsState", storages = [Storage("mirrord.xml")])
 open class MirrordSettingsState : PersistentStateComponent<MirrordSettingsState.MirrordState> {
     companion object {
@@ -54,6 +60,7 @@ open class MirrordSettingsState : PersistentStateComponent<MirrordSettingsState.
         var runsCounter: Int = 0
         var operatorUsed: Boolean = false
         var enabledByDefault: Boolean = false
+        var taskTimeoutMinutes: Int = DEFAULT_TASK_TIMEOUT_MINUTES
 
         fun disableNotification(id: NotificationId) {
             disabledNotifications = disabledNotifications.orEmpty() + id


### PR DESCRIPTION
Thank you for contributing to mirrord!

Please make sure you added a CHANGELOG file in `changelog.d/` named `issue_number.category.md`.
For example, `1054.changed.md` or `+towncrier.added.md` (if no issue).