### PR TITLE
COR-1697 — add trace-level troubleshooting logs

### DIFF
--- a/changelog.d/+troubleshooting-layer-logs.added.md
+++ b/changelog.d/+troubleshooting-layer-logs.added.md
@@ -1,0 +1,1 @@
+Added a troubleshooting setting that enables trace logs for the mirrord CLI, intproxy, and layer, with an optional directory for per-process layer log files.

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -10,10 +10,17 @@ dependencies {
     implementation("com.google.code.gson:gson:2.14.0")
     implementation("com.github.zafarkhaja:java-semver:0.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.5.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:6.1.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:6.1.0")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.0")
 
     intellijPlatform {
         intellijIdea(properties("platformVersion"))
         // Needed by com.jetbrains.jsonSchema.*
         bundledPlugin("JavaScript")
     }
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -253,12 +253,24 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         MirrordLogger.logger.debug("MirrordExecManager.start: executionInfo: $executionInfo")
 
         executionInfo.environment["MIRRORD_IGNORE_DEBUGGER_PORTS"] = "35000-65535"
+        // Verbose-logging env (when enabled in settings). Goes on executionInfo.environment so it
+        // reaches the layer through every product/platform path, including the Windows
+        // MIRRORD_CHILD_ENV payload.
+        executionInfo.environment.putAll(
+            MirrordSettingsState.instance.mirrordState.troubleshootingLayerEnvVars {
+                wslPath(wslDistribution, it)
+            }
+        )
         return executionInfo
     }
 
     /**
      * Runs `mirrord attach <PID>`. Expects `mirrord ext` to have already
      * started the intproxy and set env vars on the target process.
+     *
+     * Only reached from Rider (`RiderPatchCommandLineExtension`), where the debugger — not
+     * Gradle — owns process creation, so the JVM can't be pitm-wrapped. IDEA's Windows-native
+     * paths (including Gradle Run and Debug) all use `mirrord pitm` instead.
      *
      * CLI source: https://github.com/metalbear-co/mirrord/blob/main/mirrord/cli/src/attach.rs
      * Introduced in: https://github.com/metalbear-co/mirrord/pull/3995
@@ -303,6 +315,14 @@ class MirrordExecManager(private val service: MirrordProjectService) {
 
         executionInfo.extraArgs.add("-e")
         executionInfo.extraArgs.add("MIRRORD_IGNORE_DEBUGGER_PORTS=\"35000-65535\"")
+
+        // Verbose-logging env (when enabled in settings), forwarded into the container.
+        // A host-selected directory is not mounted into the container, so keep trace output on
+        // stderr there instead of forwarding a path that cannot refer to the chosen directory.
+        MirrordSettingsState.instance.mirrordState.troubleshootingLayerEnvVars { "" }.forEach { (key, value) ->
+            executionInfo.extraArgs.add("-e")
+            executionInfo.extraArgs.add("$key=$value")
+        }
 
         return executionInfo
     }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordProjectService.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordProjectService.kt
@@ -18,7 +18,9 @@ class MirrordProjectService(val project: Project) : Disposable {
     val versionCheck: MirrordVersionCheck = MirrordVersionCheck(this)
 
     fun mirrordApi(environment: Map<String, String>?): MirrordApi {
-        return MirrordApi(this, environment)
+        val cliEnvironment =
+            environment.orEmpty() + MirrordSettingsState.instance.mirrordState.troubleshootingCliEnvVars()
+        return MirrordApi(this, cliEnvironment)
     }
 
     val notifier: MirrordNotifier = MirrordNotifier(this)

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsComponent.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsComponent.kt
@@ -1,5 +1,7 @@
 package com.metalbear.mirrord
 
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
@@ -44,6 +46,26 @@ class MirrordSettingsComponent {
             }
         }
 
+    private val troubleshootingLogsPathLabel = JBLabel("Log directory:")
+    private val troubleshootingLogsPath = TextFieldWithBrowseButton().apply {
+        toolTipText = "directory for mirrord's trace logs (sets MIRRORD_LAYER_LOG_PATH); " +
+            "leave empty to log to stderr only"
+        addBrowseFolderListener(
+            null,
+            FileChooserDescriptorFactory.createSingleFolderDescriptor().withTitle("mirrord Layer Log Directory")
+        )
+        isEnabled = false
+    }
+
+    private val troubleshootingLogsEnabled = JBCheckBox("Collect mirrord troubleshooting logs (trace level)")
+        .apply {
+            toolTipText = "enables trace logging for the mirrord CLI and layer; when a directory is given, " +
+                "the layer writes per-process files there without changing the launched application's RUST_LOG"
+            addItemListener { e ->
+                troubleshootingLogsPath.isEnabled = e.stateChange == ItemEvent.SELECTED
+            }
+        }
+
     private val autoUpdatePanel = FormBuilder
         .createFormBuilder()
         .addComponent(autoUpdate)
@@ -60,6 +82,9 @@ class MirrordSettingsComponent {
         .addLabeledComponent(taskTimeoutLabel, taskTimeout)
         .addSeparator()
         .addComponent(autoUpdatePanel)
+        .addSeparator()
+        .addComponent(troubleshootingLogsEnabled)
+        .addLabeledComponent(troubleshootingLogsPathLabel, troubleshootingLogsPath)
         .addSeparator()
         .addComponent(JBLabel("Notify when:"))
         .apply {
@@ -125,5 +150,18 @@ class MirrordSettingsComponent {
         get() = taskTimeout.text.trim().toIntOrNull()?.takeIf { it > 0 } ?: DEFAULT_TASK_TIMEOUT_MINUTES
         set(value) {
             taskTimeout.text = value.toString()
+        }
+
+    var troubleshootingLogsEnabledStatus: Boolean
+        get() = troubleshootingLogsEnabled.isSelected
+        set(value) {
+            troubleshootingLogsEnabled.isSelected = value
+            troubleshootingLogsPath.isEnabled = value
+        }
+
+    var troubleshootingLogsPathStatus: String
+        get() = troubleshootingLogsPath.text.trim()
+        set(value) {
+            troubleshootingLogsPath.text = value.trim()
         }
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsConfigurable.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsConfigurable.kt
@@ -22,7 +22,9 @@ class MirrordSettingsConfigurable : Configurable {
                 (mirrordVersionStatus != settings.mirrordVersion) ||
                 (mirrordBinaryPathStatus != settings.mirrordBinaryPath) ||
                 (enabledOnStartupStatus != settings.enabledByDefault) ||
-                (taskTimeoutMinutesStatus != settings.taskTimeoutMinutes)
+                (taskTimeoutMinutesStatus != settings.taskTimeoutMinutes) ||
+                (troubleshootingLogsEnabledStatus != settings.troubleshootingLogsEnabled) ||
+                (troubleshootingLogsPathStatus != settings.troubleshootingLogsPath)
         }
     }
 
@@ -37,6 +39,8 @@ class MirrordSettingsConfigurable : Configurable {
             settings.mirrordBinaryPath = mirrordBinaryPathStatus
             settings.enabledByDefault = enabledOnStartupStatus
             settings.taskTimeoutMinutes = taskTimeoutMinutesStatus
+            settings.troubleshootingLogsEnabled = troubleshootingLogsEnabledStatus
+            settings.troubleshootingLogsPath = troubleshootingLogsPathStatus
         }
     }
 
@@ -51,6 +55,8 @@ class MirrordSettingsConfigurable : Configurable {
             usageBannerEnabledStatus = settings.showUsageBanner
             enabledOnStartupStatus = settings.enabledByDefault
             taskTimeoutMinutesStatus = settings.taskTimeoutMinutes
+            troubleshootingLogsEnabledStatus = settings.troubleshootingLogsEnabled
+            troubleshootingLogsPathStatus = settings.troubleshootingLogsPath
         }
     }
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsState.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsState.kt
@@ -12,6 +12,15 @@ import com.intellij.openapi.components.service
  */
 const val DEFAULT_TASK_TIMEOUT_MINUTES: Int = 2
 
