### PR TITLE
Fix release: dispatch correct infra jetbrains-version workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -224,7 +224,7 @@ jobs:
 
           gh api \
             --method POST \
-            repos/metalbear-co/infra/actions/workflows/update-vscode-version.yml/dispatches \
+            repos/metalbear-co/infra/actions/workflows/update-jetbrains-version.yml/dispatches \
             -f ref=main \
             -f inputs[jetbrains_version]=${{ needs.release.outputs.version }}
 


### PR DESCRIPTION
## Problem

The `update_infra_jetbrains_version` job in the Release workflow dispatched `update-vscode-version.yml` in the infra repo (a copy-paste leftover from the vscode repo) while passing a `jetbrains_version` input. That workflow doesn't accept it, so the dispatch failed with:

```
gh: Unexpected inputs provided: ["jetbrains_version"] (HTTP 422)
```

The rest of the release succeeded — only this final infra version-bump dispatch failed.

## Fix

Point the dispatch at `update-jetbrains-version.yml`, which declares `jetbrains_version` as its input.

Verified `update-jetbrains-version.yml` exists in `metalbear-co/infra` and accepts the `jetbrains_version` input.