### PR TITLE
COR-1701 — fix instrumentCode on Windows JDKs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,13 @@ gradleVersion = 9.5.1
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 # suppress inspection "UnusedProperty"
 kotlin.stdlib.default.dependency = false
+
+# Fixes `instrumentCode` on Windows. Javac2's classpath builder calls Ant's
+# addJavaRuntime(), whose legacy Apple-JDK logic appends a bogus `<java.home>/Packages`
+# entry that doesn't exist on a modern JDK, so the task fails with
+# "<java.home>\Packages does not exist" whenever it runs fresh (it only "passed"
+# before via up-to-date caching). The instrumenter doesn't need the Ant-added runtime —
+# it resolves JDK classes through the jrt filesystem — so turning this off is safe on
+# every platform and only skips the broken code path.
+# suppress inspection "UnusedProperty"
+systemProp.javac2.instrumentation.includeJavaRuntime = false


### PR DESCRIPTION
# Make fresh IntelliJ instrumentation builds work on Windows

## Linear

https://linear.app/metalbear/issue/COR-1701/investigate-gradle-debug-path-not-inheriting-env-vars

## Stack

1 of 3 in the IntelliJ Windows Gradle and troubleshooting stack. This small build prerequisite is based on `main` and should be reviewed first.

## Summary

Disables javac2's legacy Java-runtime classpath injection for `instrumentCode`.

This lets a clean plugin build complete on modern Windows JDKs, where Ant otherwise adds a nonexistent `<java.home>/Packages` entry.

## Motivation

The IntelliJ instrumentation task calls Ant's `addJavaRuntime()`. Its legacy Apple-JDK branch contributes a `Packages` classpath entry that does not exist on current Windows JDK layouts, so a fresh `instrumentCode` invocation fails before the plugin tests or artifact build can run.

The instrumenter resolves JDK classes through the JRT filesystem and does not need the legacy runtime entry. Setting `javac2.instrumentation.includeJavaRuntime=false` removes only that obsolete classpath contribution.

## Verification

- fresh `clean instrumentCode` across all plugin modules
- `ktlintCheck`
- plugin build through `buildPlugin`
- non-UI extension test suite

The full RemoteRobot suite reaches the PyCharm 2026.2 fixture but currently stops at the unrelated `Close theme onboarding` selector before any mirrord flow runs.

Thank you for contributing to mirrord!

A changelog entry is not included because this changes build plumbing only and has no shipped plugin behavior.
