### PR TITLE
Set `includeAuthors` and `disabledLabels` for Greptile

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,5 +1,24 @@
 {
   "excludeAuthors": ["cubby-mb[bot]", "dependabot[bot]"],
+  "includeAuthors": [
+    "0x00A5",
+    "aviramha",
+    "cristeigabriela",
+    "DmitryDodzin",
+    "eyalb181",
+    "gememma",
+    "giIuis",
+    "hank-metalbear",
+    "iniw",
+    "itsamegraf",
+    "meowjesty",
+    "MintSoup",
+    "Razz4780",
+    "skreborn",
+    "t4lz",
+    "vladrbg"
+  ],
+  "disabledLabels": ["no-greptile"],
   "ignorePatterns": [
     "flake.lock",
     "gradle/wrapper/gradle-wrapper.jar",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,13 @@ We welcome new/junior/starting developers. Feel free to join to our [Slack](http
 If you would like to start working on an issue, please comment on the issue on GitHub, so that we can assign you to that
 issue.
 
+## Greptile Reviews
+
+Greptile may review pull requests automatically. Authors and maintainers can apply the `no-greptile` label when an
+automated review is not needed, such as for a typo-only or other trivial change. Opting out of reviews that are not
+useful helps keep usage within the included monthly review quota. If Greptile's input becomes useful later, remove the
+label and request a review explicitly.
+
 ## Building the IntelliJ plugin
 
 First, make sure you have JDK 21 installed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ issue.
 
 Greptile may review pull requests automatically. Authors and maintainers can apply the `no-greptile` label when an
 automated review is not needed, such as for a typo-only or other trivial change. Opting out of reviews that are not
-useful helps keep usage within the included monthly review quota. If Greptile's input becomes useful later, remove the
-label and request a review explicitly.
+useful helps keep usage within the included monthly review quota. If Greptile's input becomes useful later, tag
+`@greptileai` in the pull request to request a review explicitly.
 
 ## Building the IntelliJ plugin
 

--- a/changelog.d/+greptile-review-policy.internal.md
+++ b/changelog.d/+greptile-review-policy.internal.md
@@ -1,0 +1,1 @@
+Configure automatic Greptile reviews and document how contributors can opt out.


### PR DESCRIPTION
## Summary

- limit automatic Greptile reviews to frequent PR authors
- allow maintainers to suppress an automatic review with the `no-greptile` label
- document the opt-out label and quota rationale in the contributor guide

## Why

Greptile consumes a monthly seat when it reviews a new author. Automatic reviews should cover frequent contributors whose regular work will use a seat anyway, while occasional contributors and trivial changes should not allocate one by default. Authors outside the allowlist can still receive a Greptile review by tagging it.

The opt-out label also lets authors and maintainers skip Greptile on changes where an automated review is not needed signal, helping keep usage within the included monthly review quota.