### PR TITLE
Retry opening the mirrord dropdown in the E2E test

### DIFF
--- a/changelog.d/+e2e-dropdown-click-retry.internal.md
+++ b/changelog.d/+e2e-dropdown-click-retry.internal.md
@@ -1,0 +1,1 @@
+Fixed an E2E test flake where the click opening the mirrord toolbar dropdown was dropped while the toolbar was still updating, leaving the test waiting for a menu that never opened.

--- a/src/test/kotlin/com/metalbear/mirrord/MirrordPluginTest.kt
+++ b/src/test/kotlin/com/metalbear/mirrord/MirrordPluginTest.kt
@@ -142,21 +142,14 @@ internal class MirrordPluginTest {
                 usageBanner.findText("Close").click()
             }
             step("Create config file") {
-                waitFor(ofSeconds(60)) {
-                    mirrordDropdownButton.isShowing && mirrordDropdownButton.isComponentEnabled()
-                }
                 // as per the extension this doesn't need to be in the dumbAware block
                 // however, there can be a loading page which can only be ignored by the
                 // dumbAware block
-                dumbAware {
-                    mirrordDropdownButton.click()
+                val dropdownMenu = dumbAware(waitAfter = false) {
+                    openMirrordDropdownMenu()
                 }
 
-                waitFor(ofSeconds(60)) {
-                    mirrordDropdownMenu.isShowing
-                }
-
-                mirrordDropdownMenu.findText("mirrord config file").click()
+                dropdownMenu.findText("mirrord config file").click()
 
                 editorTabs {
                     waitFor(ofSeconds(60)) {

--- a/src/test/kotlin/com/metalbear/mirrord/utils/IdeaFrame.kt
+++ b/src/test/kotlin/com/metalbear/mirrord/utils/IdeaFrame.kt
@@ -35,17 +35,6 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
             Duration.ofSeconds(30)
         )
 
-    val mirrordDropdownMenu: ContainerFixture
-        get() {
-            val list = waitFor<ContainerFixture?>(Duration.ofSeconds(60)) {
-                val list = findAll<ContainerFixture>(byXpath("//div[@class='MyList']"))
-                    .firstOrNull { it.hasText("mirrord for Teams") }
-                Pair(list != null, list)
-            }
-
-            return list!!
-        }
-
     val startDebugging
         get() = find<ContainerFixture>(
             byXpath("//div[@class='ActionButton' and @myaction='Debug (Debug selected configuration)']")
@@ -76,6 +65,49 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
             Duration.ofSeconds(30)
         )
 
+    /**
+     * Opens the mirrord toolbar dropdown and returns its menu.
+     *
+     * The toolbar recomputes action presentations on a background thread while the project is
+     * being opened and indexed, so the button can report itself enabled and be disabled again
+     * before the click lands. Clicks on a disabled button are silently dropped, so the button is
+     * clicked again until the menu shows up.
+     */
+    fun openMirrordDropdownMenu(timeout: Duration = Duration.ofMinutes(2)): ContainerFixture {
+        val menu = waitFor<ContainerFixture?>(
+            duration = timeout,
+            interval = Duration.ofSeconds(1),
+            errorMessage = "mirrord dropdown menu did not open"
+        ) {
+            findMirrordDropdownMenu(Duration.ofSeconds(1))?.let { return@waitFor Pair(true, it) }
+
+            clickMirrordDropdownButton()
+            // Give the popup time to show before clicking again - the button is a toggle, so
+            // clicking it while the popup is open would close it.
+            val opened = findMirrordDropdownMenu(Duration.ofSeconds(10))
+            Pair(opened != null, opened)
+        }
+
+        return menu!!
+    }
+
+    private fun findMirrordDropdownMenu(timeout: Duration): ContainerFixture? = runCatching {
+        waitFor<ContainerFixture?>(duration = timeout, interval = Duration.ofMillis(500)) {
+            val menu = findAll<ContainerFixture>(byXpath("//div[@class='MyList']"))
+                .firstOrNull { it.hasText("mirrord for Teams") }
+            Pair(menu != null, menu)
+        }
+    }.getOrNull()
+
+    private fun clickMirrordDropdownButton() {
+        runCatching {
+            val button = mirrordDropdownButton
+            if (button.isShowing && button.isComponentEnabled()) {
+                button.click()
+            }
+        }
+    }
+
     fun ContainerFixture.isComponentEnabled(): Boolean {
         return callJs(
             """
@@ -87,16 +119,16 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
 
     // dumb and smart mode refer to the state of the IDE when it is indexing and not indexing respectively
     @JvmOverloads
-    fun dumbAware(
+    fun <T> dumbAware(
         timeout: Duration = Duration.ofMinutes(5),
         waitAfter: Boolean = true,
-        function: () -> Unit
-    ) {
-        step("Wait for smart mode") {
+        function: () -> T
+    ): T {
+        return step("Wait for smart mode") {
             waitFor(duration = timeout, interval = Duration.ofSeconds(5)) {
                 runCatching { isDumbMode().not() }.getOrDefault(false)
             }
-            function()
+            val result = function()
             if (waitAfter) {
                 step("...wait for smart mode again") {
                     waitFor(duration = timeout, interval = Duration.ofSeconds(5)) {
@@ -104,6 +136,7 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
                     }
                 }
             }
+            result
         }
     }
 


### PR DESCRIPTION
`testMirrordFlow` intermittently fails at "Create config file" with a `WaitForConditionTimeoutException` waiting for the dropdown menu.

The failure video from the last flake shows why: the test clicks the mirrord toolbar button once, and at that moment the toolbar is still mid-update (run widget still says "Add Configuration", mirrord button rendered disabled). The toolbar recomputes action presentations on a background thread, so the button can pass the `isComponentEnabled()` check and be disabled again before the click lands. That click is silently dropped, the popup never opens, and the test waits 60s for a menu that will never appear — three quarters of a second later the toolbar finishes updating and the button is live again.

The fix clicks the button until the menu actually shows, checking for an already-open menu first so the toggle isn't clicked shut again.

Tested: compiles and `ktlintCheck` passes locally; the E2E job on this PR exercises the changed path.