### PR TITLE
COR-1701 — fix instrumentCode with modern JDK layouts

### DIFF
--- a/changelog.d/+instrument-code-modern-jdk.internal.md
+++ b/changelog.d/+instrument-code-modern-jdk.internal.md
@@ -1,0 +1,1 @@
+Fixed plugin instrumentation builds with modern JDK layouts.

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,13 @@ gradleVersion = 9.5.1
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 # suppress inspection "UnusedProperty"
 kotlin.stdlib.default.dependency = false
+
+# Fixes `instrumentCode` on Windows. Javac2's classpath builder calls Ant's
+# addJavaRuntime(), whose legacy Apple-JDK logic appends a bogus `<java.home>/Packages`
+# entry that doesn't exist on a modern JDK, so the task fails with
+# "<java.home>\Packages does not exist" whenever it runs fresh (it only "passed"
+# before via up-to-date caching). The instrumenter doesn't need the Ant-added runtime —
+# it resolves JDK classes through the jrt filesystem — so turning this off is safe on
+# every platform and only skips the broken code path.
+# suppress inspection "UnusedProperty"
+systemProp.javac2.instrumentation.includeJavaRuntime = false


### PR DESCRIPTION
# Fix `instrumentCode` with modern JDK layouts

## Linear

https://linear.app/metalbear/issue/COR-1701

## Summary

Stops Javac2 instrumentation from asking Ant to append legacy Java-runtime entries to its classpath.

The IntelliJ plugin build no longer fails because Ant invents a `<java.home>/Packages` entry that does not exist in modern JDK layouts.

## Motivation

Javac2's classpath builder called Ant's `addJavaRuntime()`, whose legacy Apple-JDK handling appended `<java.home>/Packages`. On a modern Windows JDK that path does not exist, so a fresh `instrumentCode` run failed before mirrord code or tests ran; cached builds could hide the problem by reporting the task up to date.

## Implementation

Sets `systemProp.javac2.instrumentation.includeJavaRuntime=false` in `gradle.properties`. IntelliJ's instrumenter resolves JDK classes through the JRT filesystem, so the Ant-added legacy runtime classpath is unnecessary. The property is safe across platforms and keeps local and CI builds on the same path.

An internal news fragment records the build-only fix and satisfies the repository's Towncrier check.

## Verification

- `ktlintCheck`;
- focused Windows Gradle injector and settings tests;
- `buildPlugin` across the repository's product modules;
- `towncrier check`;
- generated `mirrord-3.78.0.zip` on Windows.

## Stack

1. **COR-1701 — modern-JDK `instrumentCode` fix** (this PR)
2. COR-1701/COR-1697 — final Windows Gradle Run and Debug path
3. COR-1697 — trace-level troubleshooting logs

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context