+/** Layer log filter (deliberately not `RUST_LOG`, so a Rust app's own logging is unaffected). */
+private const val MIRRORD_LOG_ENV = "MIRRORD_LOG"
+
+/** Log filter for mirrord's other Rust processes (CLI/intproxy/agent). */
+private const val RUST_LOG_ENV = "RUST_LOG"
+
+/** Directory the layer writes a per-process trace log file into. */
+private const val MIRRORD_LAYER_LOG_PATH_ENV = "MIRRORD_LAYER_LOG_PATH"
+
 @State(name = "MirrordSettingsState", storages = [Storage("mirrord.xml")])
 open class MirrordSettingsState : PersistentStateComponent<MirrordSettingsState.MirrordState> {
     companion object {
@@ -62,6 +71,12 @@ open class MirrordSettingsState : PersistentStateComponent<MirrordSettingsState.
         var enabledByDefault: Boolean = false
         var taskTimeoutMinutes: Int = DEFAULT_TASK_TIMEOUT_MINUTES
 
+        /** When on, every mirrord run enables trace logging in mirrord's processes. */
+        var troubleshootingLogsEnabled: Boolean = false
+
+        /** Directory the layer writes its per-process trace log into ([MIRRORD_LAYER_LOG_PATH_ENV]). */
+        var troubleshootingLogsPath: String = ""
+
         fun disableNotification(id: NotificationId) {
             disabledNotifications = disabledNotifications.orEmpty() + id
         }
@@ -69,5 +84,38 @@ open class MirrordSettingsState : PersistentStateComponent<MirrordSettingsState.
         fun isNotificationDisabled(id: NotificationId): Boolean {
             return disabledNotifications?.contains(id) ?: false
         }
+
+        /**
+         * Environment variables that turn on verbose layer logging for troubleshooting.
+         *
+         * These are merged into the launched process's mirrord environment, including through the
+         * Windows `MIRRORD_CHILD_ENV` payload. `RUST_LOG` is deliberately excluded because it
+         * belongs on the mirrord CLI and intproxy, not on a user's Rust application.
+         *
+         * `MIRRORD_LAYER_LOG_PATH` is omitted when blank, so layer logging falls back to stderr.
+         */
+        fun troubleshootingLayerEnvVars(
+            logPathTransform: (String) -> String = { it }
+        ): Map<String, String> {
+            if (!troubleshootingLogsEnabled) {
+                return emptyMap()
+            }
+            val env = linkedMapOf(MIRRORD_LOG_ENV to "trace")
+            troubleshootingLogsPath.trim().takeIf { it.isNotEmpty() }
+                ?.let(logPathTransform)
+                ?.takeIf { it.isNotEmpty() }
+                ?.let {
+                    env[MIRRORD_LAYER_LOG_PATH_ENV] = it
+                }
+            return env
+        }
+
+        /** Trace logging applied only to mirrord's CLI process and the intproxy it starts. */
+        fun troubleshootingCliEnvVars(): Map<String, String> =
+            if (troubleshootingLogsEnabled) {
+                mapOf(RUST_LOG_ENV to "trace")
+            } else {
+                emptyMap()
+            }
     }
 }

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordSettingsStateTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordSettingsStateTest.kt
@@ -1,0 +1,56 @@
+package com.metalbear.mirrord
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MirrordSettingsStateTest {
+
+    @Test
+    fun troubleshootingLoggingKeepsRustLogOutOfTheUserProcess() {
+        val settings = MirrordSettingsState.MirrordState().apply {
+            troubleshootingLogsEnabled = true
+            troubleshootingLogsPath = " C:/logs "
+        }
+
+        assertEquals(
+            mapOf(
+                "MIRRORD_LOG" to "trace",
+                "MIRRORD_LAYER_LOG_PATH" to "C:/logs"
+            ),
+            settings.troubleshootingLayerEnvVars()
+        )
+        assertEquals(
+            mapOf("RUST_LOG" to "trace"),
+            settings.troubleshootingCliEnvVars()
+        )
+    }
+
+    @Test
+    fun troubleshootingLoggingIsEmptyWhenDisabled() {
+        val settings = MirrordSettingsState.MirrordState()
+
+        assertTrue(settings.troubleshootingLayerEnvVars().isEmpty())
+        assertTrue(settings.troubleshootingCliEnvVars().isEmpty())
+    }
+
+    @Test
+    fun troubleshootingLogPathCanBeTranslatedOrOmitted() {
+        val settings = MirrordSettingsState.MirrordState().apply {
+            troubleshootingLogsEnabled = true
+            troubleshootingLogsPath = "C:/logs"
+        }
+
+        assertEquals(
+            mapOf(
+                "MIRRORD_LOG" to "trace",
+                "MIRRORD_LAYER_LOG_PATH" to "/mnt/c/logs"
+            ),
+            settings.troubleshootingLayerEnvVars { "/mnt/c/logs" }
+        )
+        assertEquals(
+            mapOf("MIRRORD_LOG" to "trace"),
+            settings.troubleshootingLayerEnvVars { "" }
+        )
+    }
+}


### PR DESCRIPTION
# Add trace-level troubleshooting logs

## Linear

https://linear.app/metalbear/issue/COR-1697

## Summary

Adds an opt-in mirrord setting that collects trace-level layer logs in a user-selected directory.

When enabled, the extension sets `RUST_LOG=trace` for the mirrord CLI/intproxy and `MIRRORD_LOG=trace` for the layer-loaded application. This makes mirrord and its Rust dependencies observable without overriding a Rust customer's own `RUST_LOG`, and keeps the trace settings out of the Gradle daemon and unrelated processes.

## Motivation

Windows injection and debugger failures often occur after the IDE has handed control to Gradle or the customer process. `idea.log` alone cannot show socket routing, debugger-port classification, layer initialization, or remote proxy behavior. Support needs one setting that produces the complementary layer evidence without asking customers to hand-edit run configurations.

## Implementation

- adds the persisted troubleshooting toggle and log-directory UI;
- lets the user select an optional layer-log directory and passes it through `MIRRORD_LAYER_LOG_PATH`;
- sets `RUST_LOG=trace` only for the CLI/intproxy and `MIRRORD_LOG=trace` in the application environment assembled by mirrord;
- translates the directory for WSL launches;
- omits an unusable Windows host path for container launches while retaining trace verbosity;
- keeps normal launch behavior unchanged when disabled.

## Verification

- `MirrordSettingsStateTest` covers disabled/enabled environment derivation, path transforms, and omitted container paths;
- `ktlintCheck`;
- `buildPlugin`;
- `towncrier check`;
- customer-shaped real-agent E2E produced application layer logs at trace level;
- verified the Gradle daemon does not inherit the application logging environment.

## Stack

1. COR-1701 — modern-JDK `instrumentCode` fix
2. COR-1701/COR-1697 — final Windows Gradle Run and Debug path
3. **COR-1697 — trace-level troubleshooting logs** (this PR)

### Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context
- [x] I have introduced a short, clear and well-formatted changelog entry
