### PR TITLE
COR-1385: biforst: support JetBrains dev containers

### DIFF
--- a/.github/workflows/plugin_verifier.yaml
+++ b/.github/workflows/plugin_verifier.yaml
@@ -27,6 +27,6 @@ jobs:
       - name: Run plugin verifier
         env:
           CI_BUILD_PLUGIN: true
-          IDE: ${{ matrix.ide }}
+          PLATFORMTYPE: ${{ matrix.ide }}
         run: |
-          ./gradlew runPluginVerifier
+          ./gradlew verifyPlugin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -147,6 +147,24 @@ intellijPlatform {
 
     pluginVerification {
         failureLevel = EnumSet.of(VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS, VerifyPluginTask.FailureLevel.INVALID_PLUGIN)
+
+        // Without this block the verifier has no IDE to check against, so the nightly job
+        // proves nothing.
+        //
+        // The compile target is `platformVersion` while sinceBuild claims 253 and upwards. That
+        // gap is real: a platform class that moves between builds resolves at compile time and
+        // fails at run time, and only a verifier run against the newer build catches it.
+        ides {
+            // `-PverifierLocalIde=<path>` checks an IDE already on disk, which needs no download
+            // and is the quickest way to test one specific build. CI has no such install, so it
+            // falls back to the set JetBrains recommends for this plugin's declared range.
+            val localIde = providers.gradleProperty("verifierLocalIde").orNull
+            if (localIde != null) {
+                local(localIde)
+            } else {
+                recommended()
+            }
+        }
     }
 
     signing {

--- a/changelog.d/+devcontainers.added.md
+++ b/changelog.d/+devcontainers.added.md
@@ -1,0 +1,1 @@
+Added support for JetBrains dev containers: mirrord now runs the CLI where the project runs, instead of on the IDE host.

--- a/modules/core/src/main/java/com/metalbear/mirrord/bifrost/EelTransferCompat.java
+++ b/modules/core/src/main/java/com/metalbear/mirrord/bifrost/EelTransferCompat.java
@@ -1,0 +1,33 @@
+package com.metalbear.mirrord.bifrost;
+
+import com.intellij.platform.eel.provider.utils.EelPathUtils;
+
+import java.nio.file.Path;
+
+/**
+ * Calls {@code transferLocalContentToRemote} in a way that survives the 2026.1 -> 2026.2 API move.
+ *
+ * <p>The platform declares that function with default arguments, one of which is a file-attribute
+ * strategy. That strategy type is {@code EelPathUtils.FileTransferAttributesStrategy} in 2026.1 but
+ * a top-level {@code EelFileTransferAttributesStrategy} in 2026.2. Its name appears in the method
+ * descriptor, so a plugin compiled against one build fails on the other: running a 2026.1 build on
+ * 2026.2 raises {@code ClassNotFoundException} while staging the mirrord CLI into a dev container.
+ *
+ * <p>Kotlin cannot avoid it: a Kotlin call site always compiles to the synthetic
+ * {@code transferLocalContentToRemote$default} bridge, whose signature carries the strategy type
+ * even when the argument is omitted. Java has no such bridge and binds to the real two-argument
+ * overload, which is byte-identical in both builds. That is the only reason this file is Java.
+ *
+ * <p>Verify with {@code javap -c} after changing this: the emitted call must be
+ * {@code transferLocalContentToRemote:(Ljava/nio/file/Path;L...$TransferTarget;)Ljava/nio/file/Path;}
+ * with no third parameter.
+ */
+final class EelTransferCompat {
+
+    private EelTransferCompat() {
+    }
+
+    static Path transferLocalContentToRemote(Path source, EelPathUtils.TransferTarget target) {
+        return EelPathUtils.transferLocalContentToRemote(source, target);
+    }
+}

--- a/modules/core/src/main/java/com/metalbear/mirrord/bifrost/EelTransferCompat.java
+++ b/modules/core/src/main/java/com/metalbear/mirrord/bifrost/EelTransferCompat.java
@@ -5,15 +5,17 @@ import com.intellij.platform.eel.provider.utils.EelPathUtils;
 import java.nio.file.Path;
 
 /**
- * Calls {@code transferLocalContentToRemote} in a way that survives the 2026.1 -> 2026.2 API move.
+ * <b>EEL COMPAT 261/262</b> — a compatibility shim for {@code transferLocalContentToRemote},
+ * because the EEL API is unstable across IDE builds.
  *
  * <p>The platform declares that function with default arguments, one of which is a file-attribute
- * strategy. That strategy type is {@code EelPathUtils.FileTransferAttributesStrategy} in 2026.1 but
- * a top-level {@code EelFileTransferAttributesStrategy} in 2026.2. Its name appears in the method
- * descriptor, so a plugin compiled against one build fails on the other: running a 2026.1 build on
- * 2026.2 raises {@code ClassNotFoundException} while staging the mirrord CLI into a dev container.
+ * strategy. That type is {@code EelPathUtils.FileTransferAttributesStrategy} in 2026.1 but a
+ * top-level {@code EelFileTransferAttributesStrategy} in 2026.2.
  *
- * <p>Kotlin cannot avoid it: a Kotlin call site always compiles to the synthetic
+ * <p>The type name appears in the method descriptor, so a plugin compiled against one build fails
+ * on the other: a 2026.1 build running on 2026.2 raises {@code ClassNotFoundException}.
+ *
+ * <p>Kotlin cannot avoid it. A Kotlin call site always compiles to the synthetic
  * {@code transferLocalContentToRemote$default} bridge, whose signature carries the strategy type
  * even when the argument is omitted. Java has no such bridge and binds to the real two-argument
  * overload, which is byte-identical in both builds. That is the only reason this file is Java.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -6,9 +6,6 @@ import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.google.gson.JsonSyntaxException
 import com.google.gson.annotations.SerializedName
-import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.execution.wsl.WSLCommandLineOptions
-import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
@@ -18,6 +15,9 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
+import com.metalbear.mirrord.bifrost.MirrordEnvironment
+import com.metalbear.mirrord.bifrost.MirrordProcessSpec
+import com.metalbear.mirrord.bifrost.TargetPath
 import java.util.concurrent.*
 
 const val GITHUB_URL = "https://github.com/metalbear-co/mirrord"
@@ -38,6 +38,28 @@ private fun getProcessFailedStderrError(processStdError: String) = "Process fail
 private fun getContainerProcessFailedStderrError(processStdError: String) = "Container process failed with stderr: $processStdError"
 private fun getConfigVerificationFailedError(processStdError: String) = "Config verification failed: $processStdError"
 
+/**
+ * The project's current branch, for Jira integration metrics.
+ *
+ * Stays on the IDE host on purpose: this reads the project's own VCS, which the IDE already
+ * has open locally, and a failure here must never stop a run.
+ */
+private fun gitBranchOf(project: Project): String? {
+    val dir = project.guessProjectDir()?.canonicalPath ?: return null
+    return try {
+        val process = Runtime.getRuntime().exec(arrayOf("git", "-C", dir, "branch", "--show-current"))
+        if (process.waitFor(10, TimeUnit.SECONDS) && process.exitValue() == 0) {
+            process.inputStream.bufferedReader().use { it.readText() }.trim().takeIf { it.isNotEmpty() }
+        } else {
+            MirrordLogger.logger.debug("error retrieving git branch: ${process.errorStream.bufferedReader().use { it.readText() }}")
+            null
+        }
+    } catch (e: Exception) {
+        MirrordLogger.logger.debug("exception while running git command, Jira integration metrics will not be recorded: $e")
+        null
+    }
+}
+
 private fun getMirrordTaskFailedError(commandLine: String, error: Throwable) =
     "mirrord task failed for $commandLine: ${error.message ?: error.toString()}"
 private fun getMirrordBackgroundTaskFailedError(commandLine: String, error: Throwable) =
@@ -46,10 +68,6 @@ private fun getMirrordTaskTimedOutError(commandLine: String) = "mirrord task tim
 private fun getMirrordTaskTimedOutUnderReadLockError(commandLine: String) = "mirrord task timed out under read lock: $commandLine"
 private fun getMirrordTaskCancelledMessage(commandLine: String) = "mirrord task was cancelled: $commandLine"
 private fun getMirrordBackgroundTaskCancelledMessage(commandLine: String) = "mirrord background task was cancelled: $commandLine"
-
-@Suppress("DEPRECATION")
-private fun wslPath(wslDistribution: WSLDistribution?, path: String): String =
-    wslDistribution?.getWslPath(path) ?: path
 
 /**
  * Helper function to log errors to both MirrordLogger and logsService
@@ -290,7 +308,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
         val namespaces: List<String>?
     )
 
-    private class MirrordLsTask(cli: String, projectEnvVars: Map<String, String>?) : MirrordCliTask<MirrordLsOutput>(cli, "ls", null, projectEnvVars) {
+    private class MirrordLsTask(cli: TargetPath, projectEnvVars: Map<String, String>?, environment: MirrordEnvironment) : MirrordCliTask<MirrordLsOutput>(cli, "ls", null, projectEnvVars, environment) {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): MirrordLsOutput {
             val logsService = project.service<MirrordLogsService>()
 
@@ -347,7 +365,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
      *
      * @return available targets
      */
-    fun listTargets(cli: String, configFile: String?, wslDistribution: WSLDistribution?, namespace: String?, targetTypes: List<String>): MirrordLsOutput {
+    fun listTargets(cli: TargetPath, configFile: TargetPath?, environment: MirrordEnvironment, namespace: String?, targetTypes: List<String>): MirrordLsOutput {
         val envVars: MutableMap<String, String> = projectEnvVars.orEmpty().toMutableMap()
         envVars[MIRRORD_LS_RICH_OUTPUT_ENV] = "true"
         targetTypes.takeIf { it.isNotEmpty() }?.let {
@@ -356,17 +374,16 @@ class MirrordApi(private val service: MirrordProjectService, private val project
             envVars[MIRRORD_LS_TARGET_TYPES_ENV] = targetTypesJson
         }
 
-        val task = MirrordLsTask(cli, envVars.toMap()).apply {
+        val task = MirrordLsTask(cli, envVars.toMap(), environment).apply {
             this.namespace = namespace
             this.configFile = configFile
-            this.wslDistribution = wslDistribution
             this.output = "json"
         }
 
         return task.run(service.project)
     }
 
-    private class MirrordExtTask(cli: String, projectEnvVars: Map<String, String>?) : MirrordCliTask<MirrordExecution>(cli, "ext", null, projectEnvVars) {
+    private class MirrordExtTask(cli: TargetPath, projectEnvVars: Map<String, String>?, environment: MirrordEnvironment) : MirrordCliTask<MirrordExecution>(cli, "ext", null, projectEnvVars, environment) {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): MirrordExecution {
             val parser = SafeParser()
             val bufferedReader = process.inputStream.reader().buffered()
@@ -445,7 +462,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
         }
     }
 
-    private class MirrordContainerExtTask(cli: String, projectEnvVars: Map<String, String>?) : MirrordCliTask<MirrordContainerExecution>(cli, "container-ext", null, projectEnvVars) {
+    private class MirrordContainerExtTask(cli: TargetPath, projectEnvVars: Map<String, String>?, environment: MirrordEnvironment) : MirrordCliTask<MirrordContainerExecution>(cli, "container-ext", null, projectEnvVars, environment) {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): MirrordContainerExecution {
             val parser = SafeParser()
             val bufferedReader = process.inputStream.reader().buffered()
@@ -530,7 +547,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
      * Reads the output (json) from stdout which contain either a success + warnings, or the errors from the verify
      * command.
      */
-    private class MirrordVerifyConfigTask(cli: String, configPath: String, projectEnvVars: Map<String, String>?) : MirrordCliTask<String>(cli, "verify-config", listOf("--ide", configPath), projectEnvVars) {
+    private class MirrordVerifyConfigTask(cli: TargetPath, configPath: TargetPath, projectEnvVars: Map<String, String>?, environment: MirrordEnvironment) : MirrordCliTask<String>(cli, "verify-config", listOf("--ide", configPath.value), projectEnvVars, environment) {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): String {
             val logsService = project.service<MirrordLogsService>()
 
@@ -564,12 +581,11 @@ class MirrordApi(private val service: MirrordProjectService, private val project
      * @return String containing a json with either a success + warnings, or the verified config errors.
      */
     fun verifyConfig(
-        cli: String,
-        configFilePath: String,
-        wslDistribution: WSLDistribution?
+        cli: TargetPath,
+        configFilePath: TargetPath,
+        environment: MirrordEnvironment
     ): String {
-        val verifyConfigTask = MirrordVerifyConfigTask(cli, configFilePath, projectEnvVars).apply {
-            this.wslDistribution = wslDistribution
+        val verifyConfigTask = MirrordVerifyConfigTask(cli, configFilePath, projectEnvVars, environment).apply {
         }
         return verifyConfigTask.run(service.project)
     }
@@ -580,15 +596,14 @@ class MirrordApi(private val service: MirrordProjectService, private val project
      *
      * @return environment for the user's application
      */
-    fun exec(cli: String, target: MirrordExecDialog.UserSelection, configFile: String?, executable: String?, wslDistribution: WSLDistribution?): MirrordExecution {
+    fun exec(cli: TargetPath, target: MirrordExecDialog.UserSelection, configFile: TargetPath?, executable: String?, environment: MirrordEnvironment): MirrordExecution {
         bumpRunCounter()
 
-        val task = MirrordExtTask(cli, projectEnvVars).apply {
+        val task = MirrordExtTask(cli, projectEnvVars, environment).apply {
             this.target = target.target
             this.namespace = target.namespace
             this.configFile = configFile
             this.executable = executable
-            this.wslDistribution = wslDistribution
         }
 
         val result = task.run(service.project)
@@ -602,14 +617,13 @@ class MirrordApi(private val service: MirrordProjectService, private val project
         return result
     }
 
-    fun containerExec(cli: String, target: MirrordExecDialog.UserSelection, configFile: String?, wslDistribution: WSLDistribution?): MirrordContainerExecution {
+    fun containerExec(cli: TargetPath, target: MirrordExecDialog.UserSelection, configFile: TargetPath?, environment: MirrordEnvironment): MirrordContainerExecution {
         bumpRunCounter()
 
-        val task = MirrordContainerExtTask(cli, projectEnvVars).apply {
+        val task = MirrordContainerExtTask(cli, projectEnvVars, environment).apply {
             this.target = target.target
             this.namespace = target.namespace
             this.configFile = configFile
-            this.wslDistribution = wslDistribution
         }
 
         val result = task.run(service.project)
@@ -623,7 +637,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
         return result
     }
 
-    private class MirrordAttachTask(cli: String, private val pid: Long, projectEnvVars: Map<String, String>?) : MirrordCliTask<MirrordAttachExecution>(cli, "attach", listOf(pid.toString()), projectEnvVars) {
+    private class MirrordAttachTask(cli: TargetPath, private val pid: Long, projectEnvVars: Map<String, String>?, environment: MirrordEnvironment) : MirrordCliTask<MirrordAttachExecution>(cli, "attach", listOf(pid.toString()), projectEnvVars, environment) {
         // `mirrord attach` injects the layer DLL into the target process (pid)
         // and exits 0 on success. Callers must run `mirrord ext` first to start
         // the intproxy and set env vars on the target.
@@ -660,12 +674,12 @@ class MirrordApi(private val service: MirrordProjectService, private val project
         }
     }
 
-    fun attach(cli: String, pid: Long): MirrordAttachExecution {
+    fun attach(cli: TargetPath, pid: Long, environment: MirrordEnvironment): MirrordAttachExecution {
         bumpRunCounter()
 
         // Only PID is passed — target, namespace, config flags remain null.
         // `mirrord ext` must have been run first by the caller.
-        val task = MirrordAttachTask(cli, pid, projectEnvVars)
+        val task = MirrordAttachTask(cli, pid, projectEnvVars, environment)
 
         val result = task.run(service.project)
 
@@ -722,87 +736,55 @@ class MirrordApi(private val service: MirrordProjectService, private val project
  *
  * @param args: An extra list of arguments (used by `verify-config`).
  */
-private abstract class MirrordCliTask<T>(private val cli: String, private val command: String, private val args: List<String>?, private val projectEnvVars: Map<String, String>?) {
+private abstract class MirrordCliTask<T>(
+    private val cli: TargetPath,
+    private val command: String,
+    private val args: List<String>?,
+    private val projectEnvVars: Map<String, String>?,
+    private val environment: MirrordEnvironment
+) {
     var target: String? = null
     var namespace: String? = null
-    var configFile: String? = null
+    var configFile: TargetPath? = null
     var executable: String? = null
-    var wslDistribution: WSLDistribution? = null
     var output: String? = null
 
     /**
      * Returns command line for execution.
      */
-    private fun prepareCommandLine(project: Project): GeneralCommandLine {
-        val commandLine = GeneralCommandLine(cli, command).apply {
-            // Merge our `environment` vars with what's set in the current launch run configuration.
-            if (projectEnvVars != null) {
-                environment.putAll(projectEnvVars)
-            }
-
-            target?.let {
-                addParameter("-t")
-                addParameter(it)
-            }
-
-            namespace?.let {
-                environment.put("MIRRORD_TARGET_NAMESPACE", it)
-            }
-
-            // for config explanation to be printed out
-            environment["MIRRORD_EXT_PRINT_CONFIG"] = "TRUE"
-
-            configFile?.let {
-                val formattedPath = wslPath(wslDistribution, it)
-                addParameter("-f")
-                addParameter(formattedPath)
-            }
-
-            executable?.let {
-                addParameter("-e")
-                addParameter(it)
-            }
-
-            wslDistribution?.let {
-                val wslOptions = WSLCommandLineOptions().apply {
-                    isLaunchWithWslExe = true
-                    isExecuteCommandInShell = false
-                }
-                it.patchCommandLine(this, project, wslOptions)
-            }
-
-            output?.let {
-                addParameter("-o")
-                addParameter(it)
-            }
-
-            args?.let { extraArgs -> extraArgs.forEach { addParameter(it) } }
-
-            project.guessProjectDir()?.let {
-                try {
-                    val process =
-                        Runtime.getRuntime().exec(arrayOf("git", "-C", it.canonicalPath, "branch", "--show-current"))
-
-                    if (process.waitFor(10, TimeUnit.SECONDS) && process.exitValue() == 0) {
-                        val branchName = process.inputStream.bufferedReader().use { it.readText() }.trim()
-                        if (branchName.isNotEmpty()) {
-                            environment["MIRRORD_BRANCH_NAME"] = branchName
-                        }
-                    } else {
-                        val stderrOutput = process.errorStream.bufferedReader().use { it.readText() }
-                        MirrordLogger.logger.debug("error retrieving git branch: $stderrOutput")
-                    }
-                } catch (e: Exception) {
-                    MirrordLogger.logger.debug("exception while running git command, Jira integration metrics will not be recorded: $e")
-                }
-            }
-
-            environment["MIRRORD_PROGRESS_MODE"] = "json"
-            environment["MIRRORD_PROGRESS_SUPPORT_IDE"] = "true"
-            environment["MIRRORD_IDE_NAME"] = "intellij"
+    /**
+     * Builds the invocation.
+     *
+     * The environment map is complete when this returns — nothing is added to it afterwards.
+     * That is deliberate: the old code built a command line, patched it for WSL partway
+     * through, and then kept adding variables, so `MIRRORD_PROGRESS_MODE` and friends were
+     * registered for WSL interop only if statement order happened to cooperate.
+     */
+    private fun prepareSpec(project: Project): MirrordProcessSpec {
+        val commandArgs = buildList {
+            add(command)
+            target?.let { add("-t"); add(it) }
+            configFile?.let { add("-f"); add(it.value) }
+            executable?.let { add("-e"); add(it) }
+            output?.let { add("-o"); add(it) }
+            args?.let { addAll(it) }
         }
-        project.service<MirrordLogsService>().logInfo("Executing mirrord command: ${commandLine.commandLineString}")
-        return commandLine
+
+        val env = buildMap {
+            // Merge our vars with what is set in the current launch run configuration.
+            projectEnvVars?.let { putAll(it) }
+            namespace?.let { put("MIRRORD_TARGET_NAMESPACE", it) }
+            // for config explanation to be printed out
+            put("MIRRORD_EXT_PRINT_CONFIG", "TRUE")
+            gitBranchOf(project)?.let { put("MIRRORD_BRANCH_NAME", it) }
+            put("MIRRORD_PROGRESS_MODE", "json")
+            put("MIRRORD_PROGRESS_SUPPORT_IDE", "true")
+            put("MIRRORD_IDE_NAME", "intellij")
+        }
+
+        val spec = MirrordProcessSpec(cli, commandArgs, env, workingDirectory = null)
+        project.service<MirrordLogsService>().logInfo("Executing mirrord command: ${spec.describe()}")
+        return spec
     }
 
     /**
@@ -857,13 +839,13 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
      * @throws ProcessCanceledException if the user has canceled
      */
     fun run(project: Project): T {
-        val commandLine = prepareCommandLine(project)
+        val spec = prepareSpec(project)
         val logsService = project.service<MirrordLogsService>()
         val taskTimeoutMinutes = MirrordSettingsState.instance.mirrordState.taskTimeoutMinutes.toLong()
 
-        MirrordLogger.logger.info("running mirrord task with following command line: ${commandLine.commandLineString}")
+        MirrordLogger.logger.info("running mirrord task in ${environment.name}: ${spec.describe()}")
 
-        val process = commandLine.toProcessBuilder().redirectOutput(ProcessBuilder.Redirect.PIPE).redirectError(ProcessBuilder.Redirect.PIPE).start()
+        val process = environment.spawn(spec)
 
         return if (ApplicationManager.getApplication().isDispatchThread) {
             // Modal dialog with progress is very visible and can be canceled by the user,
@@ -874,14 +856,14 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
                 }
 
                 override fun onCancel() {
-                    val cancelMessage = getMirrordTaskCancelledMessage(commandLine.commandLineString)
+                    val cancelMessage = getMirrordTaskCancelledMessage(spec.describe())
                     MirrordLogger.logger.warn(cancelMessage)
                     logsService.logWarning(cancelMessage)
                     process.destroy()
                 }
 
                 override fun onThrowable(error: Throwable) {
-                    val errorMessage = getMirrordTaskFailedError(commandLine.commandLineString, error)
+                    val errorMessage = getMirrordTaskFailedError(spec.describe(), error)
                     logErrorToBoth(logsService, errorMessage)
                     process.destroy()
                 }
@@ -896,7 +878,7 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
                 }
 
                 override fun onCancel() {
-                    val cancelMessage = getMirrordBackgroundTaskCancelledMessage(commandLine.commandLineString)
+                    val cancelMessage = getMirrordBackgroundTaskCancelledMessage(spec.describe())
                     MirrordLogger.logger.warn(cancelMessage)
                     logsService.logWarning(cancelMessage)
                     process.destroy()
@@ -904,7 +886,7 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
                 }
 
                 override fun onThrowable(error: Throwable) {
-                    val errorMessage = getMirrordBackgroundTaskFailedError(commandLine.commandLineString, error)
+                    val errorMessage = getMirrordBackgroundTaskFailedError(spec.describe(), error)
                     logErrorToBoth(logsService, errorMessage)
                     process.destroy()
                     env.completeExceptionally(error)
@@ -919,7 +901,7 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
                 throw ProcessCanceledException(e)
             } catch (e: TimeoutException) {
                 process.destroy()
-                val errorMessage = getMirrordTaskTimedOutError(commandLine.commandLineString)
+                val errorMessage = getMirrordTaskTimedOutError(spec.describe())
                 logErrorToBoth(logsService, errorMessage)
                 throw MirrordError("mirrord process timed out")
             }
@@ -933,7 +915,7 @@ private abstract class MirrordCliTask<T>(private val cli: String, private val co
             } catch (e: ProcessCanceledException) {
                 // In this case, process is canceled only after a timeout.
                 process.destroy()
-                val errorMessage = getMirrordTaskTimedOutUnderReadLockError(commandLine.commandLineString)
+                val errorMessage = getMirrordTaskTimedOutUnderReadLockError(spec.describe())
                 logErrorToBoth(logsService, errorMessage)
                 throw MirrordError("mirrord process timed out")
             }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -41,8 +41,7 @@ private fun getConfigVerificationFailedError(processStdError: String) = "Config 
 /**
  * The project's current branch, for Jira integration metrics.
  *
- * Stays on the IDE host on purpose: this reads the project's own VCS, which the IDE already
- * has open locally, and a failure here must never stop a run.
+ * Runs on the IDE host, which is where the project's VCS is. A failure here never stops a run.
  */
 private fun gitBranchOf(project: Project): String? {
     val dir = project.guessProjectDir()?.canonicalPath ?: return null
@@ -727,9 +726,8 @@ private abstract class MirrordCliTask<T>(
      * Set when the plugin itself kills the process.
      *
      * Every kill path already reports its own reason: a cancel warning, a task failure, or a
-     * timeout. The compute thread sees the resulting non-zero exit afterwards, so without this it
-     * reports the same event a second time as a crash — including an IDE error report naming the
-     * plugin for something the plugin did on purpose.
+     * timeout. The compute thread then sees a non-zero exit, and without this flag reports the
+     * same event a second time as a crash.
      */
     @Volatile
     private var abortedByPlugin = false
@@ -737,7 +735,7 @@ private abstract class MirrordCliTask<T>(
     /**
      * The only way this class kills a process.
      *
-     * Routed through one place so the flag cannot be missed. It was, for four of six kill paths.
+     * Routed through one place so the flag cannot be missed.
      */
     private fun abort(process: Process) {
         abortedByPlugin = true
@@ -747,8 +745,7 @@ private abstract class MirrordCliTask<T>(
     /**
      * Reports a non-zero exit, unless the plugin caused it.
      *
-     * Shared because this epilogue was identical at five call sites, and the abort check has to
-     * come first at every one of them.
+     * Shared, because the abort check has to come first everywhere this epilogue is used.
      */
     protected fun failFromExit(
         logsService: MirrordLogsService,

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -317,10 +317,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
 
             process.waitFor()
             if (process.exitValue() != 0) {
-                val processStdError = process.errorStream.bufferedReader().readText()
-                val errorMessage = getTargetListingFailedError(processStdError)
-                logErrorToBoth(logsService, errorMessage)
-                throw MirrordError.fromStdErr(processStdError)
+                failFromExit(logsService, process, message = ::getTargetListingFailedError)
             }
 
             val data = process.inputStream.bufferedReader().readText()
@@ -449,11 +446,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
 
             process.waitFor()
             if (process.exitValue() != 0) {
-                val processStdError = process.errorStream.bufferedReader().readText()
-                val errorMessage = getProcessFailedStderrError(processStdError)
-                logErrorToBoth(logsService, errorMessage)
-                logsService.onMirrordExecutionEnd()
-                throw MirrordError.fromStdErr(processStdError)
+                failFromExit(logsService, process, endsExecution = true, message = ::getProcessFailedStderrError)
             } else {
                 logsService.logError("Invalid output from mirrord binary")
                 logsService.onMirrordExecutionEnd()
@@ -528,11 +521,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
 
             process.waitFor()
             if (process.exitValue() != 0) {
-                val processStdError = process.errorStream.bufferedReader().readText()
-                val errorMessage = getContainerProcessFailedStderrError(processStdError)
-                logErrorToBoth(logsService, errorMessage)
-                logsService.onMirrordExecutionEnd()
-                throw MirrordError.fromStdErr(processStdError)
+                failFromExit(logsService, process, endsExecution = true, message = ::getContainerProcessFailedStderrError)
             } else {
                 logsService.logError("Invalid output from mirrord container binary")
                 logsService.onMirrordExecutionEnd()
@@ -556,10 +545,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
 
             process.waitFor()
             if (process.exitValue() != 0) {
-                val processStdError = process.errorStream.bufferedReader().readText()
-                val errorMessage = getConfigVerificationFailedError(processStdError)
-                logErrorToBoth(logsService, errorMessage)
-                throw MirrordError.fromStdErr(processStdError)
+                failFromExit(logsService, process, message = ::getConfigVerificationFailedError)
             }
 
             val bufferedReader = process.inputStream.reader().buffered()
@@ -585,9 +571,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
         configFilePath: TargetPath,
         environment: MirrordEnvironment
     ): String {
-        val verifyConfigTask = MirrordVerifyConfigTask(cli, configFilePath, projectEnvVars, environment).apply {
-        }
-        return verifyConfigTask.run(service.project)
+        return MirrordVerifyConfigTask(cli, configFilePath, projectEnvVars, environment).run(service.project)
     }
 
     /**
@@ -659,11 +643,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
 
             process.waitFor()
             if (process.exitValue() != 0) {
-                val processStdError = process.errorStream.bufferedReader().readText()
-                val errorMessage = "Attach process failed with stderr: $processStdError"
-                logErrorToBoth(logsService, errorMessage)
-                logsService.onMirrordExecutionEnd()
-                throw MirrordError.fromStdErr(processStdError)
+                failFromExit(logsService, process, endsExecution = true) { "Attach process failed with stderr: $it" }
             }
 
             MirrordLogger.logger.info("mirrord attach exited with code 0, layer injected into pid $pid")
@@ -743,15 +723,57 @@ private abstract class MirrordCliTask<T>(
     private val projectEnvVars: Map<String, String>?,
     private val environment: MirrordEnvironment
 ) {
+    /**
+     * Set when the plugin itself kills the process.
+     *
+     * Every kill path already reports its own reason: a cancel warning, a task failure, or a
+     * timeout. The compute thread sees the resulting non-zero exit afterwards, so without this it
+     * reports the same event a second time as a crash — including an IDE error report naming the
+     * plugin for something the plugin did on purpose.
+     */
+    @Volatile
+    private var abortedByPlugin = false
+
+    /**
+     * The only way this class kills a process.
+     *
+     * Routed through one place so the flag cannot be missed. It was, for four of six kill paths.
+     */
+    private fun abort(process: Process) {
+        abortedByPlugin = true
+        process.destroy()
+    }
+
+    /**
+     * Reports a non-zero exit, unless the plugin caused it.
+     *
+     * Shared because this epilogue was identical at five call sites, and the abort check has to
+     * come first at every one of them.
+     */
+    protected fun failFromExit(
+        logsService: MirrordLogsService,
+        process: Process,
+        endsExecution: Boolean = false,
+        message: (String) -> String
+    ): Nothing {
+        if (abortedByPlugin) {
+            throw ProcessCanceledException()
+        }
+
+        val stdErr = process.errorStream.bufferedReader().readText()
+        logErrorToBoth(logsService, message(stdErr))
+        if (endsExecution) {
+            logsService.onMirrordExecutionEnd()
+        }
+        throw MirrordError.fromStdErr(stdErr)
+    }
+
     var target: String? = null
     var namespace: String? = null
     var configFile: TargetPath? = null
     var executable: String? = null
     var output: String? = null
 
-    /**
-     * Returns command line for execution.
-     */
     /**
      * Builds the invocation.
      *
@@ -859,13 +881,13 @@ private abstract class MirrordCliTask<T>(
                     val cancelMessage = getMirrordTaskCancelledMessage(spec.describe())
                     MirrordLogger.logger.warn(cancelMessage)
                     logsService.logWarning(cancelMessage)
-                    process.destroy()
+                    abort(process)
                 }
 
                 override fun onThrowable(error: Throwable) {
                     val errorMessage = getMirrordTaskFailedError(spec.describe(), error)
                     logErrorToBoth(logsService, errorMessage)
-                    process.destroy()
+                    abort(process)
                 }
             })
         } else if (!ApplicationManager.getApplication().isReadAccessAllowed) {
@@ -881,14 +903,14 @@ private abstract class MirrordCliTask<T>(
                     val cancelMessage = getMirrordBackgroundTaskCancelledMessage(spec.describe())
                     MirrordLogger.logger.warn(cancelMessage)
                     logsService.logWarning(cancelMessage)
-                    process.destroy()
+                    abort(process)
                     env.cancel(true)
                 }
 
                 override fun onThrowable(error: Throwable) {
                     val errorMessage = getMirrordBackgroundTaskFailedError(spec.describe(), error)
                     logErrorToBoth(logsService, errorMessage)
-                    process.destroy()
+                    abort(process)
                     env.completeExceptionally(error)
                 }
             })
@@ -900,7 +922,7 @@ private abstract class MirrordCliTask<T>(
             } catch (e: CancellationException) {
                 throw ProcessCanceledException(e)
             } catch (e: TimeoutException) {
-                process.destroy()
+                abort(process)
                 val errorMessage = getMirrordTaskTimedOutError(spec.describe())
                 logErrorToBoth(logsService, errorMessage)
                 throw MirrordError("mirrord process timed out")
@@ -914,7 +936,7 @@ private abstract class MirrordCliTask<T>(
                 computeWithResponsiveCancel(project, process, TimeoutProgressChecker(taskTimeoutMinutes, TimeUnit.MINUTES))
             } catch (e: ProcessCanceledException) {
                 // In this case, process is canceled only after a timeout.
-                process.destroy()
+                abort(process)
                 val errorMessage = getMirrordTaskTimedOutUnderReadLockError(spec.describe())
                 logErrorToBoth(logsService, errorMessage)
                 throw MirrordError("mirrord process timed out")

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -13,9 +13,9 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.system.CpuArch
+import com.metalbear.mirrord.bifrost.HostPath
 import com.metalbear.mirrord.bifrost.MirrordEnvironment
 import com.metalbear.mirrord.bifrost.MirrordEnvironments
-import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import com.metalbear.mirrord.bifrost.MirrordTargetArch
 import com.metalbear.mirrord.bifrost.MirrordTargetPlatform
 import com.metalbear.mirrord.bifrost.TargetPath
@@ -92,7 +92,7 @@ class MirrordBinaryManager {
      */
     class DownloadInitializer : ProjectActivity {
         override suspend fun execute(project: Project) {
-            UpdateTask(project, null, MirrordEnvironments.resolve(MirrordLaunchContext(project)), false).queue()
+            UpdateTask(project, null, MirrordEnvironments.forProject(project), false).queue()
         }
     }
 
@@ -308,6 +308,9 @@ class MirrordBinaryManager {
         Files.move(tmpDestination, destination, StandardCopyOption.REPLACE_EXISTING)
     }
 
+    /** See [advertiseLargeBinary]. A released mirrord is comfortably below this. */
+    private val LARGE_BINARY_ADVISORY_BYTES = 256L * 1_048_576
+
     private class MirrordBinary(val command: TargetPath, environment: MirrordEnvironment) {
         val version: String
 
@@ -318,10 +321,13 @@ class MirrordBinaryManager {
             // behaviour change for WSL rather than a fix.
             version = output.stdout.trim().split(' ').getOrNull(1)?.trim()
                 ?: run {
-                    MirrordLogger.logger.debug(
-                        "`mirrord --version` gave exit=${output.exitCode} stdout='${output.stdout}' stderr='${output.stderr}'"
-                    )
-                    throw RuntimeException("failed to get mirrord version")
+                    // The reason belongs in the exception, not only in a DEBUG line. A binary
+                    // built on a rolling-release host against a newer glibc than the target's
+                    // fails here with a linker message, and "failed to get mirrord version"
+                    // sends the reader nowhere.
+                    val reason = output.stderr.trim().lines().firstOrNull()?.take(200)
+                        ?: "exit=${output.exitCode}, no output"
+                    throw RuntimeException(reason)
                 }
         }
     }
@@ -429,7 +435,7 @@ class MirrordBinaryManager {
         // honour a custom binary path the way `getBinary` does — otherwise a user who pointed
         // the plugin at their own build is still told it is unsupported, and can even be
         // force-fed a download of the managed one.
-        val environment = MirrordEnvironments.resolve(MirrordLaunchContext(project))
+        val environment = MirrordEnvironments.forProject(project)
 
         fun resolveLocal(): MirrordBinary? = try {
             val customPath = MirrordSettingsState.instance.mirrordState.mirrordBinaryPath.trim()
@@ -530,7 +536,7 @@ class MirrordBinaryManager {
      * startup dialog so users see the same warning + path on both surfaces.
      */
     private fun enforceWindowsNativeMin(binary: MirrordBinary, platform: MirrordTargetPlatform) {
-        if (!isWinNative(platform)) return
+        if (!platform.isWinNative) return
         val parsed = try {
             Version.valueOf(binary.version)
         } catch (_: Exception) {
@@ -592,28 +598,90 @@ class MirrordBinaryManager {
         )
     }
 
+    /**
+     * Warns before a slow copy, so it does not read as a hang.
+     *
+     * Deliberately one sentence. The reason the binary is large — the CLI embeds the layer, so an
+     * unstripped Linux debug build reaches ~1 GB — is in the log, not in the notification.
+     *
+     * Driven by [MirrordEnvironment.provide]'s copy callback rather than called beforehand, because
+     * only `provide` knows whether bytes actually move: a local target and legacy WSL both resolve
+     * the path without copying, and announcing a transfer there is simply false.
+     *
+     * Fires only above [LARGE_BINARY_ADVISORY_BYTES], and carries "don't show again", so a
+     * released binary stays quiet.
+     */
+    private fun advertiseLargeBinary(bytes: Long, environment: MirrordEnvironment, project: Project) {
+        if (bytes <= LARGE_BINARY_ADVISORY_BYTES) return
+
+        val megabytes = bytes / 1_048_576
+        project
+            .service<MirrordProjectService>()
+            .notifier
+            .notification(
+                "mirrord is copying a large binary ($megabytes MB) into ${environment.name}. " +
+                    "This only happens once.",
+                NotificationType.WARNING
+            )
+            .withDontShowAgain(MirrordSettingsState.NotificationId.LARGE_BINARY_STAGED)
+            .fire()
+    }
+
     private fun validateCustomBinary(
         path: String,
         environment: MirrordEnvironment,
         project: Project
     ): MirrordBinary? {
-        return try {
-            // Already a target-side path: the user typed something meaningful where mirrord
-            // runs, so it must not be translated. The old code relied on getWslPath returning
-            // null for an already-Linux path; this makes that reliance explicit.
-            MirrordBinary(TargetPath(path), environment)
-        } catch (e: Exception) {
-            MirrordLogger.logger.debug("custom mirrord binary path is invalid: $path", e)
-            project
-                .service<MirrordProjectService>()
-                .notifier
-                .notification(
-                    "custom mirrord binary path is invalid: $path",
-                    NotificationType.WARNING
+        // On-device first, remote second.
+        //
+        // The setting is filled in with a file chooser on the user's own machine, so a host path
+        // is the normal case. Treating it as target-side only meant a perfectly good local build
+        // was rejected as "invalid" under a dev container, because that path names nothing inside
+        // the container.
+        //
+        // Staging goes through `provide`, which is content-addressed: the destination is keyed on
+        // a sha256 of the file, so an unchanged binary resolves to a path that already exists and
+        // nothing is copied. A rebuilt binary hashes differently and is copied once. When the
+        // environment is local, `provide` returns the path unchanged and no copy happens at all.
+        var hostFailure: String? = null
+        val hostFile = runCatching { HostPath.of(path) }.getOrNull()
+        if (hostFile != null && runCatching { Files.isRegularFile(hostFile.path) }.getOrDefault(false)) {
+            runCatching {
+                MirrordBinary(
+                    environment.provide(hostFile, "mirrord") { bytes ->
+                        advertiseLargeBinary(bytes, environment, project)
+                    },
+                    environment
                 )
-                .withDontShowAgain(MirrordSettingsState.NotificationId.MIRRORD_BINARY_PATH_INVALID)
-                .fire()
-            null
+            }
+                .onFailure {
+                    hostFailure = it.message
+                    MirrordLogger.logger.warn(
+                        "mirrord binary at $path was staged into ${environment.name} but is not usable there: ${it.message}"
+                    )
+                }
+                .getOrNull()
+                ?.let { return it }
         }
+
+        // Remote second: the user pointed at something that already exists where mirrord runs —
+        // inside the container, or inside the WSL distribution.
+        runCatching { MirrordBinary(TargetPath(path), environment) }
+            .onFailure { MirrordLogger.logger.debug("target-side mirrord binary at $path is not usable", it) }
+            .getOrNull()
+            ?.let { return it }
+
+        project
+            .service<MirrordProjectService>()
+            .notifier
+            .notification(
+                hostFailure
+                    ?.let { "mirrord binary at $path does not run in ${environment.name}: $it" }
+                    ?: "custom mirrord binary path is invalid: $path",
+                NotificationType.WARNING
+            )
+            .withDontShowAgain(MirrordSettingsState.NotificationId.MIRRORD_BINARY_PATH_INVALID)
+            .fire()
+        return null
     }
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -1,7 +1,6 @@
 package com.metalbear.mirrord
 
 import com.github.zafarkhaja.semver.Version
-import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
@@ -14,6 +13,12 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.system.CpuArch
+import com.metalbear.mirrord.bifrost.MirrordEnvironment
+import com.metalbear.mirrord.bifrost.MirrordEnvironments
+import com.metalbear.mirrord.bifrost.MirrordLaunchContext
+import com.metalbear.mirrord.bifrost.MirrordTargetArch
+import com.metalbear.mirrord.bifrost.MirrordTargetPlatform
+import com.metalbear.mirrord.bifrost.TargetPath
 import java.net.URI
 import java.net.URLEncoder
 import java.net.http.HttpClient
@@ -39,6 +44,34 @@ private const val DOWNLOAD_ENDPOINT = "https://github.com/metalbear-co/mirrord/r
  */
 private const val MIN_WINDOWS_NATIVE_VERSION = "3.245.0"
 
+/** How long to wait for a short probe such as `mirrord --version` or `which mirrord`. */
+private const val PROBE_TIMEOUT_MILLIS = 5000L
+
+/**
+ * The release asset for a given target platform.
+ *
+ * Pure, so every combination is unit-tested — including the ones that used to be unreachable.
+ * The old form asked `SystemInfo` and `CpuArch`, i.e. the IDE host, so a macOS IDE could never
+ * have picked a Linux asset even when the project ran in a Linux container.
+ */
+internal fun mirrordDownloadUrl(version: String, platform: MirrordTargetPlatform): String = when {
+    // Darwin ships one universal binary covering both architectures.
+    platform.isMac -> "$DOWNLOAD_ENDPOINT/$version/mirrord_mac_universal"
+
+    platform.isWindows -> when (platform.arch) {
+        MirrordTargetArch.X86_64 -> "$DOWNLOAD_ENDPOINT/$version/mirrord.exe"
+        MirrordTargetArch.ARM64 -> throw MirrordError(
+            "mirrord has no Windows build for ${platform.archDirectoryName}.",
+            "Windows support currently requires an x86-64 target."
+        )
+    }
+
+    else -> when (platform.arch) {
+        MirrordTargetArch.ARM64 -> "$DOWNLOAD_ENDPOINT/$version/mirrord_linux_aarch64"
+        MirrordTargetArch.X86_64 -> "$DOWNLOAD_ENDPOINT/$version/mirrord_linux_x86_64"
+    }
+}
+
 /**
  * For dynamically fetching and storing mirrord binary.
  */
@@ -50,27 +83,8 @@ class MirrordBinaryManager {
     @Volatile
     private var downloadVersion: String? = null
 
-    companion object {
-        /** Cross-platform `which`/`where` lookup. Returns the first match or null. */
-        fun which(binary: String): String? {
-            return try {
-                val cmd = if (SystemInfo.isWindows) arrayOf("where", "$binary.exe") else arrayOf("which", binary)
-                val child = Runtime.getRuntime().exec(cmd)
-                val result = child.waitFor()
-                if (result != 0) return null
-                child.inputReader().readLine()?.trim()?.takeIf { it.isNotBlank() }
-            } catch (_: Exception) {
-                null
-            }
-        }
-
-        @Suppress("DEPRECATION")
-        internal fun wslPath(wslDistribution: WSLDistribution, path: String): String =
-            wslDistribution.getWslPath(path) ?: path
-    }
-
-    fun getCliPath(product: String, wslDistribution: WSLDistribution?, project: Project): String {
-        return getBinary(product, wslDistribution, project)
+    fun getCliPath(product: String, environment: MirrordEnvironment, project: Project): TargetPath {
+        return getBinary(product, environment, project)
     }
 
     /**
@@ -78,7 +92,7 @@ class MirrordBinaryManager {
      */
     class DownloadInitializer : ProjectActivity {
         override suspend fun execute(project: Project) {
-            UpdateTask(project, null, null, false).queue()
+            UpdateTask(project, null, MirrordEnvironments.resolve(MirrordLaunchContext(project)), false).queue()
         }
     }
 
@@ -110,7 +124,7 @@ class MirrordBinaryManager {
     private class UpdateTask(
         private val project: Project,
         private val product: String?,
-        private val wslDistribution: WSLDistribution?,
+        private val environment: MirrordEnvironment,
         private val checkInPath: Boolean
     ) : Task.Backgroundable(project, "mirrord", true), DumbAware {
         companion object State {
@@ -122,7 +136,7 @@ class MirrordBinaryManager {
 
         override fun run(indicator: ProgressIndicator) {
             service<MirrordBinaryManager>()
-                .runUpdate(project, product, wslDistribution, checkInPath, indicator)
+                .runUpdate(project, product, environment, checkInPath, indicator)
         }
     }
 
@@ -135,7 +149,7 @@ class MirrordBinaryManager {
     private fun runUpdate(
         project: Project,
         product: String?,
-        wslDistribution: WSLDistribution?,
+        environment: MirrordEnvironment,
         checkInPath: Boolean,
         indicator: ProgressIndicator
     ) {
@@ -175,9 +189,9 @@ class MirrordBinaryManager {
         }
 
         val local = if (checkInPath) {
-            getLocalBinary(version, wslDistribution)
+            getLocalBinary(version, environment)
         } else {
-            findBinaryInStorage(version, wslDistribution)
+            findBinaryInStorage(version, environment)
         }
 
         if (local != null) {
@@ -193,7 +207,7 @@ class MirrordBinaryManager {
         }
 
         try {
-            updateBinary(indicator, wslDistribution)
+            updateBinary(indicator, environment.platform())
             val downloaded = downloadVersion
             if (downloaded != null) {
                 project
@@ -250,30 +264,10 @@ class MirrordBinaryManager {
         return response.body()
     }
 
-    private fun updateBinary(indicator: ProgressIndicator, wslDistribution: WSLDistribution? = null) {
+    private fun updateBinary(indicator: ProgressIndicator, platform: MirrordTargetPlatform) {
         val version = downloadVersion ?: return
 
-        val url = if (SystemInfo.isMac) {
-            "$DOWNLOAD_ENDPOINT/$version/mirrord_mac_universal"
-        } else if (isWinNative(wslDistribution)) {
-            if (CpuArch.isIntel64()) {
-                "$DOWNLOAD_ENDPOINT/$version/mirrord.exe"
-            } else {
-                throw RuntimeException("Unsupported architecture: ${CpuArch.CURRENT.name}")
-            }
-        } else if (SystemInfo.isLinux || SystemInfo.isWindows) {
-            // Native Linux, or Windows host targeting WSL — both use the Linux
-            // binary. WSL inherits host arch, so CpuArch is the right proxy.
-            if (CpuArch.isArm64()) {
-                "$DOWNLOAD_ENDPOINT/$version/mirrord_linux_aarch64"
-            } else if (CpuArch.isIntel64()) {
-                "$DOWNLOAD_ENDPOINT/$version/mirrord_linux_x86_64"
-            } else {
-                throw RuntimeException("Unsupported architecture: " + CpuArch.CURRENT.name)
-            }
-        } else {
-            throw RuntimeException("Unsupported platform: " + SystemInfo.OS_NAME)
-        }
+        val url = mirrordDownloadUrl(version, platform)
 
         indicator.text = "mirrord is downloading binary version $version..."
         indicator.fraction = 0.0
@@ -300,53 +294,55 @@ class MirrordBinaryManager {
             }
         }
 
-        val destination = MirrordPathManager.getPath(CLI_BINARY, true, wslDistribution)
+        val destination = MirrordPathManager.getPath(CLI_BINARY, true, platform).path
         Files.createDirectories(destination.parent)
 
         val tmpDestination = destination.resolveSibling(destination.name + UUID.randomUUID().toString())
 
         Files.write(tmpDestination, bytes)
-        destination.toFile().setExecutable(true)
+        // Set the bit on the file we are about to move, not on the one it replaces. The old
+        // order marked the *previous* binary executable (or nothing at all, on a first install)
+        // and only worked because MirrordPathManager repaired it lazily on the next read. That
+        // repair is host-side, so it cannot help a copy staged into a container.
+        tmpDestination.toFile().setExecutable(true)
         Files.move(tmpDestination, destination, StandardCopyOption.REPLACE_EXISTING)
     }
 
-    private class MirrordBinary(val command: String, wslDistribution: WSLDistribution?) {
+    private class MirrordBinary(val command: TargetPath, environment: MirrordEnvironment) {
         val version: String
 
         init {
-            version = if (wslDistribution != null) {
-                val command = wslPath(wslDistribution, command)
-                val output = wslDistribution.executeOnWsl(5000, command, "--version")
-                output.stdout.split(' ')[1].trim()
-            } else {
-                val child = Runtime.getRuntime().exec(arrayOf(command, "--version"))
-                val result = child.waitFor()
-                if (result != 0) {
-                    MirrordLogger.logger.debug("`mirrord --version` failed with code $result")
+            val output = environment.probe(command, listOf("--version"), PROBE_TIMEOUT_MILLIS)
+            // Parse leniently and report the exit code only when the output is unusable. The old
+            // WSL path ignored the exit code entirely, so failing on it here would have been a
+            // behaviour change for WSL rather than a fix.
+            version = output.stdout.trim().split(' ').getOrNull(1)?.trim()
+                ?: run {
+                    MirrordLogger.logger.debug(
+                        "`mirrord --version` gave exit=${output.exitCode} stdout='${output.stdout}' stderr='${output.stderr}'"
+                    )
                     throw RuntimeException("failed to get mirrord version")
                 }
-
-                child.inputReader().readLine().split(' ')[1].trim()
-            }
         }
     }
 
     /**
-     * @return executable found with `which mirrord`
+     * @return executable found on the target's `PATH`
      */
-    private fun findBinaryInPath(requiredVersion: String?, wslDistribution: WSLDistribution?): MirrordBinary? {
+    private fun findBinaryInPath(requiredVersion: String?, environment: MirrordEnvironment): MirrordBinary? {
         try {
-            val output = if (wslDistribution == null) {
-                which("mirrord") ?: throw RuntimeException("mirrord not found in PATH")
-            } else {
-                val output = wslDistribution.executeOnWsl(5000, "which", "mirrord")
-                if (output.exitCode != 0) {
-                    throw RuntimeException("`which` failed with code ${output.exitCode}")
-                }
-                output.stdoutLines.first().trim()
-            }
+            val windows = environment.platform().isWindows
+            val locator = TargetPath(if (windows) "where" else "which")
+            val wanted = if (windows) "$CLI_BINARY.exe" else CLI_BINARY
 
-            val binary = MirrordBinary(output, wslDistribution)
+            val output = environment.probe(locator, listOf(wanted), PROBE_TIMEOUT_MILLIS)
+            if (output.exitCode != 0) {
+                throw RuntimeException("`${locator.value}` failed with code ${output.exitCode}")
+            }
+            val found = output.stdout.lineSequence().firstOrNull { it.isNotBlank() }?.trim()
+                ?: throw RuntimeException("mirrord not found in PATH")
+
+            val binary = MirrordBinary(TargetPath(found), environment)
             val isRequiredVersion = try {
                 // for release CI, the tag can be greater than the latest release
                 if (System.getenv("CI_BUILD_PLUGIN") == "true") {
@@ -370,10 +366,13 @@ class MirrordBinaryManager {
     /**
      * @return executable found in plugin storage
      */
-    private fun findBinaryInStorage(requiredVersion: String?, wslDistribution: WSLDistribution?): MirrordBinary? {
+    private fun findBinaryInStorage(requiredVersion: String?, environment: MirrordEnvironment): MirrordBinary? {
         try {
-            MirrordPathManager.getBinary(CLI_BINARY, true, wslDistribution)?.let {
-                val binary = MirrordBinary(it, wslDistribution)
+            MirrordPathManager.getBinary(CLI_BINARY, true, environment.platform())?.let { hostPath ->
+                // Plugin storage lives on the IDE host, which a container cannot see at any
+                // path. `provide` copies it across if it has to, and does nothing when the
+                // target can already reach it — local and WSL never pay for a transfer.
+                val binary = MirrordBinary(environment.provide(hostPath, CLI_BINARY), environment)
                 val isRequiredVersion = try {
                     Version.valueOf(binary.version).equals(Version.valueOf(requiredVersion))
                 } catch (e: Exception) {
@@ -393,8 +392,8 @@ class MirrordBinaryManager {
     /**
      * @return the local installation of mirrord, either in `PATH` or in plugin storage
      */
-    private fun getLocalBinary(requiredVersion: String?, wslDistribution: WSLDistribution?): MirrordBinary? {
-        return findBinaryInPath(requiredVersion, wslDistribution) ?: findBinaryInStorage(requiredVersion, wslDistribution)
+    private fun getLocalBinary(requiredVersion: String?, environment: MirrordEnvironment): MirrordBinary? {
+        return findBinaryInPath(requiredVersion, environment) ?: findBinaryInStorage(requiredVersion, environment)
     }
 
     /**
@@ -426,8 +425,17 @@ class MirrordBinaryManager {
             return
         }
 
+        // Resolve against the project's environment rather than assuming the host, and
+        // honour a custom binary path the way `getBinary` does — otherwise a user who pointed
+        // the plugin at their own build is still told it is unsupported, and can even be
+        // force-fed a download of the managed one.
+        val environment = MirrordEnvironments.resolve(MirrordLaunchContext(project))
+
         fun resolveLocal(): MirrordBinary? = try {
-            getLocalBinary(null, null)
+            val customPath = MirrordSettingsState.instance.mirrordState.mirrordBinaryPath.trim()
+            customPath.takeIf { it.isNotEmpty() }
+                ?.let { validateCustomBinary(it, environment, project) }
+                ?: getLocalBinary(null, environment)
         } catch (e: Exception) {
             MirrordLogger.logger.debug("checkWindowsNativeSupport: local lookup failed", e)
             null
@@ -486,7 +494,7 @@ class MirrordBinaryManager {
             val latest = fetchLatestSupportedVersion(null, indicator)
             latestSupportedVersion = latest
             downloadVersion = latest
-            updateBinary(indicator)
+            updateBinary(indicator, environment.platform())
         } catch (e: Exception) {
             MirrordLogger.logger.warn("checkWindowsNativeSupport: auto-update failed: ${e.message}", e)
         } finally {
@@ -510,7 +518,7 @@ class MirrordBinaryManager {
         MirrordWindowsUnsupportedDialog.showVersionUnsupportedOnce(
             MIN_WINDOWS_NATIVE_VERSION,
             actual,
-            binary?.command
+            binary?.command?.value
         )
     }
 
@@ -521,8 +529,8 @@ class MirrordBinaryManager {
      * or unparseable. The error body uses the same wording as the proactive
      * startup dialog so users see the same warning + path on both surfaces.
      */
-    private fun enforceWindowsNativeMin(binary: MirrordBinary, wslDistribution: WSLDistribution?) {
-        if (!isWinNative(wslDistribution)) return
+    private fun enforceWindowsNativeMin(binary: MirrordBinary, platform: MirrordTargetPlatform) {
+        if (!isWinNative(platform)) return
         val parsed = try {
             Version.valueOf(binary.version)
         } catch (_: Exception) {
@@ -535,7 +543,7 @@ class MirrordBinaryManager {
         val body = MirrordWindowsUnsupportedDialog.buildVersionUnsupportedBody(
             MIN_WINDOWS_NATIVE_VERSION,
             found,
-            binary.command
+            binary.command.value
         )
         throw MirrordError(
             body,
@@ -553,17 +561,17 @@ class MirrordBinaryManager {
      * @throws MirrordError if no local binary could be resolved
      * @return the path to the binary
      */
-    fun getBinary(product: String, wslDistribution: WSLDistribution?, project: Project): String {
+    fun getBinary(product: String, environment: MirrordEnvironment, project: Project): TargetPath {
         val customPath = MirrordSettingsState.instance.mirrordState.mirrordBinaryPath.trim()
         if (customPath.isNotEmpty()) {
-            validateCustomBinary(customPath, wslDistribution, project)?.let {
-                enforceWindowsNativeMin(it, wslDistribution)
+            validateCustomBinary(customPath, environment, project)?.let {
+                enforceWindowsNativeMin(it, environment.platform())
                 return it.command
             }
         }
 
         val indicator = ProgressManager.getInstance().progressIndicator ?: EmptyProgressIndicator()
-        runUpdate(project, product, wslDistribution, true, indicator)
+        runUpdate(project, product, environment, true, indicator)
 
         val autoUpdate = MirrordSettingsState.instance.mirrordState.autoUpdate
         val userVersion = MirrordSettingsState.instance.mirrordState.mirrordVersion
@@ -573,8 +581,8 @@ class MirrordBinaryManager {
             else -> null
         }
 
-        getLocalBinary(wantedVersion, wslDistribution)?.let {
-            enforceWindowsNativeMin(it, wslDistribution)
+        getLocalBinary(wantedVersion, environment)?.let {
+            enforceWindowsNativeMin(it, environment.platform())
             return it.command
         }
 
@@ -586,11 +594,14 @@ class MirrordBinaryManager {
 
     private fun validateCustomBinary(
         path: String,
-        wslDistribution: WSLDistribution?,
+        environment: MirrordEnvironment,
         project: Project
     ): MirrordBinary? {
         return try {
-            MirrordBinary(path, wslDistribution)
+            // Already a target-side path: the user typed something meaningful where mirrord
+            // runs, so it must not be translated. The old code relied on getWslPath returning
+            // null for an already-Linux path; this makes that reliance explicit.
+            MirrordBinary(TargetPath(path), environment)
         } catch (e: Exception) {
             MirrordLogger.logger.debug("custom mirrord binary path is invalid: $path", e)
             project

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordBinaryManager.kt
@@ -300,10 +300,7 @@ class MirrordBinaryManager {
         val tmpDestination = destination.resolveSibling(destination.name + UUID.randomUUID().toString())
 
         Files.write(tmpDestination, bytes)
-        // Set the bit on the file we are about to move, not on the one it replaces. The old
-        // order marked the *previous* binary executable (or nothing at all, on a first install)
-        // and only worked because MirrordPathManager repaired it lazily on the next read. That
-        // repair is host-side, so it cannot help a copy staged into a container.
+        // Set the bit on the file we are about to move, not on the one it replaces.
         tmpDestination.toFile().setExecutable(true)
         Files.move(tmpDestination, destination, StandardCopyOption.REPLACE_EXISTING)
     }
@@ -316,15 +313,13 @@ class MirrordBinaryManager {
 
         init {
             val output = environment.probe(command, listOf("--version"), PROBE_TIMEOUT_MILLIS)
-            // Parse leniently and report the exit code only when the output is unusable. The old
-            // WSL path ignored the exit code entirely, so failing on it here would have been a
-            // behaviour change for WSL rather than a fix.
+            // Parse leniently, and report the exit code only when the output is unusable. The
+            // WSL path ignored the exit code, so failing on it here would change WSL behaviour.
             version = output.stdout.trim().split(' ').getOrNull(1)?.trim()
                 ?: run {
-                    // The reason belongs in the exception, not only in a DEBUG line. A binary
-                    // built on a rolling-release host against a newer glibc than the target's
-                    // fails here with a linker message, and "failed to get mirrord version"
-                    // sends the reader nowhere.
+                    // The reason belongs in the exception, not only in a DEBUG line: a binary
+                    // built against a newer glibc than the target's fails here with a linker
+                    // message that "failed to get mirrord version" would hide.
                     val reason = output.stderr.trim().lines().firstOrNull()?.take(200)
                         ?: "exit=${output.exitCode}, no output"
                     throw RuntimeException(reason)
@@ -337,18 +332,9 @@ class MirrordBinaryManager {
      */
     private fun findBinaryInPath(requiredVersion: String?, environment: MirrordEnvironment): MirrordBinary? {
         try {
-            val windows = environment.platform().isWindows
-            val locator = TargetPath(if (windows) "where" else "which")
-            val wanted = if (windows) "$CLI_BINARY.exe" else CLI_BINARY
+            val found = environment.locate(CLI_BINARY) ?: throw RuntimeException("mirrord not found in PATH")
 
-            val output = environment.probe(locator, listOf(wanted), PROBE_TIMEOUT_MILLIS)
-            if (output.exitCode != 0) {
-                throw RuntimeException("`${locator.value}` failed with code ${output.exitCode}")
-            }
-            val found = output.stdout.lineSequence().firstOrNull { it.isNotBlank() }?.trim()
-                ?: throw RuntimeException("mirrord not found in PATH")
-
-            val binary = MirrordBinary(TargetPath(found), environment)
+            val binary = MirrordBinary(found, environment)
             val isRequiredVersion = try {
                 // for release CI, the tag can be greater than the latest release
                 if (System.getenv("CI_BUILD_PLUGIN") == "true") {
@@ -601,15 +587,11 @@ class MirrordBinaryManager {
     /**
      * Warns before a slow copy, so it does not read as a hang.
      *
-     * Deliberately one sentence. The reason the binary is large — the CLI embeds the layer, so an
-     * unstripped Linux debug build reaches ~1 GB — is in the log, not in the notification.
+     * Driven by [MirrordEnvironment.provide]'s copy callback rather than called beforehand,
+     * because only `provide` knows whether bytes actually move. A local target and legacy WSL
+     * both resolve the path without copying.
      *
-     * Driven by [MirrordEnvironment.provide]'s copy callback rather than called beforehand, because
-     * only `provide` knows whether bytes actually move: a local target and legacy WSL both resolve
-     * the path without copying, and announcing a transfer there is simply false.
-     *
-     * Fires only above [LARGE_BINARY_ADVISORY_BYTES], and carries "don't show again", so a
-     * released binary stays quiet.
+     * Fires only above [LARGE_BINARY_ADVISORY_BYTES], and carries "don't show again".
      */
     private fun advertiseLargeBinary(bytes: Long, environment: MirrordEnvironment, project: Project) {
         if (bytes <= LARGE_BINARY_ADVISORY_BYTES) return
@@ -632,17 +614,10 @@ class MirrordBinaryManager {
         environment: MirrordEnvironment,
         project: Project
     ): MirrordBinary? {
-        // On-device first, remote second.
+        // On-device first, remote second. The setting is filled in with a file chooser on the
+        // user's own machine, so a host path is the normal case.
         //
-        // The setting is filled in with a file chooser on the user's own machine, so a host path
-        // is the normal case. Treating it as target-side only meant a perfectly good local build
-        // was rejected as "invalid" under a dev container, because that path names nothing inside
-        // the container.
-        //
-        // Staging goes through `provide`, which is content-addressed: the destination is keyed on
-        // a sha256 of the file, so an unchanged binary resolves to a path that already exists and
-        // nothing is copied. A rebuilt binary hashes differently and is copied once. When the
-        // environment is local, `provide` returns the path unchanged and no copy happens at all.
+        // Staging goes through `provide`, so an unchanged binary is not copied again.
         var hostFailure: String? = null
         val hostFile = runCatching { HostPath.of(path) }.getOrNull()
         if (hostFile != null && runCatching { Files.isRegularFile(hostFile.path) }.getOrDefault(false)) {
@@ -664,8 +639,7 @@ class MirrordBinaryManager {
                 ?.let { return it }
         }
 
-        // Remote second: the user pointed at something that already exists where mirrord runs —
-        // inside the container, or inside the WSL distribution.
+        // Remote second: the user pointed at something that already exists where mirrord runs.
         runCatching { MirrordBinary(TargetPath(path), environment) }
             .onFailure { MirrordLogger.logger.debug("target-side mirrord binary at $path is not usable", it) }
             .getOrNull()

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigAPI.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigAPI.kt
@@ -3,6 +3,8 @@ package com.metalbear.mirrord
 import com.google.gson.Gson
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
 import java.nio.charset.Charset
 
@@ -52,6 +54,15 @@ class MirrordConfigAPI(private val service: MirrordProjectService) {
      * @param configFromEnv path to mirrord specified in the configuration.
      */
     fun getConfigPath(configFromEnv: String?): String? {
+        // Logged at INFO, not DEBUG. Falling through every branch here means the CLI runs with
+        // built-in defaults -- mirror instead of steal, no filters, no port mapping -- and says
+        // nothing about it. That silence is precisely how COR-1385 presented, so the resolution
+        // has to be visible in a default-level log.
+        MirrordLogger.logger.info(
+            "mirrord.config: resolving — activeConfig=${service.activeConfig?.path ?: "none"} " +
+                "fromEnv=${configFromEnv ?: "none"}"
+        )
+
         service.activeConfig?.let {
             service.notifier.notification(
                 "Using mirrord active config",
@@ -78,6 +89,11 @@ class MirrordConfigAPI(private val service: MirrordProjectService) {
             return it.path
         }
 
+        MirrordLogger.logger.warn(
+            "mirrord.config: NO CONFIG FOUND — the CLI will run with built-in defaults " +
+                "(mirror mode, no http filter, no port mapping). Searched: active config, " +
+                "$CONFIG_ENV_NAME, then the project's .mirrord directory."
+        )
         return null
     }
 
@@ -87,6 +103,29 @@ class MirrordConfigAPI(private val service: MirrordProjectService) {
      * @throws InvalidProjectException if the directory could not be found.
      */
     fun getProjectDir(): VirtualFile {
+        // `guessProjectDir` is the platform's own answer, and it consults BaseProjectDirectories
+        // — the API that is authoritative for a dev-container or remote project, which raw content
+        // roots are not.
+        //
+        // Deriving the root from the project or workspace file holds for a locally opened project,
+        // but inside a JetBrains dev container that file lives under the IDE's own configuration
+        // directory, so the derived path is ~/.config/JetBrains/<IDE>. Everything anchored here
+        // shares that fault: the `.mirrord` lookup, `createDefaultConfig` writing a new config
+        // outside the project and outside version control, and the `$ProjectPath$` macro in a run
+        // configuration's MIRRORD_CONFIG_FILE.
+        service.project.guessProjectDir()?.let { return it }
+
+        return projectDirFromProjectFile()
+    }
+
+    /**
+     * The project root as derived from the project or workspace file.
+     *
+     * Correct only when that file sits inside the project, which is not true in a dev container.
+     * Kept as a fallback for projects with no content roots, and used by [getDefaultConfig] so the
+     * log can show what each source produced.
+     */
+    private fun projectDirFromProjectFile(): VirtualFile {
         val knownLocationFile = service.project.projectFile
             ?: service.project.workspaceFile
             ?: throw InvalidProjectException(
@@ -119,7 +158,31 @@ class MirrordConfigAPI(private val service: MirrordProjectService) {
      * @throws InvalidProjectException if parent directory for `.mirrord` could not be found.
      */
     fun getDefaultConfig(): VirtualFile? {
-        return getMirrordDir()
+        val contentRoots = runCatching {
+            ProjectRootManager.getInstance(service.project).contentRoots.toList()
+        }.getOrDefault(emptyList())
+
+        val candidates = buildList {
+            service.project.guessProjectDir()?.let { guessed ->
+                add(ConfigRootCandidate("guessProjectDir", guessed.path, guessed.findChild(".mirrord")?.takeIf { it.isDirectory }))
+            }
+            contentRoots.forEachIndexed { index, root ->
+                add(ConfigRootCandidate("contentRoot[$index]", root.path, root.findChild(".mirrord")?.takeIf { it.isDirectory }))
+            }
+            val heuristic = runCatching { projectDirFromProjectFile() }.getOrNull()
+            add(ConfigRootCandidate("projectFileHeuristic", heuristic?.path, heuristic?.findChild(".mirrord")?.takeIf { it.isDirectory }))
+        }
+
+        candidates.forEach { candidate ->
+            MirrordLogger.logger.info(
+                "mirrord.config: candidate source=${candidate.source} dir=${candidate.rootPath ?: "none"} " +
+                    "mirrordDir=${candidate.mirrordDir?.path ?: "not found"} " +
+                    "children=${candidate.mirrordDir?.children?.joinToString(",") { it.name } ?: "-"}"
+            )
+        }
+
+        return chooseConfigRoot(candidates)
+            ?.mirrordDir
             ?.children
             ?.filter { isValidConfigExt(it) }
             ?.minByOrNull { it.name }
@@ -148,3 +211,28 @@ class MirrordConfigAPI(private val service: MirrordProjectService) {
         }
     }
 }
+
+/**
+ * One place the `.mirrord` directory might live, and whether it was actually there.
+ *
+ * [root] and [mirrordDir] are nullable because a candidate source is allowed to produce nothing.
+ */
+internal data class ConfigRootCandidate<T>(
+    val source: String,
+    val rootPath: String?,
+    val mirrordDir: T?
+)
+
+/**
+ * Picks the first candidate that actually holds a `.mirrord` directory.
+ *
+ * Split out from [MirrordConfigAPI.getDefaultConfig] so the *ordering rule* can be tested without
+ * an IDE. The rule is not cosmetic. Deriving the project root from the project or workspace file
+ * holds for a locally opened project, but inside a JetBrains dev container that file lives under
+ * the IDE's own configuration directory, so the derived root was `~/.config/JetBrains/<IDE>` and
+ * `.mirrord` was never found. mirrord then ran with built-in defaults -- mirror instead of steal,
+ * no filter, no port mapping -- and said nothing. Content roots must therefore be consulted first,
+ * and the file-derived heuristic must stay a fallback rather than the only source.
+ */
+internal fun <T> chooseConfigRoot(candidates: List<ConfigRootCandidate<T>>): ConfigRootCandidate<T>? =
+    candidates.firstOrNull { it.mirrordDir != null }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigAPI.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordConfigAPI.kt
@@ -55,9 +55,7 @@ class MirrordConfigAPI(private val service: MirrordProjectService) {
      */
     fun getConfigPath(configFromEnv: String?): String? {
         // Logged at INFO, not DEBUG. Falling through every branch here means the CLI runs with
-        // built-in defaults -- mirror instead of steal, no filters, no port mapping -- and says
-        // nothing about it. That silence is precisely how COR-1385 presented, so the resolution
-        // has to be visible in a default-level log.
+        // built-in defaults.
         MirrordLogger.logger.info(
             "mirrord.config: resolving — activeConfig=${service.activeConfig?.path ?: "none"} " +
                 "fromEnv=${configFromEnv ?: "none"}"
@@ -107,12 +105,12 @@ class MirrordConfigAPI(private val service: MirrordProjectService) {
         // — the API that is authoritative for a dev-container or remote project, which raw content
         // roots are not.
         //
-        // Deriving the root from the project or workspace file holds for a locally opened project,
-        // but inside a JetBrains dev container that file lives under the IDE's own configuration
-        // directory, so the derived path is ~/.config/JetBrains/<IDE>. Everything anchored here
-        // shares that fault: the `.mirrord` lookup, `createDefaultConfig` writing a new config
-        // outside the project and outside version control, and the `$ProjectPath$` macro in a run
-        // configuration's MIRRORD_CONFIG_FILE.
+        // Deriving the root from the project or workspace file holds for a locally opened
+        // project. Inside a JetBrains dev container that file lives under the IDE's own
+        // configuration directory, so the derived path is ~/.config/JetBrains/<IDE>.
+        //
+        // Everything anchored here shares that fault: the `.mirrord` lookup, `createDefaultConfig`
+        // writing outside version control, and the `$ProjectPath$` macro in MIRRORD_CONFIG_FILE.
         service.project.guessProjectDir()?.let { return it }
 
         return projectDirFromProjectFile()
@@ -226,13 +224,13 @@ internal data class ConfigRootCandidate<T>(
 /**
  * Picks the first candidate that actually holds a `.mirrord` directory.
  *
- * Split out from [MirrordConfigAPI.getDefaultConfig] so the *ordering rule* can be tested without
- * an IDE. The rule is not cosmetic. Deriving the project root from the project or workspace file
- * holds for a locally opened project, but inside a JetBrains dev container that file lives under
- * the IDE's own configuration directory, so the derived root was `~/.config/JetBrains/<IDE>` and
- * `.mirrord` was never found. mirrord then ran with built-in defaults -- mirror instead of steal,
- * no filter, no port mapping -- and said nothing. Content roots must therefore be consulted first,
- * and the file-derived heuristic must stay a fallback rather than the only source.
+ * Split out from [MirrordConfigAPI.getDefaultConfig] so the ordering rule can be tested without
+ * an IDE.
+ *
+ * The order matters. Deriving the project root from the project or workspace file holds for a
+ * locally opened project, but inside a JetBrains dev container that file lives under the IDE's
+ * own configuration directory. Content roots come first, and the file-derived heuristic stays a
+ * fallback.
  */
 internal fun <T> chooseConfigRoot(candidates: List<ConfigRootCandidate<T>>): ConfigRootCandidate<T>? =
     candidates.firstOrNull { it.mirrordDir != null }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -160,18 +160,10 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         // Find the mirrord config path, then call `mirrord verify-config {path}` so we can display warnings/errors
         // from the config without relying on mirrord-layer.
 
-        // The lookup finds the file through the IDE's own VFS, so it is a host path. It has
-        // to be translated before the CLI sees it: under a dev container the CLI runs where the
-        // host filesystem does not exist, and mirrord answers an unreadable config by silently
-        // falling back to defaults — which is exactly how COR-1385 presented.
+        // The lookup goes through the IDE's own VFS, so it returns a host path. It has to be
+        // translated before the CLI sees it.
         val configPath = service.configApi.getConfigPath(mirrordConfigPath)?.let { raw ->
             // On-device first, remote second, the same order the custom binary path uses.
-            //
-            // A user is allowed to point MIRRORD_CONFIG_FILE at a path that is already valid where
-            // mirrord runs — `/workspaces/app/mirrord.json` inside the container. Converting that
-            // blindly is worse than doing nothing: on a Windows host `Paths.get` rewrites it with
-            // backslashes, the CLI cannot read it, and mirrord falls back to built-in defaults in
-            // silence. That is the COR-1385 signature this code exists to remove.
             val hostFile = runCatching { HostPath.of(raw) }.getOrNull()
             if (hostFile != null && runCatching { Files.exists(hostFile.path) }.getOrDefault(false)) {
                 environment.resolve(hostFile)
@@ -268,11 +260,8 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         // MIRRORD_CHILD_ENV payload.
         executionInfo.environment.putAll(
             MirrordSettingsState.instance.mirrordState.troubleshootingLayerEnvVars { hostPath ->
-                // Never let a diagnostic setting stop the product from starting. `resolve` throws
-                // when the target cannot see the path, and a host directory chosen in Settings is
-                // not mounted into a container — so translating it strictly turned "switch on
-                // verbose logs" into "every run fails". Falling back to the raw path at worst puts
-                // the log somewhere unhelpful, which is what a user of this switch can act on.
+                // A diagnostic setting must never stop the product from starting. `resolve`
+                // throws when the target cannot see the path, so fall back to the raw path.
                 runCatching { environment.resolve(HostPath.of(hostPath)).value }
                     .getOrElse {
                         MirrordLogger.logger.warn(

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -12,12 +12,8 @@ import com.intellij.openapi.progress.Task
 import com.metalbear.mirrord.bifrost.HostPath
 import com.metalbear.mirrord.bifrost.MirrordEnvironment
 import com.metalbear.mirrord.bifrost.TargetPath
+import java.nio.file.Files
 
-/**
- * Functions to be called when one of our entry points to the program is called - when process is
- * launched, when go entrypoint, etc. It will check to see if it already occurred for current run and
- * if it did, it will do nothing
- */
 class MirrordExecManager(private val service: MirrordProjectService) {
     /**
      * Is thrown when the progress bar dialog for listing targets, specifically during initialisation, is cancelled.
@@ -168,9 +164,22 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         // to be translated before the CLI sees it: under a dev container the CLI runs where the
         // host filesystem does not exist, and mirrord answers an unreadable config by silently
         // falling back to defaults — which is exactly how COR-1385 presented.
-        val configPath = service.configApi.getConfigPath(mirrordConfigPath)
-            ?.let { environment.resolve(HostPath.of(it)) }
-        MirrordLogger.logger.debug("MirrordExecManager.start: config path is $configPath")
+        val configPath = service.configApi.getConfigPath(mirrordConfigPath)?.let { raw ->
+            // On-device first, remote second, the same order the custom binary path uses.
+            //
+            // A user is allowed to point MIRRORD_CONFIG_FILE at a path that is already valid where
+            // mirrord runs — `/workspaces/app/mirrord.json` inside the container. Converting that
+            // blindly is worse than doing nothing: on a Windows host `Paths.get` rewrites it with
+            // backslashes, the CLI cannot read it, and mirrord falls back to built-in defaults in
+            // silence. That is the COR-1385 signature this code exists to remove.
+            val hostFile = runCatching { HostPath.of(raw) }.getOrNull()
+            if (hostFile != null && runCatching { Files.exists(hostFile.path) }.getOrDefault(false)) {
+                environment.resolve(hostFile)
+            } else {
+                TargetPath(raw)
+            }
+        }
+        MirrordLogger.logger.info("mirrord.config: resolved target-side config path = ${configPath ?: "NONE (defaults will apply)"}")
 
         val verifiedConfig = configPath?.let {
             val verifiedConfigOutput =
@@ -258,8 +267,20 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         // reaches the layer through every product/platform path, including the Windows
         // MIRRORD_CHILD_ENV payload.
         executionInfo.environment.putAll(
-            MirrordSettingsState.instance.mirrordState.troubleshootingLayerEnvVars {
-                environment.resolve(HostPath.of(it)).value
+            MirrordSettingsState.instance.mirrordState.troubleshootingLayerEnvVars { hostPath ->
+                // Never let a diagnostic setting stop the product from starting. `resolve` throws
+                // when the target cannot see the path, and a host directory chosen in Settings is
+                // not mounted into a container — so translating it strictly turned "switch on
+                // verbose logs" into "every run fails". Falling back to the raw path at worst puts
+                // the log somewhere unhelpful, which is what a user of this switch can act on.
+                runCatching { environment.resolve(HostPath.of(hostPath)).value }
+                    .getOrElse {
+                        MirrordLogger.logger.warn(
+                            "mirrord: troubleshooting log path '$hostPath' is not reachable from " +
+                                "${environment.name}; passing it through unchanged"
+                        )
+                        hostPath
+                    }
             }
         )
         return executionInfo

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordExecManager.kt
@@ -1,6 +1,5 @@
 package com.metalbear.mirrord
 
-import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.WriteAction
@@ -10,6 +9,9 @@ import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
+import com.metalbear.mirrord.bifrost.HostPath
+import com.metalbear.mirrord.bifrost.MirrordEnvironment
+import com.metalbear.mirrord.bifrost.TargetPath
 
 /**
  * Functions to be called when one of our entry points to the program is called - when process is
@@ -35,14 +37,14 @@ class MirrordExecManager(private val service: MirrordProjectService) {
      * @throws ProcessCanceledException if the dialog cannot be displayed
      */
     private fun chooseTarget(
-        cli: String,
-        wslDistribution: WSLDistribution?,
-        config: String?,
+        cli: TargetPath,
+        environment: MirrordEnvironment,
+        config: TargetPath?,
         mirrordApi: MirrordApi
     ): MirrordExecDialog.UserSelection {
         MirrordLogger.logger.debug("choose target called")
 
-        val getTargets = { namespace: String?, targetTypes: List<String> -> mirrordApi.listTargets(cli, config, wslDistribution, namespace, targetTypes) }
+        val getTargets = { namespace: String?, targetTypes: List<String> -> mirrordApi.listTargets(cli, config, environment, namespace, targetTypes) }
         val application = ApplicationManager.getApplication()
 
         val selected = if (application.isDispatchThread) {
@@ -75,7 +77,7 @@ class MirrordExecManager(private val service: MirrordProjectService) {
                 .apply {
                     config.let {
                         when {
-                            it != null -> withOpenPath(it)
+                            it != null -> withOpenPath(it.value)
                             else -> withAction("Create") { _, _ ->
                                 WriteAction.run<InvalidProjectException> {
                                     val newConfig = service.configApi.createDefaultConfig()
@@ -94,14 +96,8 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         return selected ?: throw ProcessCanceledException()
     }
 
-    private fun cliPath(wslDistribution: WSLDistribution?, product: String): String {
-        val path = service<MirrordBinaryManager>().getCliPath(product, wslDistribution, service.project)
-        return wslPath(wslDistribution, path)
-    }
-
-    @Suppress("DEPRECATION")
-    private fun wslPath(wslDistribution: WSLDistribution?, path: String): String =
-        wslDistribution?.getWslPath(path) ?: path
+    private fun cliPath(environment: MirrordEnvironment, product: String): TargetPath =
+        service<MirrordBinaryManager>().getCliPath(product, environment, service.project)
 
     /**
      * Starts a plugin version check in a background thread.
@@ -130,11 +126,11 @@ class MirrordExecManager(private val service: MirrordProjectService) {
      * Returns null if mirrord is disabled.
      */
     private fun prepareStart(
-        wslDistribution: WSLDistribution?,
+        environment: MirrordEnvironment,
         product: String,
         projectEnvVars: Map<String, String>?,
         mirrordApi: MirrordApi
-    ): Pair<String?, MirrordExecDialog.UserSelection>? {
+    ): Pair<TargetPath?, MirrordExecDialog.UserSelection>? {
         MirrordLogger.logger.debug("MirrordExecManager.start")
         val mirrordActiveValue = projectEnvVars?.get("MIRRORD_ACTIVE")
         val explicitlyEnabled = mirrordActiveValue == "1"
@@ -162,24 +158,29 @@ class MirrordExecManager(private val service: MirrordProjectService) {
                 it
             }
         }
-        val cli = cliPath(wslDistribution, product)
+        val cli = cliPath(environment, product)
 
         MirrordLogger.logger.debug("MirrordExecManager.start: mirrord cli path is $cli")
         // Find the mirrord config path, then call `mirrord verify-config {path}` so we can display warnings/errors
         // from the config without relying on mirrord-layer.
 
+        // The lookup finds the file through the IDE's own VFS, so it is a host path. It has
+        // to be translated before the CLI sees it: under a dev container the CLI runs where the
+        // host filesystem does not exist, and mirrord answers an unreadable config by silently
+        // falling back to defaults — which is exactly how COR-1385 presented.
         val configPath = service.configApi.getConfigPath(mirrordConfigPath)
+            ?.let { environment.resolve(HostPath.of(it)) }
         MirrordLogger.logger.debug("MirrordExecManager.start: config path is $configPath")
 
         val verifiedConfig = configPath?.let {
             val verifiedConfigOutput =
-                mirrordApi.verifyConfig(cli, wslPath(wslDistribution, it), wslDistribution)
+                mirrordApi.verifyConfig(cli, it, environment)
             MirrordLogger.logger.debug("MirrordExecManager.start: verifiedConfigOutput: $verifiedConfigOutput")
             MirrordVerifiedConfig(verifiedConfigOutput, service.notifier).apply {
                 MirrordLogger.logger.debug("MirrordExecManager.start: MirrordVerifiedConfig: $it")
                 if (isError()) {
                     MirrordLogger.logger.debug("MirrordExecManager.start: invalid config error")
-                    throw InvalidConfigException(it, "Validation failed for config")
+                    throw InvalidConfigException(it.value, "Validation failed for config")
                 }
             }
         }
@@ -190,7 +191,7 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         val target = if (!targetSet) {
             // There is no config file or the config does not specify a target, so show dialog.
             MirrordLogger.logger.debug("target not selected, showing dialog")
-            chooseTarget(cli, wslDistribution, configPath, mirrordApi)
+            chooseTarget(cli, environment, configPath, mirrordApi)
         } else {
             MirrordExecDialog.UserSelection(null, null)
         }
@@ -232,7 +233,7 @@ class MirrordExecManager(private val service: MirrordProjectService) {
      * @throws ProcessCanceledException if the user cancelled
      */
     private fun start(
-        wslDistribution: WSLDistribution?,
+        environment: MirrordEnvironment,
         executable: String?,
         product: String,
         projectEnvVars: Map<String, String>?
@@ -240,15 +241,15 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         checkForSuspiciousEnvVars(projectEnvVars)
 
         val mirrordApi = service.mirrordApi(projectEnvVars)
-        val (configPath, target) = this.prepareStart(wslDistribution, product, projectEnvVars, mirrordApi) ?: return null
-        val cli = cliPath(wslDistribution, product)
+        val (configPath, target) = this.prepareStart(environment, product, projectEnvVars, mirrordApi) ?: return null
+        val cli = cliPath(environment, product)
 
         val executionInfo = mirrordApi.exec(
             cli,
             target,
             configPath,
             executable,
-            wslDistribution
+            environment
         )
         MirrordLogger.logger.debug("MirrordExecManager.start: executionInfo: $executionInfo")
 
@@ -258,7 +259,7 @@ class MirrordExecManager(private val service: MirrordProjectService) {
         // MIRRORD_CHILD_ENV payload.
         executionInfo.environment.putAll(
             MirrordSettingsState.instance.mirrordState.troubleshootingLayerEnvVars {
-                wslPath(wslDistribution, it)
+                environment.resolve(HostPath.of(it)).value
             }
         )
         return executionInfo
@@ -275,14 +276,14 @@ class MirrordExecManager(private val service: MirrordProjectService) {
      * CLI source: https://github.com/metalbear-co/mirrord/blob/main/mirrord/cli/src/attach.rs
      * Introduced in: https://github.com/metalbear-co/mirrord/pull/3995
      */
-    fun attach(cliPath: String, projectEnvVars: Map<String, String>, pid: Long): MirrordAttachExecution {
+    fun attach(cliPath: TargetPath, projectEnvVars: Map<String, String>, pid: Long, environment: MirrordEnvironment): MirrordAttachExecution {
         MirrordLogger.logger.info(
             "MirrordExecManager.attach: ENTER pid=$pid cliPath=$cliPath projectEnvVars=${projectEnvVars.size}"
         )
         val started = System.currentTimeMillis()
         val mirrordApi = service.mirrordApi(projectEnvVars)
         try {
-            val result = mirrordApi.attach(cliPath, pid)
+            val result = mirrordApi.attach(cliPath, pid, environment)
             MirrordLogger.logger.info(
                 "MirrordExecManager.attach: SUCCESS pid=$pid in ${System.currentTimeMillis() - started}ms"
             )
@@ -297,19 +298,19 @@ class MirrordExecManager(private val service: MirrordProjectService) {
     }
 
     private fun containerStart(
-        wslDistribution: WSLDistribution?,
+        environment: MirrordEnvironment,
         product: String,
         projectEnvVars: Map<String, String>?
     ): MirrordContainerExecution? {
         val mirrordApi = service.mirrordApi(projectEnvVars)
-        val (configPath, target) = this.prepareStart(wslDistribution, product, projectEnvVars, mirrordApi) ?: return null
-        val cli = cliPath(wslDistribution, product)
+        val (configPath, target) = this.prepareStart(environment, product, projectEnvVars, mirrordApi) ?: return null
+        val cli = cliPath(environment, product)
 
         val executionInfo = mirrordApi.containerExec(
             cli,
             target,
             configPath,
-            wslDistribution
+            environment
         )
         MirrordLogger.logger.debug("MirrordExecManager.start: executionInfo: $executionInfo")
 
@@ -332,13 +333,17 @@ class MirrordExecManager(private val service: MirrordProjectService) {
      *
      * Helps to handle special cases and differences between the IDEs or language runners (like npm).
      */
-    class Wrapper(private val manager: MirrordExecManager, private val product: String, private val extraEnvVars: Map<String, String>?) {
-        var wsl: WSLDistribution? = null
+    class Wrapper(
+        private val manager: MirrordExecManager,
+        private val product: String,
+        private val extraEnvVars: Map<String, String>?,
+        private val environment: MirrordEnvironment
+    ) {
         var executable: String? = null
 
         fun start(): MirrordExecution? {
             return try {
-                manager.start(wsl, executable, product, extraEnvVars)
+                manager.start(environment, executable, product, extraEnvVars)
             } catch (e: MirrordError) {
                 e.showHelp(manager.service.project)
                 throw e
@@ -357,7 +362,7 @@ class MirrordExecManager(private val service: MirrordProjectService) {
 
         fun containerStart(): MirrordContainerExecution? {
             return try {
-                manager.containerStart(wsl, product, extraEnvVars)
+                manager.containerStart(environment, product, extraEnvVars)
             } catch (e: MirrordError) {
                 e.showHelp(manager.service.project)
                 throw e
@@ -382,7 +387,7 @@ class MirrordExecManager(private val service: MirrordProjectService) {
      *
      * @return A `Wrapper` where you may call `start` to start running mirrord.
      */
-    fun wrapper(product: String, extraEnvVars: Map<String, String>?): Wrapper {
-        return Wrapper(this, product, extraEnvVars)
+    fun wrapper(product: String, extraEnvVars: Map<String, String>?, environment: MirrordEnvironment): Wrapper {
+        return Wrapper(this, product, extraEnvVars, environment)
     }
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNpmExecutionListener.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNpmExecutionListener.kt
@@ -59,8 +59,6 @@ class MirrordNpmExecutionListener : ExecutionListener {
             }
         } catch (e: CancellationException) {
             // The user pressed Cancel. Let it travel; the platform aborts the launch quietly.
-            // Logging it through `logger.error` would raise an IDE error report naming mirrord as
-            // the plugin to blame for something the user asked for.
             throw e
         } catch (e: Exception) {
             MirrordLogger.logger.error("mirrord failed to patch npm run: $e")
@@ -75,11 +73,8 @@ class MirrordNpmExecutionListener : ExecutionListener {
         try {
             runSettings.envs = executionGuard.originEnv
 
-            // No host check here. originPackageManagerPackageRef is assigned only where
-            // patchedPath came back, and that only happens for a macOS *target*, so the null
-            // check below is already the correct and complete gate. Asking the IDE host instead
-            // would additionally skip the restore when a non-Mac host drives a macOS target,
-            // leaving the run configuration permanently pointed at the patched package manager.
+            // No host check. `originPackageManagerPackageRef` is set only for a macOS target,
+            // so the null check below is the complete gate.
             executionGuard.originPackageManagerPackageRef?.let {
                 runSettings.packageManagerPackageRef = it
             }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNpmExecutionListener.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNpmExecutionListener.kt
@@ -4,10 +4,11 @@ import com.intellij.execution.ExecutionListener
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.target.createEnvironmentRequest
-import com.intellij.execution.wsl.WSLDistribution
-import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.openapi.components.service
 import com.intellij.openapi.util.SystemInfo
+import com.metalbear.mirrord.bifrost.MirrordEnvironment
+import com.metalbear.mirrord.bifrost.MirrordEnvironments
+import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 
 data class RunConfigGuard(val executionId: Long) {
     var originEnv: Map<String, String> = LinkedHashMap()
@@ -24,7 +25,7 @@ class MirrordNpmExecutionListener : ExecutionListener {
         return env.runProfile::class.qualifiedName == "com.intellij.lang.javascript.buildTools.npm.rc.NpmRunConfiguration"
     }
 
-    private fun patchNpmEnv(wslDistribution: WSLDistribution?, env: ExecutionEnvironment) {
+    private fun patchNpmEnv(environment: MirrordEnvironment, env: ExecutionEnvironment) {
         val service = env.project.service<MirrordProjectService>()
 
         val executionGuard = executions[env.executionId]!!
@@ -32,7 +33,10 @@ class MirrordNpmExecutionListener : ExecutionListener {
         try {
             val runSettings = MirrordNpmMutableRunSettings.fromRunProfile(env.project, env.runProfile)
 
-            val executablePath = if (SystemInfo.isMac) {
+            // macOS strips DYLD_INSERT_LIBRARIES from signed binaries, so the CLI has to
+            // re-sign a copy. Keyed on the *target* now, not the IDE host: a Mac driving a Linux
+            // container needs no patching, and a Linux IDE driving a macOS target does.
+            val executablePath = if (environment.platform().isMac) {
                 runSettings.packageManagerPackagePath
             } else {
                 null
@@ -40,8 +44,7 @@ class MirrordNpmExecutionListener : ExecutionListener {
 
             executionGuard.originEnv = LinkedHashMap(runSettings.envs)
 
-            service.execManager.wrapper("JS", executionGuard.originEnv).apply {
-                wsl = wslDistribution
+            service.execManager.wrapper("JS", executionGuard.originEnv, environment).apply {
                 executable = executablePath
             }.start()?.let { executionInfo ->
                 var envs = (executionGuard.originEnv + executionInfo.environment)
@@ -92,12 +95,11 @@ class MirrordNpmExecutionListener : ExecutionListener {
 
         executions[env.executionId] = RunConfigGuard(env.executionId)
 
-        val wsl = when (val request = createEnvironmentRequest(env.runProfile, env.project)) {
-            is WslTargetEnvironmentRequest -> request.configuration.distribution!!
-            else -> null
-        }
+        val environment = MirrordEnvironments.resolve(
+            MirrordLaunchContext(env.project, createEnvironmentRequest(env.runProfile, env.project))
+        )
 
-        patchNpmEnv(wsl, env)
+        patchNpmEnv(environment, env)
 
         super.processStartScheduled(executorId, env)
     }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNpmExecutionListener.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordNpmExecutionListener.kt
@@ -3,12 +3,10 @@ package com.metalbear.mirrord
 import com.intellij.execution.ExecutionListener
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.execution.target.createEnvironmentRequest
 import com.intellij.openapi.components.service
-import com.intellij.openapi.util.SystemInfo
 import com.metalbear.mirrord.bifrost.MirrordEnvironment
 import com.metalbear.mirrord.bifrost.MirrordEnvironments
-import com.metalbear.mirrord.bifrost.MirrordLaunchContext
+import kotlinx.coroutines.CancellationException
 
 data class RunConfigGuard(val executionId: Long) {
     var originEnv: Map<String, String> = LinkedHashMap()
@@ -59,6 +57,11 @@ class MirrordNpmExecutionListener : ExecutionListener {
                     runSettings.packageManagerPackagePath = it
                 }
             }
+        } catch (e: CancellationException) {
+            // The user pressed Cancel. Let it travel; the platform aborts the launch quietly.
+            // Logging it through `logger.error` would raise an IDE error report naming mirrord as
+            // the plugin to blame for something the user asked for.
+            throw e
         } catch (e: Exception) {
             MirrordLogger.logger.error("mirrord failed to patch npm run: $e")
             service.notifier.notifyRichError("mirrord failed to patch npm run")
@@ -72,11 +75,17 @@ class MirrordNpmExecutionListener : ExecutionListener {
         try {
             runSettings.envs = executionGuard.originEnv
 
-            if (SystemInfo.isMac) {
-                executionGuard.originPackageManagerPackageRef?.let {
-                    runSettings.packageManagerPackageRef = it
-                }
+            // No host check here. originPackageManagerPackageRef is assigned only where
+            // patchedPath came back, and that only happens for a macOS *target*, so the null
+            // check below is already the correct and complete gate. Asking the IDE host instead
+            // would additionally skip the restore when a non-Mac host drives a macOS target,
+            // leaving the run configuration permanently pointed at the patched package manager.
+            executionGuard.originPackageManagerPackageRef?.let {
+                runSettings.packageManagerPackageRef = it
             }
+        } catch (e: CancellationException) {
+            // Cleanup runs in `finally`, so the run configuration is still restored.
+            throw e
         } catch (e: Exception) {
             MirrordLogger.logger.error("mirrord failed to clear npm run patch: $e")
             val service = env.project.service<MirrordProjectService>()
@@ -95,9 +104,7 @@ class MirrordNpmExecutionListener : ExecutionListener {
 
         executions[env.executionId] = RunConfigGuard(env.executionId)
 
-        val environment = MirrordEnvironments.resolve(
-            MirrordLaunchContext(env.project, createEnvironmentRequest(env.runProfile, env.project))
-        )
+        val environment = MirrordEnvironments.forRunProfile(env.project, env.runProfile)
 
         patchNpmEnv(environment, env)
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordPathManager.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordPathManager.kt
@@ -1,64 +1,57 @@
 package com.metalbear.mirrord
 
-import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.openapi.application.PathManager
-import com.intellij.openapi.util.SystemInfo
-import com.intellij.util.system.CpuArch
+import com.metalbear.mirrord.bifrost.HostPath
+import com.metalbear.mirrord.bifrost.MirrordTargetPlatform
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
 /**
- * For accessing to binaries stored in the plugin directory.
+ * Where a plugin-managed binary lives on the IDE host.
+ *
+ * These are always [HostPath]s. The plugin directory belongs to the IDE, so under a dev
+ * container nothing here is visible to the process mirrord is attaching to — use
+ * [com.metalbear.mirrord.bifrost.MirrordEnvironment.provide] to get a binary across.
  */
 object MirrordPathManager {
     private fun pluginDir(): Path = Paths.get(PathManager.getPluginsPath(), "mirrord")
 
     /**
-     * Resolves the on-disk path to a plugin-managed binary.
+     * The layout under the plugin directory for a binary built for [platform].
      *
-     * When [wslDistribution] is non-null on a Windows host, the target is a
-     * WSL distribution — a Linux binary is required, not `mirrord.exe`. WSL
-     * runs are treated like native Linux (linux folder, no `.exe`) regardless
-     * of host OS. Windows-native runs pass `wslDistribution = null`.
+     * Pure, so every combination is unit-tested. Note this asks the *target* platform, not the
+     * IDE host: a macOS host running a Linux container needs `bin/linux/x86-64/mirrord`, and the
+     * old `SystemInfo`-based version would have handed back a macOS build.
      */
-    fun getPath(name: String, universalOnMac: Boolean, wslDistribution: WSLDistribution? = null): Path {
-        val treatAsLinux = SystemInfo.isLinux || wslDistribution != null
-        val os = when {
-            treatAsLinux -> "linux"
-            SystemInfo.isMac -> "macos"
-            SystemInfo.isWindows -> "windows"
-            else -> throw RuntimeException("Unsupported platform: " + SystemInfo.OS_NAME)
+    fun binaryRelativePath(name: String, universalOnMac: Boolean, platform: MirrordTargetPlatform): String {
+        val binaryName = if (platform.isWindows) "$name.exe" else name
+        return if (platform.isMac && universalOnMac) {
+            // Darwin builds ship as one universal binary, so there is no architecture segment.
+            "bin/${platform.osDirectoryName}/$binaryName"
+        } else {
+            "bin/${platform.osDirectoryName}/${platform.archDirectoryName}/$binaryName"
         }
-
-        val arch = when {
-            // WSL inherits the host architecture on Windows, so CpuArch is the
-            // right proxy for both native Linux and Windows+WSL.
-            CpuArch.isIntel64() -> "x86-64"
-            CpuArch.isArm64() -> "arm64"
-            else -> throw RuntimeException("Unsupported architecture: " + CpuArch.CURRENT.name)
-        }
-
-        val binaryName = if (isWinNative(wslDistribution)) "$name.exe" else name
-
-        val format = when {
-            SystemInfo.isMac && universalOnMac -> "bin/$os/$binaryName"
-            else -> "bin/$os/$arch/$binaryName"
-        }
-
-        return pluginDir().resolve(format)
     }
 
-    /**
-     * Get matching binary based on platform and architecture. See [getPath]
-     * for the semantics of [wslDistribution].
-     */
-    fun getBinary(name: String, universalOnMac: Boolean, wslDistribution: WSLDistribution? = null): String? {
-        val binaryPath = this.getPath(name, universalOnMac, wslDistribution).takeIf { Files.exists(it) } ?: return null
+    /** Resolves the on-disk host path a binary for [platform] would occupy. */
+    fun getPath(name: String, universalOnMac: Boolean, platform: MirrordTargetPlatform): HostPath =
+        HostPath(pluginDir().resolve(binaryRelativePath(name, universalOnMac, platform)))
+
+    /** As [getPath], but null unless the file exists and could be made executable. */
+    fun getBinary(name: String, universalOnMac: Boolean, platform: MirrordTargetPlatform): HostPath? {
+        val binaryPath = getPath(name, universalOnMac, platform).path.takeIf { Files.exists(it) } ?: return null
         return if (Files.isExecutable(binaryPath) || binaryPath.toFile().setExecutable(true)) {
-            return binaryPath.toString()
+            HostPath(binaryPath)
         } else {
             null
         }
     }
+
+    /**
+     * For helper binaries that genuinely run on the IDE host rather than in the target — at
+     * present only Goland's `dlv`, which the IDE launches itself.
+     */
+    fun getHostBinary(name: String, universalOnMac: Boolean): HostPath? =
+        getBinary(name, universalOnMac, MirrordTargetPlatform.ofHost())
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordPitm.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordPitm.kt
@@ -12,10 +12,8 @@ import java.util.Base64
  * `mirrord.exe attach` for debug) should be used — that is, when the process being
  * injected runs on Windows.
  *
- * This asks about the *target*, not the IDE host, and the distinction is not academic: a Linux
- * container opened from a Windows IDE is not Windows-native, and a Windows target reached from
- * a Linux IDE is. The previous form (`SystemInfo.isWindows && wsl == null`) got both wrong,
- * because the only non-host environment it could name was WSL.
+ * This asks about the *target*, not the IDE host: a Linux container opened from a Windows IDE
+ * is not Windows-native, and a Windows target reached from a Linux IDE is.
  */
 val MirrordTargetPlatform.isWinNative: Boolean get() = isWindows
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordPitm.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordPitm.kt
@@ -17,7 +17,7 @@ import java.util.Base64
  * a Linux IDE is. The previous form (`SystemInfo.isWindows && wsl == null`) got both wrong,
  * because the only non-host environment it could name was WSL.
  */
-fun isWinNative(platform: MirrordTargetPlatform): Boolean = platform.isWindows
+val MirrordTargetPlatform.isWinNative: Boolean get() = isWindows
 
 /**
  * Helper for the `mirrord pitm` (Process In The Middle) Windows injection mode.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordPitm.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordPitm.kt
@@ -3,18 +3,21 @@ package com.metalbear.mirrord
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.execution.wsl.WSLDistribution
-import com.intellij.openapi.util.SystemInfo
+import com.metalbear.mirrord.bifrost.MirrordTargetPlatform
+import com.metalbear.mirrord.bifrost.TargetPath
 import java.util.Base64
 
 /**
  * True when mirrord's Windows-native injection path (`mirrord.exe pitm` for run,
- * `mirrord.exe attach` for debug) should be used. Requires an actual Windows host
- * AND no resolved WSL distribution — WSL targets use the Linux/LD_PRELOAD path
- * regardless of host OS.
+ * `mirrord.exe attach` for debug) should be used — that is, when the process being
+ * injected runs on Windows.
+ *
+ * This asks about the *target*, not the IDE host, and the distinction is not academic: a Linux
+ * container opened from a Windows IDE is not Windows-native, and a Windows target reached from
+ * a Linux IDE is. The previous form (`SystemInfo.isWindows && wsl == null`) got both wrong,
+ * because the only non-host environment it could name was WSL.
  */
-fun isWinNative(wsl: WSLDistribution?): Boolean =
-    SystemInfo.isWindows && wsl == null
+fun isWinNative(platform: MirrordTargetPlatform): Boolean = platform.isWindows
 
 /**
  * Helper for the `mirrord pitm` (Process In The Middle) Windows injection mode.
@@ -45,7 +48,7 @@ object MirrordPitm {
      */
     fun wrapCommandLine(
         commandLine: GeneralCommandLine,
-        cliPath: String,
+        cliPath: TargetPath,
         mirrordEnvVars: Map<String, String>,
         envToUnset: List<String>?
     ) {
@@ -74,7 +77,7 @@ object MirrordPitm {
         val originalExe = commandLine.exePath
         val originalArgs = commandLine.parametersList.list.toList()
 
-        commandLine.exePath = cliPath
+        commandLine.exePath = cliPath.value
         commandLine.parametersList.clearAll()
         commandLine.addParameters("pitm", "--", originalExe)
         commandLine.addParameters(originalArgs)

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsComponent.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsComponent.kt
@@ -66,6 +66,13 @@ class MirrordSettingsComponent {
             }
         }
 
+    private val useLegacyWsl = JBCheckBox("Use legacy WSL integration")
+        .apply {
+            toolTipText = "WSL normally runs through the IDE's execution environment layer, the same path " +
+                "Dev Containers use. Turn this on only if a WSL setup stops working after an update — " +
+                "it restores the previous wsl.exe integration. Has no effect outside WSL."
+        }
+
     private val autoUpdatePanel = FormBuilder
         .createFormBuilder()
         .addComponent(autoUpdate)
@@ -85,6 +92,7 @@ class MirrordSettingsComponent {
         .addSeparator()
         .addComponent(troubleshootingLogsEnabled)
         .addLabeledComponent(troubleshootingLogsPathLabel, troubleshootingLogsPath)
+        .addComponent(useLegacyWsl)
         .addSeparator()
         .addComponent(JBLabel("Notify when:"))
         .apply {
@@ -163,5 +171,11 @@ class MirrordSettingsComponent {
         get() = troubleshootingLogsPath.text.trim()
         set(value) {
             troubleshootingLogsPath.text = value.trim()
+        }
+
+    var useLegacyWslStatus: Boolean
+        get() = useLegacyWsl.isSelected
+        set(value) {
+            useLegacyWsl.isSelected = value
         }
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsConfigurable.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsConfigurable.kt
@@ -24,7 +24,8 @@ class MirrordSettingsConfigurable : Configurable {
                 (enabledOnStartupStatus != settings.enabledByDefault) ||
                 (taskTimeoutMinutesStatus != settings.taskTimeoutMinutes) ||
                 (troubleshootingLogsEnabledStatus != settings.troubleshootingLogsEnabled) ||
-                (troubleshootingLogsPathStatus != settings.troubleshootingLogsPath)
+                (troubleshootingLogsPathStatus != settings.troubleshootingLogsPath) ||
+                (useLegacyWslStatus != settings.useLegacyWsl)
         }
     }
 
@@ -41,6 +42,7 @@ class MirrordSettingsConfigurable : Configurable {
             settings.taskTimeoutMinutes = taskTimeoutMinutesStatus
             settings.troubleshootingLogsEnabled = troubleshootingLogsEnabledStatus
             settings.troubleshootingLogsPath = troubleshootingLogsPathStatus
+            settings.useLegacyWsl = useLegacyWslStatus
         }
     }
 
@@ -57,6 +59,7 @@ class MirrordSettingsConfigurable : Configurable {
             taskTimeoutMinutesStatus = settings.taskTimeoutMinutes
             troubleshootingLogsEnabledStatus = settings.troubleshootingLogsEnabled
             troubleshootingLogsPathStatus = settings.troubleshootingLogsPath
+            useLegacyWslStatus = settings.useLegacyWsl
         }
     }
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsState.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsState.kt
@@ -74,6 +74,19 @@ open class MirrordSettingsState : PersistentStateComponent<MirrordSettingsState.
         /** When on, every mirrord run enables trace logging in mirrord's processes. */
         var troubleshootingLogsEnabled: Boolean = false
 
+        /**
+         * Opt out of running WSL through the IntelliJ Platform's execution environment layer
+         * (EEL) and fall back to the legacy `wsl.exe` integration.
+         *
+         * WSL normally goes through EEL, the same mechanism that makes Dev Containers work,
+         * so there is one code path for every non-local environment. This flag exists purely
+         * as an escape hatch: if a WSL setup regresses under EEL, turning this on restores the
+         * previous `getWslPath` + `patchCommandLine` behaviour without downgrading the plugin.
+         *
+         * Expected to be removed once EEL-backed WSL has been validated across enough setups.
+         */
+        var useLegacyWsl: Boolean = false
+
         /** Directory the layer writes its per-process trace log into ([MIRRORD_LAYER_LOG_PATH_ENV]). */
         var troubleshootingLogsPath: String = ""
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsState.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordSettingsState.kt
@@ -52,7 +52,8 @@ open class MirrordSettingsState : PersistentStateComponent<MirrordSettingsState.
         SLACK_INVITE("mirrord offers a Slack server invitation"),
         MIRRORD_FOR_TEAMS("mirrord occasionally informs about mirrord for Teams"),
         NEWSLETTER_SIGNUP("mirrord occasionally informs about the mirrord newsletter"),
-        MIRRORD_BINARY_PATH_INVALID("custom mirrord binary path is invalid or not executable")
+        MIRRORD_BINARY_PATH_INVALID("custom mirrord binary path is invalid or not executable"),
+        LARGE_BINARY_STAGED("a large mirrord binary is copied into the target environment")
     }
 
     class MirrordState {

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/EelEnvironment.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/EelEnvironment.kt
@@ -22,13 +22,24 @@ import java.nio.file.attribute.PosixFilePermission
 import java.util.UUID
 
 /**
- * The one implementation that carries everything: local, WSL, Docker, dev containers, SSH.
+ * Runs a fixed set of operations against whichever environment a project lives in — local, WSL,
+ * Docker, a dev container, or SSH — so that callers never branch on which one it is.
  *
- * There is deliberately no `if (descriptor is LocalEelDescriptor)` branch on the main path.
- * JetBrains document that check as an anti-pattern, and converting a local descriptor is
- * instant and does no I/O, so a special case would buy a second code path to maintain and
- * nothing else. [isLocal] exists only for the two things they do sanction — work that belongs
- * on the IDE host, and port forwarding.
+ * | Member | What it does |
+ * |---|---|
+ * | [platform] | OS and architecture of the target |
+ * | [resolve] | host path to target path |
+ * | [provide] | copy a host file across, if the target cannot already see it |
+ * | [locate] | find an executable on the target's `PATH` |
+ * | [spawn] | start a process at the target |
+ * | [probe] | run a short command and wait for it |
+ *
+ * All of it goes through [EelApi], the platform's own abstraction over these environments.
+ *
+ * There is no `if (descriptor is LocalEelDescriptor)` branch on the main path. JetBrains
+ * document that check as an anti-pattern, and converting a local descriptor does no I/O, so the
+ * special case would add a second code path and nothing else. [isLocal] exists for the two
+ * things they do sanction: work that belongs on the IDE host, and port forwarding.
  */
 class EelEnvironment(
     private val descriptor: EelDescriptor,
@@ -39,10 +50,7 @@ class EelEnvironment(
 
     override val isLocal: Boolean = descriptor === LocalEelDescriptor
 
-    /**
-     * The first crossing may start and deploy an agent, so it is done once and reused. Every
-     * later call is cheap.
-     */
+    /** The first crossing can start and deploy an agent, so it is done once and reused. */
     private val api: EelApi by lazy {
         tracer.crossing("connect", name) { descriptor.toEelApi() }
     }
@@ -57,17 +65,19 @@ class EelEnvironment(
     }
 
     /**
-     * The target's own environment.
+     * The environment variables a login shell would see at the target.
      *
-     * This is load-bearing and easy to miss. `EelExecApi` takes the *complete* environment for a
-     * process — unlike `GeneralCommandLine`, which defaults to inheriting the parent's. Passing
-     * only mirrord's own variables would compile perfectly and then strip `PATH`, `HOME` and
-     * `KUBECONFIG` from the CLI, so every Kubernetes call would fail with an authentication
-     * error that looks nothing like its cause.
+     * Read with `EelExecApi.fetchLoginShellEnvVariables`, which starts a login shell there and
+     * returns its full variable set. See `EelExecApi` in `com.intellij.platform.eel`.
+     *
+     * Every spawn needs this. `EelExecApi` takes the *complete* environment for a process, where
+     * `GeneralCommandLine` inherits the parent's by default. Passing only mirrord's own variables
+     * compiles, then strips `PATH`, `HOME` and `KUBECONFIG` from the CLI, and every Kubernetes
+     * call fails with an authentication error that looks nothing like its cause.
      */
-    private val baseEnvironment: Map<String, String> by lazy {
+    private val targetEnvVariables: Map<String, String> by lazy {
         tracer.crossing("fetch-env", name) { api.exec.fetchLoginShellEnvVariables() }.also {
-            MirrordLogger.logger.info("mirrord.bifrost: base environment resolved vars=${it.size} env=$name")
+            MirrordLogger.logger.info("mirrord.bifrost: target env variables resolved vars=${it.size} env=$name")
         }
     }
 
@@ -86,25 +96,19 @@ class EelEnvironment(
         }
 
     /**
-     * Content-addressed staging: the SHA-256 of the file is part of its destination path.
+     * Provides a file to the target environment, hashing its contents with SHA-256 so that
+     * needless copies do not happen.
      *
-     * A version-keyed path would be wrong for the case that matters most day to day — rebuilding
-     * mirrord locally produces different bytes under the same version string, and the stale copy
-     * would win silently. Hashing the content makes that impossible, and makes the cache check a
-     * single `exists` rather than a re-read of ~100 MB.
-     *
-     * Windows targets fall back to an uncached temporary copy: there is no `/tmp` to anchor a
-     * stable path to, and the dev-container case this exists for is POSIX.
+     * The hash is part of the destination path. That way one hash answers the question, instead
+     * of hashing both the file to stage and whatever is already staged there.
      */
     override fun provide(path: HostPath, name: String, onCopy: (Long) -> Unit): TargetPath {
-        // Already visible from the target? Then nothing needs to move — true for local, and for
-        // WSL via the UNC root, so only containers ever pay for a transfer.
+        // Nothing moves if the target can already see the file. That covers local, and WSL
+        // through the UNC root, so only containers pay for a transfer.
         //
-        // The existence check is the load-bearing part. `resolve` only says whether a path can
-        // be *expressed* in the target's terms, not whether the file is actually there: for a
-        // dev container it will cheerfully hand back a host path that exists nowhere inside the
-        // container. Trusting it skipped the transfer entirely and left mirrord looking for a
-        // 73 MB binary that had never been copied across.
+        // The existence check is what makes this correct. `resolve` says only whether a path can
+        // be *expressed* in the target's terms, not whether the file is there — for a dev
+        // container it hands back a host path that exists nowhere inside the container.
         runCatching { resolve(path) }.getOrNull()?.let { candidate ->
             val reachable = runCatching {
                 Files.exists(EelPath.parse(candidate.value, descriptor).asNioPath())
@@ -121,7 +125,8 @@ class EelEnvironment(
 
         if (platform().isWindows) {
             return tracer.crossing("provide", this.name) {
-                // No permission step: Windows targets have no POSIX mode bits to set.
+                // Uncached, and no permission step: a Windows target has no `/tmp` to anchor a
+                // stable path to, and no POSIX mode bits to set.
                 val copied = EelTransferCompat.transferLocalContentToRemote(
                     path.path,
                     EelPathUtils.TransferTarget.Temporary(descriptor)
@@ -149,18 +154,15 @@ class EelEnvironment(
             )
             onCopy(bytes)
 
-            // An explicit transfer target writes the file but will not create the directories
-            // leading to it, so a first copy into a fresh container fails with NoSuchFileException
-            // on a path that reads as though the *source* were missing. These are routed paths, so
-            // this creates the directory inside the target.
+            // Make sure the parent directories exist. An explicit transfer target writes the
+            // file but does not create them, and the path is routed, so this runs in the target.
             Files.createDirectories(destinationNio.parent)
 
-            // Transfer to a unique temporary name and move it into place. The cache check above is
-            // only `exists`, so a transfer interrupted by a timeout, a cancel, or a container
-            // restart would otherwise leave a truncated file at the content-addressed path — where
-            // it is served as a valid cache hit forever, because the hash names the *source*
-            // bytes and never gets re-verified. `updateBinary` already writes host-side files this
-            // way; the target side needs the same guarantee.
+            // We first move to a temporary path, and after we are sure the move succeeded, move
+            // to the true target path, to prevent incomplete host-to-remote transfers.
+            //
+            // The cache check above is only `exists`, so a truncated file left at the
+            // content-addressed path would be served as a cache hit forever.
             val staging = destinationNio.resolveSibling("$name.${UUID.randomUUID()}.partial")
             try {
                 EelTransferCompat.transferLocalContentToRemote(
@@ -175,6 +177,7 @@ class EelEnvironment(
                     }
                     .getOrThrow()
             } catch (e: Throwable) {
+                // If any step failed, delete the temporary file too.
                 runCatching { Files.deleteIfExists(staging) }
                 throw e
             }
@@ -182,24 +185,31 @@ class EelEnvironment(
         }
     }
 
+    /** `EelExecApi.findExeFilesInPath` is the platform's own `which`, run at the target. */
+    override fun locate(executable: String): TargetPath? =
+        tracer.crossing("locate", name) { api.exec.findExeFilesInPath(executable) }
+            .firstOrNull()
+            ?.let { TargetPath(it.toString()) }
+
+    /** The EEL process is converted to a plain [Process], so nothing downstream knows the difference. */
     override fun spawn(spec: MirrordProcessSpec): Process =
         tracer.crossing("spawn", name) {
             api.exec.spawnProcess(spec.executable.value)
                 .args(spec.args)
-                .env(baseEnvironment + spec.env)
+                .env(targetEnvVariables + spec.env)
                 .apply { spec.workingDirectory?.let { workingDirectory(EelPath.parse(it.value, descriptor)) } }
                 .eelIt()
         }.convertToJavaProcess().also {
             MirrordLogger.logger.info("mirrord.bifrost: spawned ${spec.describe()} env=$name side=${if (isLocal) "host" else "target"}")
         }
 
+    /** Runs a short command at the target and waits for it. */
     override fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): ProcessOutput {
         val spec = MirrordProcessSpec(executable, args, emptyMap(), null)
 
-        // `CapturingProcessHandler` drains both pipes concurrently and enforces the timeout. Doing
-        // it by hand needs two reader threads to avoid the deadlock where a child fills the stderr
-        // pipe while this side is still reading stdout — and reading stdout to EOF first makes the
-        // timeout unreachable, because that read blocks until the child exits.
+        // `CapturingProcessHandler` drains both pipes at once and enforces the timeout. By hand
+        // this needs two reader threads: a child that fills the stderr pipe while this side reads
+        // stdout deadlocks, and reading stdout to EOF first blocks until the child exits.
         val output = CapturingProcessHandler(spawn(spec), StandardCharsets.UTF_8, spec.describe())
             .runProcess(timeoutMillis.toInt())
 
@@ -212,17 +222,9 @@ class EelEnvironment(
     /**
      * Sets the mode bits on a freshly staged file.
      *
-     * Deliberately not done with the platform's transfer-attribute strategy. That type is
-     * `EelPathUtils.FileTransferAttributesStrategy` in 2026.1 but a top-level
-     * `EelFileTransferAttributesStrategy` in 2026.2, which changes the *method descriptor* of
-     * every `transferLocalContentToRemote` overload that accepts it. A plugin compiled against
-     * one build then dies on the other: compiled against 2026.1 and run on 2026.2, it raises
-     * `ClassNotFoundException` while staging the CLI into a dev container. This is the same
-     * 261/262 churn already noted for `EelUnavailableException` in [MirrordBifrostTracer].
-     *
-     * The two-argument overload is byte-identical across both builds, so the transfer uses that
-     * and the permissions are applied here. Doing it explicitly also removes the old ordering
-     * trap where the executable bit was set on a file that was about to be replaced.
+     * **EEL COMPAT 261/262** — the platform's transfer-attribute strategy type moved between
+     * builds, so the transfer goes through `EelTransferCompat` and the permissions are set here
+     * instead. See `EelTransferCompat` for the full account.
      */
     private fun makeExecutable(target: Path) {
         runCatching { Files.setPosixFilePermissions(target, EXECUTABLE_PERMISSIONS) }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/EelEnvironment.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/EelEnvironment.kt
@@ -92,11 +92,26 @@ class EelEnvironment(
      * stable path to, and the dev-container case this exists for is POSIX.
      */
     override fun provide(path: HostPath, name: String): TargetPath {
-        // Already visible from the target? Then nothing needs to move. True for local, and for
+        // Already visible from the target? Then nothing needs to move — true for local, and for
         // WSL via the UNC root, so only containers ever pay for a transfer.
-        runCatching { resolve(path) }.getOrNull()?.let {
-            MirrordLogger.logger.info("mirrord.bifrost: provide VISIBLE name=$name target=$it env=${this.name}")
-            return it
+        //
+        // The existence check is the load-bearing part. `resolve` only says whether a path can
+        // be *expressed* in the target's terms, not whether the file is actually there: for a
+        // dev container it will cheerfully hand back a host path that exists nowhere inside the
+        // container. Trusting it skipped the transfer entirely and left mirrord looking for a
+        // 73 MB binary that had never been copied across.
+        runCatching { resolve(path) }.getOrNull()?.let { candidate ->
+            val reachable = runCatching {
+                Files.exists(EelPath.parse(candidate.value, descriptor).asNioPath())
+            }.getOrDefault(false)
+
+            if (reachable) {
+                MirrordLogger.logger.info("mirrord.bifrost: provide VISIBLE name=$name target=$candidate env=${this.name}")
+                return candidate
+            }
+            MirrordLogger.logger.info(
+                "mirrord.bifrost: provide NOT-VISIBLE name=$name candidate=$candidate env=${this.name} — staging a copy"
+            )
         }
 
         val strategy = EelPathUtils.FileTransferAttributesStrategy.copyWithRequiredPosixPermissions(
@@ -136,6 +151,11 @@ class EelEnvironment(
                 "mirrord.bifrost: provide COPY name=$name sha=$digest host=$path target=$destination " +
                     "bytes=${runCatching { Files.size(path.path) }.getOrDefault(-1L)} env=${this.name}"
             )
+            // An explicit transfer target writes the file but will not create the directories
+            // leading to it, so a first copy into a fresh container fails with NoSuchFileException
+            // on a path that reads as though the *source* were missing. These are routed paths, so
+            // this creates the directory inside the target.
+            Files.createDirectories(destinationNio.parent)
             EelPathUtils.transferLocalContentToRemote(
                 path.path,
                 EelPathUtils.TransferTarget.Explicit(destinationNio),

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/EelEnvironment.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/EelEnvironment.kt
@@ -1,0 +1,183 @@
+package com.metalbear.mirrord.bifrost
+
+import com.intellij.platform.eel.EelApi
+import com.intellij.platform.eel.EelDescriptor
+import com.intellij.platform.eel.path.EelPath
+import com.intellij.platform.eel.provider.LocalEelDescriptor
+import com.intellij.platform.eel.provider.asEelPath
+import com.intellij.platform.eel.provider.asNioPath
+import com.intellij.platform.eel.provider.toEelApi
+import com.intellij.platform.eel.provider.utils.EelPathUtils
+import com.intellij.platform.eel.spawnProcess
+import com.metalbear.mirrord.MirrordError
+import com.metalbear.mirrord.MirrordLogger
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
+import java.security.MessageDigest
+import java.util.concurrent.TimeUnit
+
+/**
+ * The one implementation that carries everything: local, WSL, Docker, dev containers, SSH.
+ *
+ * There is deliberately no `if (descriptor is LocalEelDescriptor)` branch on the main path.
+ * JetBrains document that check as an anti-pattern, and converting a local descriptor is
+ * instant and does no I/O, so a special case would buy a second code path to maintain and
+ * nothing else. [isLocal] exists only for the two things they do sanction — work that belongs
+ * on the IDE host, and port forwarding.
+ */
+class EelEnvironment(
+    private val descriptor: EelDescriptor,
+    private val tracer: MirrordBifrostTracer = MirrordBifrostTracer.shared
+) : MirrordEnvironment {
+
+    override val name: String = descriptor.name
+
+    override val isLocal: Boolean = descriptor === LocalEelDescriptor
+
+    /**
+     * The first crossing may start and deploy an agent, so it is done once and reused. Every
+     * later call is cheap.
+     */
+    private val api: EelApi by lazy {
+        tracer.crossing("connect", name) { descriptor.toEelApi() }
+    }
+
+    private val cachedPlatform: MirrordTargetPlatform by lazy {
+        MirrordTargetPlatform.fromEel(api.platform).also {
+            MirrordLogger.logger.info(
+                "mirrord.bifrost: platform target=$it host=${MirrordTargetPlatform.ofHost()} " +
+                    "mismatch=${it != MirrordTargetPlatform.ofHost()} env=$name"
+            )
+        }
+    }
+
+    /**
+     * The target's own environment.
+     *
+     * This is load-bearing and easy to miss. `EelExecApi` takes the *complete* environment for a
+     * process — unlike `GeneralCommandLine`, which defaults to inheriting the parent's. Passing
+     * only mirrord's own variables would compile perfectly and then strip `PATH`, `HOME` and
+     * `KUBECONFIG` from the CLI, so every Kubernetes call would fail with an authentication
+     * error that looks nothing like its cause.
+     */
+    private val baseEnvironment: Map<String, String> by lazy {
+        tracer.crossing("fetch-env", name) { api.exec.fetchLoginShellEnvVariables() }.also {
+            MirrordLogger.logger.info("mirrord.bifrost: base environment resolved vars=${it.size} env=$name")
+        }
+    }
+
+    override fun platform(): MirrordTargetPlatform = cachedPlatform
+
+    override fun resolve(path: HostPath): TargetPath =
+        try {
+            TargetPath(path.path.asEelPath().toString())
+        } catch (e: Throwable) {
+            throw MirrordError(
+                "mirrord cannot see `$path` from $name.",
+                "The file has to be reachable from the environment mirrord runs in. If it lives " +
+                    "outside the project, move it inside or point mirrord at a copy that does.",
+                e
+            )
+        }
+
+    /**
+     * Content-addressed staging: the SHA-256 of the file is part of its destination path.
+     *
+     * A version-keyed path would be wrong for the case that matters most day to day — rebuilding
+     * mirrord locally produces different bytes under the same version string, and the stale copy
+     * would win silently. Hashing the content makes that impossible, and makes the cache check a
+     * single `exists` rather than a re-read of ~100 MB.
+     *
+     * Windows targets fall back to an uncached temporary copy: there is no `/tmp` to anchor a
+     * stable path to, and the dev-container case this exists for is POSIX.
+     */
+    override fun provide(path: HostPath, name: String): TargetPath {
+        // Already visible from the target? Then nothing needs to move. True for local, and for
+        // WSL via the UNC root, so only containers ever pay for a transfer.
+        runCatching { resolve(path) }.getOrNull()?.let {
+            MirrordLogger.logger.info("mirrord.bifrost: provide VISIBLE name=$name target=$it env=${this.name}")
+            return it
+        }
+
+        val strategy = EelPathUtils.FileTransferAttributesStrategy.copyWithRequiredPosixPermissions(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_EXECUTE,
+            PosixFilePermission.GROUP_READ,
+            PosixFilePermission.GROUP_EXECUTE,
+            PosixFilePermission.OTHERS_READ,
+            PosixFilePermission.OTHERS_EXECUTE
+        )
+
+        if (platform().isWindows) {
+            return tracer.crossing("provide", this.name) {
+                val copied = EelPathUtils.transferLocalContentToRemote(
+                    path.path,
+                    EelPathUtils.TransferTarget.Temporary(descriptor),
+                    strategy
+                )
+                TargetPath(copied.asEelPath().toString())
+            }
+        }
+
+        val digest = sha256Prefix(path)
+        val destination = EelPath.parse("/tmp/mirrord-ide/$digest/$name", descriptor)
+        val destinationNio = destination.asNioPath()
+
+        if (tracer.crossing("provide-check", this.name) { Files.exists(destinationNio) }) {
+            MirrordLogger.logger.info(
+                "mirrord.bifrost: provide CACHED name=$name sha=$digest target=$destination env=${this.name}"
+            )
+            return TargetPath(destination.toString())
+        }
+
+        return tracer.crossing("provide", this.name) {
+            MirrordLogger.logger.info(
+                "mirrord.bifrost: provide COPY name=$name sha=$digest host=$path target=$destination " +
+                    "bytes=${runCatching { Files.size(path.path) }.getOrDefault(-1L)} env=${this.name}"
+            )
+            EelPathUtils.transferLocalContentToRemote(
+                path.path,
+                EelPathUtils.TransferTarget.Explicit(destinationNio),
+                strategy
+            )
+            TargetPath(destination.toString())
+        }
+    }
+
+    override fun spawn(spec: MirrordProcessSpec): Process =
+        tracer.crossing("spawn", name) {
+            api.exec.spawnProcess(spec.executable.value)
+                .args(spec.args)
+                .env(baseEnvironment + spec.env)
+                .apply { spec.workingDirectory?.let { workingDirectory(EelPath.parse(it.value, descriptor)) } }
+                .eelIt()
+        }.convertToJavaProcess().also {
+            MirrordLogger.logger.info("mirrord.bifrost: spawned ${spec.describe()} env=$name side=${if (isLocal) "host" else "target"}")
+        }
+
+    override fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): MirrordProbeOutput {
+        val process = spawn(MirrordProcessSpec(executable, args, emptyMap(), null))
+        val stdout = process.inputStream.bufferedReader().readText()
+        val stderr = process.errorStream.bufferedReader().readText()
+        val finished = process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)
+        if (!finished) {
+            process.destroyForcibly()
+            throw MirrordError("`$executable ${args.joinToString(" ")}` did not finish within ${timeoutMillis}ms in $name")
+        }
+        return MirrordProbeOutput(process.exitValue(), stdout, stderr)
+    }
+
+    private fun sha256Prefix(path: HostPath): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        Files.newInputStream(path.path).use { stream ->
+            val buffer = ByteArray(1 shl 16)
+            while (true) {
+                val read = stream.read(buffer)
+                if (read <= 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }.take(16)
+    }
+}

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/EelEnvironment.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/EelEnvironment.kt
@@ -1,5 +1,7 @@
 package com.metalbear.mirrord.bifrost
 
+import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.execution.process.ProcessOutput
 import com.intellij.platform.eel.EelApi
 import com.intellij.platform.eel.EelDescriptor
 import com.intellij.platform.eel.path.EelPath
@@ -9,12 +11,15 @@ import com.intellij.platform.eel.provider.asNioPath
 import com.intellij.platform.eel.provider.toEelApi
 import com.intellij.platform.eel.provider.utils.EelPathUtils
 import com.intellij.platform.eel.spawnProcess
+import com.intellij.util.io.sha256Hex
 import com.metalbear.mirrord.MirrordError
 import com.metalbear.mirrord.MirrordLogger
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.PosixFilePermission
-import java.security.MessageDigest
-import java.util.concurrent.TimeUnit
+import java.util.UUID
 
 /**
  * The one implementation that carries everything: local, WSL, Docker, dev containers, SSH.
@@ -91,7 +96,7 @@ class EelEnvironment(
      * Windows targets fall back to an uncached temporary copy: there is no `/tmp` to anchor a
      * stable path to, and the dev-container case this exists for is POSIX.
      */
-    override fun provide(path: HostPath, name: String): TargetPath {
+    override fun provide(path: HostPath, name: String, onCopy: (Long) -> Unit): TargetPath {
         // Already visible from the target? Then nothing needs to move — true for local, and for
         // WSL via the UNC root, so only containers ever pay for a transfer.
         //
@@ -114,22 +119,12 @@ class EelEnvironment(
             )
         }
 
-        val strategy = EelPathUtils.FileTransferAttributesStrategy.copyWithRequiredPosixPermissions(
-            PosixFilePermission.OWNER_READ,
-            PosixFilePermission.OWNER_WRITE,
-            PosixFilePermission.OWNER_EXECUTE,
-            PosixFilePermission.GROUP_READ,
-            PosixFilePermission.GROUP_EXECUTE,
-            PosixFilePermission.OTHERS_READ,
-            PosixFilePermission.OTHERS_EXECUTE
-        )
-
         if (platform().isWindows) {
             return tracer.crossing("provide", this.name) {
-                val copied = EelPathUtils.transferLocalContentToRemote(
+                // No permission step: Windows targets have no POSIX mode bits to set.
+                val copied = EelTransferCompat.transferLocalContentToRemote(
                     path.path,
-                    EelPathUtils.TransferTarget.Temporary(descriptor),
-                    strategy
+                    EelPathUtils.TransferTarget.Temporary(descriptor)
                 )
                 TargetPath(copied.asEelPath().toString())
             }
@@ -147,20 +142,42 @@ class EelEnvironment(
         }
 
         return tracer.crossing("provide", this.name) {
+            val bytes = runCatching { Files.size(path.path) }.getOrDefault(-1L)
             MirrordLogger.logger.info(
                 "mirrord.bifrost: provide COPY name=$name sha=$digest host=$path target=$destination " +
-                    "bytes=${runCatching { Files.size(path.path) }.getOrDefault(-1L)} env=${this.name}"
+                    "bytes=$bytes env=${this.name}"
             )
+            onCopy(bytes)
+
             // An explicit transfer target writes the file but will not create the directories
             // leading to it, so a first copy into a fresh container fails with NoSuchFileException
             // on a path that reads as though the *source* were missing. These are routed paths, so
             // this creates the directory inside the target.
             Files.createDirectories(destinationNio.parent)
-            EelPathUtils.transferLocalContentToRemote(
-                path.path,
-                EelPathUtils.TransferTarget.Explicit(destinationNio),
-                strategy
-            )
+
+            // Transfer to a unique temporary name and move it into place. The cache check above is
+            // only `exists`, so a transfer interrupted by a timeout, a cancel, or a container
+            // restart would otherwise leave a truncated file at the content-addressed path — where
+            // it is served as a valid cache hit forever, because the hash names the *source*
+            // bytes and never gets re-verified. `updateBinary` already writes host-side files this
+            // way; the target side needs the same guarantee.
+            val staging = destinationNio.resolveSibling("$name.${UUID.randomUUID()}.partial")
+            try {
+                EelTransferCompat.transferLocalContentToRemote(
+                    path.path,
+                    EelPathUtils.TransferTarget.Explicit(staging)
+                )
+                // Before the move, so the file is never visible at its final path without the bit.
+                makeExecutable(staging)
+                runCatching { Files.move(staging, destinationNio, StandardCopyOption.ATOMIC_MOVE) }
+                    .recoverCatching {
+                        Files.move(staging, destinationNio, StandardCopyOption.REPLACE_EXISTING)
+                    }
+                    .getOrThrow()
+            } catch (e: Throwable) {
+                runCatching { Files.deleteIfExists(staging) }
+                throw e
+            }
             TargetPath(destination.toString())
         }
     }
@@ -176,28 +193,60 @@ class EelEnvironment(
             MirrordLogger.logger.info("mirrord.bifrost: spawned ${spec.describe()} env=$name side=${if (isLocal) "host" else "target"}")
         }
 
-    override fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): MirrordProbeOutput {
-        val process = spawn(MirrordProcessSpec(executable, args, emptyMap(), null))
-        val stdout = process.inputStream.bufferedReader().readText()
-        val stderr = process.errorStream.bufferedReader().readText()
-        val finished = process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)
-        if (!finished) {
-            process.destroyForcibly()
+    override fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): ProcessOutput {
+        val spec = MirrordProcessSpec(executable, args, emptyMap(), null)
+
+        // `CapturingProcessHandler` drains both pipes concurrently and enforces the timeout. Doing
+        // it by hand needs two reader threads to avoid the deadlock where a child fills the stderr
+        // pipe while this side is still reading stdout — and reading stdout to EOF first makes the
+        // timeout unreachable, because that read blocks until the child exits.
+        val output = CapturingProcessHandler(spawn(spec), StandardCharsets.UTF_8, spec.describe())
+            .runProcess(timeoutMillis.toInt())
+
+        if (output.isTimeout) {
             throw MirrordError("`$executable ${args.joinToString(" ")}` did not finish within ${timeoutMillis}ms in $name")
         }
-        return MirrordProbeOutput(process.exitValue(), stdout, stderr)
+        return output
     }
 
-    private fun sha256Prefix(path: HostPath): String {
-        val digest = MessageDigest.getInstance("SHA-256")
-        Files.newInputStream(path.path).use { stream ->
-            val buffer = ByteArray(1 shl 16)
-            while (true) {
-                val read = stream.read(buffer)
-                if (read <= 0) break
-                digest.update(buffer, 0, read)
+    /**
+     * Sets the mode bits on a freshly staged file.
+     *
+     * Deliberately not done with the platform's transfer-attribute strategy. That type is
+     * `EelPathUtils.FileTransferAttributesStrategy` in 2026.1 but a top-level
+     * `EelFileTransferAttributesStrategy` in 2026.2, which changes the *method descriptor* of
+     * every `transferLocalContentToRemote` overload that accepts it. A plugin compiled against
+     * one build then dies on the other: compiled against 2026.1 and run on 2026.2, it raises
+     * `ClassNotFoundException` while staging the CLI into a dev container. This is the same
+     * 261/262 churn already noted for `EelUnavailableException` in [MirrordBifrostTracer].
+     *
+     * The two-argument overload is byte-identical across both builds, so the transfer uses that
+     * and the permissions are applied here. Doing it explicitly also removes the old ordering
+     * trap where the executable bit was set on a file that was about to be replaced.
+     */
+    private fun makeExecutable(target: Path) {
+        runCatching { Files.setPosixFilePermissions(target, EXECUTABLE_PERMISSIONS) }
+            .onFailure {
+                MirrordLogger.logger.warn(
+                    "mirrord.bifrost: could not set the executable bit on $target in $name — " +
+                        "mirrord will not be runnable there",
+                    it
+                )
             }
-        }
-        return digest.digest().joinToString("") { "%02x".format(it) }.take(16)
+    }
+
+    private fun sha256Prefix(path: HostPath): String = sha256Hex(path.path).take(16)
+
+    private companion object {
+        /** 0755 — the staged CLI must be runnable by whichever user the target runs as. */
+        val EXECUTABLE_PERMISSIONS: Set<PosixFilePermission> = setOf(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_EXECUTE,
+            PosixFilePermission.GROUP_READ,
+            PosixFilePermission.GROUP_EXECUTE,
+            PosixFilePermission.OTHERS_READ,
+            PosixFilePermission.OTHERS_EXECUTE
+        )
     }
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/LegacyWslEnvironment.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/LegacyWslEnvironment.kt
@@ -8,18 +8,16 @@ import com.intellij.openapi.project.Project
 import com.metalbear.mirrord.MirrordLogger
 
 /**
- * The old road, kept open beside the bridge.
+ * The `wsl.exe` integration that shipped before EEL, behind the "Use legacy WSL integration"
+ * setting.
  *
- * WSL runs through [EelEnvironment] by default now. This exists purely as an escape hatch: if a
- * WSL setup regresses under EEL, the user flips "Use legacy WSL integration" in settings and
- * gets exactly the behaviour they had before, without downgrading the plugin.
+ * WSL runs through [EelEnvironment] by default now. This is the escape hatch: if a WSL setup
+ * regresses under EEL, the user turns the setting on and gets the previous behaviour back
+ * without downgrading the plugin.
  *
- * Every line here is lifted from the code it replaces, deliberately unimproved. `getWslPath` is
- * still the deprecated `String` overload, the command-line options are still the same two flags,
- * and probes still go through `executeOnWsl`. Tidying any of it would make this a *different*
- * implementation, which is the one thing it must not be — WSL has no test coverage on Linux, so
- * "identical to what shipped" is the only guarantee available. Delete the whole file once
- * EEL-backed WSL has been validated on a Windows machine.
+ * Every line here is lifted from the code it replaces and left unimproved, because "identical to
+ * what shipped" is the only guarantee available — WSL has no test coverage on Linux. Delete the
+ * file once EEL-backed WSL is validated on a Windows machine.
  */
 class LegacyWslEnvironment(
     private val distribution: WSLDistribution,
@@ -30,10 +28,7 @@ class LegacyWslEnvironment(
 
     override val isLocal: Boolean = false
 
-    /**
-     * WSL always runs Linux, on the host's architecture — which is what the old
-     * `treatAsLinux = SystemInfo.isLinux || wsl != null` plus `CpuArch.CURRENT` amounted to.
-     */
+    /** WSL always runs Linux, on the host's architecture. */
     override fun platform(): MirrordTargetPlatform =
         MirrordTargetPlatform(MirrordTargetOs.LINUX, MirrordTargetPlatform.ofHost().arch)
 
@@ -41,15 +36,22 @@ class LegacyWslEnvironment(
     @Suppress("DEPRECATION")
     override fun resolve(path: HostPath): TargetPath {
         val raw = path.path.toString()
-        // The String overload, not the Path one. They are equivalent today, but the deprecated
-        // one is what shipped and what MirrordWslCharacterizationTest pins.
+        // The String overload, not the Path one. Equivalent today, but the deprecated one is
+        // what shipped and what MirrordWslCharacterizationTest pins.
         return TargetPath(distribution.getWslPath(raw) ?: raw)
     }
 
-    /** WSL sees the host filesystem under /mnt, so nothing is ever copied. */
-    // No `onCopy`: WSL reaches the host filesystem through /mnt, so this is a path
-    // translation and no bytes move.
+    /** WSL reaches the host filesystem under /mnt, so this translates a path and copies nothing. */
     override fun provide(path: HostPath, name: String, onCopy: (Long) -> Unit): TargetPath = resolve(path)
+
+    /** Was `which <executable>` through `executeOnWsl`. Kept, so WSL behaviour does not move. */
+    override fun locate(executable: String): TargetPath? =
+        probe(TargetPath("which"), listOf(executable), LOCATE_TIMEOUT_MILLIS)
+            .stdout
+            .lineSequence()
+            .firstOrNull { it.isNotBlank() }
+            ?.trim()
+            ?.let { TargetPath(it) }
 
     override fun spawn(spec: MirrordProcessSpec): Process {
         val commandLine = GeneralCommandLine(spec.executable.value)
@@ -74,10 +76,13 @@ class LegacyWslEnvironment(
     /**
      * Was `wslDistribution.executeOnWsl(5000, command, "--version")`.
      *
-     * Kept off [spawn] on purpose: `executeOnWsl` defaults to `isExecuteCommandInShell = true`
-     * and `isLaunchWithWslExe = false` — the exact opposite of the options above — so routing
-     * probes through [spawn] would quietly change how they run.
+     * Kept off [spawn]: `executeOnWsl` defaults to `isExecuteCommandInShell = true` and
+     * `isLaunchWithWslExe = false`, the opposite of the options above.
      */
     override fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): ProcessOutput =
         distribution.executeOnWsl(timeoutMillis.toInt(), executable.value, *args.toTypedArray())
+
+    private companion object {
+        const val LOCATE_TIMEOUT_MILLIS = 5_000L
+    }
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/LegacyWslEnvironment.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/LegacyWslEnvironment.kt
@@ -1,0 +1,82 @@
+package com.metalbear.mirrord.bifrost
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.wsl.WSLCommandLineOptions
+import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.openapi.project.Project
+import com.metalbear.mirrord.MirrordLogger
+
+/**
+ * The old road, kept open beside the bridge.
+ *
+ * WSL runs through [EelEnvironment] by default now. This exists purely as an escape hatch: if a
+ * WSL setup regresses under EEL, the user flips "Use legacy WSL integration" in settings and
+ * gets exactly the behaviour they had before, without downgrading the plugin.
+ *
+ * Every line here is lifted from the code it replaces, deliberately unimproved. `getWslPath` is
+ * still the deprecated `String` overload, the command-line options are still the same two flags,
+ * and probes still go through `executeOnWsl`. Tidying any of it would make this a *different*
+ * implementation, which is the one thing it must not be — WSL has no test coverage on Linux, so
+ * "identical to what shipped" is the only guarantee available. Delete the whole file once
+ * EEL-backed WSL has been validated on a Windows machine.
+ */
+class LegacyWslEnvironment(
+    private val distribution: WSLDistribution,
+    private val project: Project?
+) : MirrordEnvironment {
+
+    override val name: String = "WSL/legacy:${distribution.msId}"
+
+    override val isLocal: Boolean = false
+
+    /**
+     * WSL always runs Linux, on the host's architecture — which is what the old
+     * `treatAsLinux = SystemInfo.isLinux || wsl != null` plus `CpuArch.CURRENT` amounted to.
+     */
+    override fun platform(): MirrordTargetPlatform =
+        MirrordTargetPlatform(MirrordTargetOs.LINUX, MirrordTargetPlatform.ofHost().arch)
+
+    /** Was `MirrordExecManager.wslPath`: `wslDistribution?.getWslPath(path) ?: path`. */
+    @Suppress("DEPRECATION")
+    override fun resolve(path: HostPath): TargetPath {
+        val raw = path.path.toString()
+        // The String overload, not the Path one. They are equivalent today, but the deprecated
+        // one is what shipped and what MirrordWslCharacterizationTest pins.
+        return TargetPath(distribution.getWslPath(raw) ?: raw)
+    }
+
+    /** WSL sees the host filesystem under /mnt, so nothing is ever copied. */
+    override fun provide(path: HostPath, name: String): TargetPath = resolve(path)
+
+    override fun spawn(spec: MirrordProcessSpec): Process {
+        val commandLine = GeneralCommandLine(spec.executable.value)
+            .withParameters(spec.args)
+            .withEnvironment(spec.env)
+        spec.workingDirectory?.let { commandLine.withWorkDirectory(it.value) }
+
+        val wslOptions = WSLCommandLineOptions().apply {
+            isLaunchWithWslExe = true
+            isExecuteCommandInShell = false
+        }
+        distribution.patchCommandLine(commandLine, project, wslOptions)
+
+        MirrordLogger.logger.info("mirrord.bifrost: spawned ${spec.describe()} env=$name side=target (wsl.exe)")
+
+        return commandLine.toProcessBuilder()
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .redirectError(ProcessBuilder.Redirect.PIPE)
+            .start()
+    }
+
+    /**
+     * Was `wslDistribution.executeOnWsl(5000, command, "--version")`.
+     *
+     * Kept off [spawn] on purpose: `executeOnWsl` defaults to `isExecuteCommandInShell = true`
+     * and `isLaunchWithWslExe = false` — the exact opposite of the options above — so routing
+     * probes through [spawn] would quietly change how they run.
+     */
+    override fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): MirrordProbeOutput {
+        val output = distribution.executeOnWsl(timeoutMillis.toInt(), executable.value, *args.toTypedArray())
+        return MirrordProbeOutput(output.exitCode, output.stdout, output.stderr)
+    }
+}

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/LegacyWslEnvironment.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/LegacyWslEnvironment.kt
@@ -1,6 +1,7 @@
 package com.metalbear.mirrord.bifrost
 
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.ProcessOutput
 import com.intellij.execution.wsl.WSLCommandLineOptions
 import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.openapi.project.Project
@@ -46,7 +47,9 @@ class LegacyWslEnvironment(
     }
 
     /** WSL sees the host filesystem under /mnt, so nothing is ever copied. */
-    override fun provide(path: HostPath, name: String): TargetPath = resolve(path)
+    // No `onCopy`: WSL reaches the host filesystem through /mnt, so this is a path
+    // translation and no bytes move.
+    override fun provide(path: HostPath, name: String, onCopy: (Long) -> Unit): TargetPath = resolve(path)
 
     override fun spawn(spec: MirrordProcessSpec): Process {
         val commandLine = GeneralCommandLine(spec.executable.value)
@@ -75,8 +78,6 @@ class LegacyWslEnvironment(
      * and `isLaunchWithWslExe = false` — the exact opposite of the options above — so routing
      * probes through [spawn] would quietly change how they run.
      */
-    override fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): MirrordProbeOutput {
-        val output = distribution.executeOnWsl(timeoutMillis.toInt(), executable.value, *args.toTypedArray())
-        return MirrordProbeOutput(output.exitCode, output.stdout, output.stderr)
-    }
+    override fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): ProcessOutput =
+        distribution.executeOnWsl(timeoutMillis.toInt(), executable.value, *args.toTypedArray())
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordBifrostTrace.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordBifrostTrace.kt
@@ -2,11 +2,11 @@ package com.metalbear.mirrord.bifrost
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.runBlockingMaybeCancellable
-import com.intellij.platform.eel.provider.EelUnavailableException
 import com.metalbear.mirrord.MirrordError
 import com.metalbear.mirrord.MirrordLogger
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
+import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
@@ -113,7 +113,10 @@ class MirrordBifrostTracer(
         } catch (e: TimeoutCancellationException) {
             MirrordLogger.logger.warn("mirrord.bifrost: TIMEOUT op=$operation id=$id env=$environment elapsed=${elapsed()}ms limit=${hardMillis}ms", e)
             throw bifrostFailure(environment, operation, e)
-        } catch (e: EelUnavailableException) {
+        } catch (e: IOException) {
+            // Covers the platform's own "environment not reachable" signal without naming it:
+            // EelUnavailableException is an IOException, and it exists in build 261 but not 262.
+            // Referencing it directly made the plugin fail to load on newer IDEs entirely.
             MirrordLogger.logger.warn("mirrord.bifrost: UNAVAIL op=$operation id=$id env=$environment elapsed=${elapsed()}ms", e)
             throw bifrostFailure(environment, operation, e)
         } catch (e: MirrordError) {
@@ -147,7 +150,7 @@ internal fun bifrostFailure(environment: String, operation: String, cause: Throw
         cause
     )
 
-    is EelUnavailableException -> MirrordError(
+    is IOException -> MirrordError(
         "mirrord could not reach $environment.",
         CLI_FALLBACK_HELP,
         cause

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordBifrostTrace.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordBifrostTrace.kt
@@ -2,8 +2,11 @@ package com.metalbear.mirrord.bifrost
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.runBlockingMaybeCancellable
+import com.intellij.platform.ide.progress.ModalTaskOwner
+import com.intellij.platform.ide.progress.runWithModalProgressBlocking
 import com.metalbear.mirrord.MirrordError
 import com.metalbear.mirrord.MirrordLogger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import java.io.IOException
@@ -77,12 +80,31 @@ class MirrordBifrostTracer(
      * bounds us even when there is no progress indicator to cancel from.
      */
     fun <T> crossing(operation: String, environment: String, block: suspend () -> T): T {
-        if (ApplicationManager.getApplication()?.isDispatchThread == true) {
-            // Loud in development, logged in production. Blocking the EDT on a container that is
-            // starting up freezes the whole IDE, and it is the easiest mistake to make here.
-            MirrordLogger.logger.error(
-                "mirrord.bifrost: crossing '$operation' attempted on the EDT — this can freeze the IDE"
-            )
+        // Some platform extension points are called on the EDT by contract and cannot be moved
+        // off it -- ExecutionListener.processStarting is one, and that is where the Node/npm path
+        // starts mirrord. Still logged as an error, because doing this work on the EDT is a design
+        // fault we want to see and fix at the call site, not a state to settle for.
+        val onEdt = ApplicationManager.getApplication()?.isDispatchThread == true
+        if (onEdt) {
+            // WARN, not ERROR. `Logger.error` raises an IDE error report that names mirrord as the
+            // plugin to blame, which reads as a crash for a condition the user cannot act on.
+            //
+            // First occurrence of each operation warns; later ones drop to debug. Silencing them
+            // entirely would hide the condition for every product after the first, because the set
+            // is per-session and keyed on the operation name rather than on the call site.
+            //
+            // `runWithModalProgressBlocking` below keeps the IDE responsive, but it does not make
+            // the call correct. The fix is to move the work off the EDT at the call site, and this
+            // line is how we know whether that has happened.
+            val message = "mirrord.bifrost: crossing '$operation' runs on the EDT — the IDE is " +
+                "blocked behind a modal dialog until it finishes. This should be moved to a " +
+                "background thread; see MirrordNpmExecutionListener.processStarting."
+
+            if (edtReported.add(operation)) {
+                MirrordLogger.logger.warn(message)
+            } else {
+                MirrordLogger.logger.debug(message)
+            }
         }
 
         val id = "bifrost-%04d".format(nextId.incrementAndGet())
@@ -96,15 +118,34 @@ class MirrordBifrostTracer(
         fun elapsed() = (System.nanoTime() - started) / 1_000_000
 
         return try {
-            val result = runBlockingMaybeCancellable {
-                withTimeout(hardMillis) { block() }
+            // `runBlockingCancellable` throws IllegalStateException on the EDT in build 262:
+            // "This method is forbidden on EDT because it does not pump the event queue." That
+            // killed every Node launch. A modal progress dialog is the platform's own prescribed
+            // answer -- it pumps the queue, keeps the IDE responsive, and gives the user a Cancel
+            // button instead of a frozen window while a cold container starts.
+            val result = if (onEdt) {
+                runWithModalProgressBlocking(ModalTaskOwner.guess(), "mirrord: $operation in $environment") {
+                    withTimeout(hardMillis) { block() }
+                }
+            } else {
+                runBlockingMaybeCancellable {
+                    withTimeout(hardMillis) { block() }
+                }
             }
             val took = elapsed()
+
+            // Compare before recording. `record` folds this sample into the moving average, so
+            // asking `isSlow` afterwards compares the sample against a baseline that has already
+            // absorbed it: with SMOOTHING 0.25 and SLOW_FACTOR 3 that turns the documented 3x
+            // threshold into an effective 9x, and ordinary outliers stop being reported.
+            val slow = baselines.isSlow(operation, took, softMillis)
             baselines.record(operation, took)
 
-            if (baselines.isSlow(operation, took, softMillis)) {
+            if (slow) {
                 val message = "mirrord: $operation took ${took}ms in $environment (usually ${baseline}ms)"
                 MirrordLogger.logger.warn("mirrord.bifrost: SLOW    op=$operation id=$id env=$environment elapsed=${took}ms baseline=${baseline}ms")
+                // TODO(COR-1385): surface this to the user as a notification, with
+                // `withDontShowAgain`. Until then a slow crossing is visible only in the log.
                 onSlow(message)
             } else {
                 MirrordLogger.logger.info("mirrord.bifrost: OK      op=$operation id=$id env=$environment elapsed=${took}ms")
@@ -113,6 +154,20 @@ class MirrordBifrostTracer(
         } catch (e: TimeoutCancellationException) {
             MirrordLogger.logger.warn("mirrord.bifrost: TIMEOUT op=$operation id=$id env=$environment elapsed=${elapsed()}ms limit=${hardMillis}ms", e)
             throw bifrostFailure(environment, operation, e)
+        } catch (e: CancellationException) {
+            // Cancellation is control flow, not a failure. The resolution chain in
+            // MirrordEnvironmentSource follows the same rule.
+            //
+            // `ProcessCanceledException` extends `CancellationException`, so one arm covers both
+            // the platform's Cancel button and coroutine cancellation.
+            //
+            // Wrapping it in a MirrordError turned Cancel into an error popup, and into an IDE
+            // error report naming the plugin as the thing to blame.
+            //
+            // Declared after TimeoutCancellationException on purpose. That is a subclass, and a
+            // timeout genuinely is a failure.
+            MirrordLogger.logger.info("mirrord.bifrost: CANCEL  op=$operation id=$id env=$environment elapsed=${elapsed()}ms")
+            throw e
         } catch (e: IOException) {
             // Covers the platform's own "environment not reachable" signal without naming it:
             // EelUnavailableException is an IOException, and it exists in build 261 but not 262.
@@ -124,12 +179,19 @@ class MirrordBifrostTracer(
             MirrordLogger.logger.warn("mirrord.bifrost: FAIL    op=$operation id=$id env=$environment elapsed=${elapsed()}ms: ${e.cause?.message ?: e.message}")
             throw e
         } catch (e: Throwable) {
-            MirrordLogger.logger.warn("mirrord.bifrost: FAIL    op=$operation id=$id env=$environment elapsed=${elapsed()}ms: ${e.message}", e)
+            // A LinkageError or ClassNotFoundException means a platform API moved between IDE
+            // builds. `bifrostFailure` already turns those into the version-mismatch message; the
+            // only thing that differs here is the log tag.
+            val tag = if (e is LinkageError || e is ClassNotFoundException) "MISMATCH" else "FAIL    "
+            MirrordLogger.logger.warn("mirrord.bifrost: $tag op=$operation id=$id env=$environment elapsed=${elapsed()}ms: ${e.message}", e)
             throw bifrostFailure(environment, operation, e)
         }
     }
 
     companion object {
+        /** Operations already reported as running on the EDT, so each is named at most once. */
+        private val edtReported: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
         /** Reaching a container for the first time can mean starting and deploying an agent. */
         const val DEFAULT_SOFT_MILLIS = 5_000L
         const val DEFAULT_HARD_MILLIS = 60_000L
@@ -153,6 +215,15 @@ internal fun bifrostFailure(environment: String, operation: String, cause: Throw
     is IOException -> MirrordError(
         "mirrord could not reach $environment.",
         CLI_FALLBACK_HELP,
+        cause
+    )
+
+    is LinkageError, is ClassNotFoundException -> MirrordError(
+        "mirrord is not compatible with this build of the IDE.",
+        "This plugin build was compiled against a different IntelliJ Platform version, and an " +
+            "API it needs has moved: ${cause.message}. Please update the mirrord plugin. If it is " +
+            "already current, report this with your IDE build number — the EEL API it depends on " +
+            "is still experimental and changes between releases.",
         cause
     )
 

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordBifrostTrace.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordBifrostTrace.kt
@@ -1,0 +1,165 @@
+package com.metalbear.mirrord.bifrost
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.runBlockingMaybeCancellable
+import com.intellij.platform.eel.provider.EelUnavailableException
+import com.metalbear.mirrord.MirrordError
+import com.metalbear.mirrord.MirrordLogger
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Running per-operation timings, so "slow" is measured rather than guessed.
+ *
+ * Reaching a cold dev container legitimately takes seconds; reaching a warm one takes
+ * milliseconds. A fixed threshold would either cry wolf on every first run or never fire at all.
+ * An exponentially weighted moving average adapts to whatever normal turns out to be on a given
+ * machine, which is what makes an intermittent stall visible as an outlier instead of noise.
+ */
+class MirrordBifrostBaselines {
+    private val baselines = ConcurrentHashMap<String, Double>()
+    private val counts = ConcurrentHashMap<String, Long>()
+
+    fun record(operation: String, elapsedMillis: Long) {
+        baselines.compute(operation) { _, previous ->
+            if (previous == null) elapsedMillis.toDouble() else (SMOOTHING * elapsedMillis) + ((1 - SMOOTHING) * previous)
+        }
+        counts.merge(operation, 1L, Long::plus)
+    }
+
+    fun baselineMillis(operation: String): Long? = baselines[operation]?.toLong()
+
+    fun sampleCount(operation: String): Long = counts[operation] ?: 0L
+
+    /**
+     * An operation is slow when it exceeds both [floorMillis] and a multiple of its own
+     * baseline. The floor stops a fast operation from being called slow just because it was
+     * three times its usual two milliseconds.
+     */
+    fun isSlow(operation: String, elapsedMillis: Long, floorMillis: Long): Boolean {
+        if (elapsedMillis < floorMillis) return false
+        val baseline = baselineMillis(operation) ?: return false
+        return elapsedMillis > baseline * SLOW_FACTOR
+    }
+
+    private companion object {
+        const val SMOOTHING = 0.25
+        const val SLOW_FACTOR = 3
+    }
+}
+
+/**
+ * Wraps every crossing of the bridge so that a slow or failed one is obvious in `idea.log`.
+ *
+ * COR-1385 went four months partly because the plugin failed *silently*: no error, no warning,
+ * just a connected-layer count that stayed at zero. Remote environments add two more ways to
+ * fail quietly — slow, and unreachable — so each crossing reports which of the three it was.
+ *
+ * Grep `mirrord.bifrost:` in `idea.log` and the whole story should be there without a debugger.
+ */
+class MirrordBifrostTracer(
+    private val softMillis: Long = DEFAULT_SOFT_MILLIS,
+    private val hardMillis: Long = DEFAULT_HARD_MILLIS,
+    private val onSlow: (String) -> Unit = {},
+    private val baselines: MirrordBifrostBaselines = MirrordBifrostBaselines()
+) {
+    private val nextId = AtomicLong()
+
+    /**
+     * Runs one crossing, bounded and instrumented.
+     *
+     * Uses `runBlockingMaybeCancellable` rather than EEL's own `*Blocking` bridges: those are
+     * uncancellable, so a wedged container would hold the thread until some socket timeout gave
+     * up, and the Cancel button the surrounding [com.intellij.openapi.progress.ProgressManager]
+     * already shows would do nothing. This way the platform can cancel us, and [withTimeout]
+     * bounds us even when there is no progress indicator to cancel from.
+     */
+    fun <T> crossing(operation: String, environment: String, block: suspend () -> T): T {
+        if (ApplicationManager.getApplication()?.isDispatchThread == true) {
+            // Loud in development, logged in production. Blocking the EDT on a container that is
+            // starting up freezes the whole IDE, and it is the easiest mistake to make here.
+            MirrordLogger.logger.error(
+                "mirrord.bifrost: crossing '$operation' attempted on the EDT — this can freeze the IDE"
+            )
+        }
+
+        val id = "bifrost-%04d".format(nextId.incrementAndGet())
+        val baseline = baselines.baselineMillis(operation)
+        MirrordLogger.logger.info(
+            "mirrord.bifrost: BEGIN   op=$operation id=$id env=$environment " +
+                "baseline=${baseline?.let { "${it}ms" } ?: "none"} n=${baselines.sampleCount(operation)} hard=${hardMillis}ms"
+        )
+
+        val started = System.nanoTime()
+        fun elapsed() = (System.nanoTime() - started) / 1_000_000
+
+        return try {
+            val result = runBlockingMaybeCancellable {
+                withTimeout(hardMillis) { block() }
+            }
+            val took = elapsed()
+            baselines.record(operation, took)
+
+            if (baselines.isSlow(operation, took, softMillis)) {
+                val message = "mirrord: $operation took ${took}ms in $environment (usually ${baseline}ms)"
+                MirrordLogger.logger.warn("mirrord.bifrost: SLOW    op=$operation id=$id env=$environment elapsed=${took}ms baseline=${baseline}ms")
+                onSlow(message)
+            } else {
+                MirrordLogger.logger.info("mirrord.bifrost: OK      op=$operation id=$id env=$environment elapsed=${took}ms")
+            }
+            result
+        } catch (e: TimeoutCancellationException) {
+            MirrordLogger.logger.warn("mirrord.bifrost: TIMEOUT op=$operation id=$id env=$environment elapsed=${elapsed()}ms limit=${hardMillis}ms", e)
+            throw bifrostFailure(environment, operation, e)
+        } catch (e: EelUnavailableException) {
+            MirrordLogger.logger.warn("mirrord.bifrost: UNAVAIL op=$operation id=$id env=$environment elapsed=${elapsed()}ms", e)
+            throw bifrostFailure(environment, operation, e)
+        } catch (e: MirrordError) {
+            // Already carries a user-facing message; do not wrap it in a second one.
+            MirrordLogger.logger.warn("mirrord.bifrost: FAIL    op=$operation id=$id env=$environment elapsed=${elapsed()}ms: ${e.cause?.message ?: e.message}")
+            throw e
+        } catch (e: Throwable) {
+            MirrordLogger.logger.warn("mirrord.bifrost: FAIL    op=$operation id=$id env=$environment elapsed=${elapsed()}ms: ${e.message}", e)
+            throw bifrostFailure(environment, operation, e)
+        }
+    }
+
+    companion object {
+        /** Reaching a container for the first time can mean starting and deploying an agent. */
+        const val DEFAULT_SOFT_MILLIS = 5_000L
+        const val DEFAULT_HARD_MILLIS = 60_000L
+
+        val shared = MirrordBifrostTracer()
+    }
+}
+
+/**
+ * Turns a failed crossing into an error that names the environment and offers a way forward.
+ *
+ * Pure, so the message wording is unit-tested.
+ */
+internal fun bifrostFailure(environment: String, operation: String, cause: Throwable): MirrordError = when (cause) {
+    is TimeoutCancellationException -> MirrordError(
+        "mirrord timed out reaching $environment while trying to $operation.",
+        CLI_FALLBACK_HELP,
+        cause
+    )
+
+    is EelUnavailableException -> MirrordError(
+        "mirrord could not reach $environment.",
+        CLI_FALLBACK_HELP,
+        cause
+    )
+
+    else -> MirrordError(
+        "mirrord failed to $operation in $environment: ${cause.message ?: cause::class.java.simpleName}",
+        CLI_FALLBACK_HELP,
+        cause
+    )
+}
+
+private const val CLI_FALLBACK_HELP =
+    "If the environment is a dev container, check that it is running. You can always run mirrord " +
+        "directly inside it instead: mirrord exec -f ./mirrord.json -- <your command>"

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordBifrostTrace.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordBifrostTrace.kt
@@ -16,10 +16,9 @@ import java.util.concurrent.atomic.AtomicLong
 /**
  * Running per-operation timings, so "slow" is measured rather than guessed.
  *
- * Reaching a cold dev container legitimately takes seconds; reaching a warm one takes
- * milliseconds. A fixed threshold would either cry wolf on every first run or never fire at all.
- * An exponentially weighted moving average adapts to whatever normal turns out to be on a given
- * machine, which is what makes an intermittent stall visible as an outlier instead of noise.
+ * A cold dev container takes seconds to reach and a warm one takes milliseconds, so a fixed
+ * threshold either fires on every first run or never fires. The moving average adapts to
+ * whatever normal is on a given machine.
  */
 class MirrordBifrostBaselines {
     private val baselines = ConcurrentHashMap<String, Double>()
@@ -37,9 +36,8 @@ class MirrordBifrostBaselines {
     fun sampleCount(operation: String): Long = counts[operation] ?: 0L
 
     /**
-     * An operation is slow when it exceeds both [floorMillis] and a multiple of its own
-     * baseline. The floor stops a fast operation from being called slow just because it was
-     * three times its usual two milliseconds.
+     * An operation is slow when it passes both [floorMillis] and a multiple of its own baseline.
+     * The floor stops a fast operation being called slow at three times its usual 2 ms.
      */
     fun isSlow(operation: String, elapsedMillis: Long, floorMillis: Long): Boolean {
         if (elapsedMillis < floorMillis) return false
@@ -54,13 +52,12 @@ class MirrordBifrostBaselines {
 }
 
 /**
- * Wraps every crossing of the bridge so that a slow or failed one is obvious in `idea.log`.
+ * Wraps every crossing into a [MirrordEnvironment], so a slow or failed one shows in `idea.log`.
  *
- * COR-1385 went four months partly because the plugin failed *silently*: no error, no warning,
- * just a connected-layer count that stayed at zero. Remote environments add two more ways to
- * fail quietly — slow, and unreachable — so each crossing reports which of the three it was.
+ * A remote environment fails in three ways — slow, unreachable, and broken — and each crossing
+ * reports which one it was.
  *
- * Grep `mirrord.bifrost:` in `idea.log` and the whole story should be there without a debugger.
+ * Grep `mirrord.bifrost:` in `idea.log` if you suspect something is wrong.
  */
 class MirrordBifrostTracer(
     private val softMillis: Long = DEFAULT_SOFT_MILLIS,
@@ -73,32 +70,26 @@ class MirrordBifrostTracer(
     /**
      * Runs one crossing, bounded and instrumented.
      *
-     * Uses `runBlockingMaybeCancellable` rather than EEL's own `*Blocking` bridges: those are
-     * uncancellable, so a wedged container would hold the thread until some socket timeout gave
-     * up, and the Cancel button the surrounding [com.intellij.openapi.progress.ProgressManager]
-     * already shows would do nothing. This way the platform can cancel us, and [withTimeout]
-     * bounds us even when there is no progress indicator to cancel from.
+     * Uses `runBlockingMaybeCancellable` rather than EEL's own `*Blocking` bridges, which cannot
+     * be cancelled: a wedged container would hold the thread until a socket timeout, and the
+     * Cancel button of the surrounding
+     * [com.intellij.openapi.progress.ProgressManager] would do nothing.
+     *
+     * [withTimeout] bounds the call even when there is no progress indicator to cancel from.
      */
     fun <T> crossing(operation: String, environment: String, block: suspend () -> T): T {
-        // Some platform extension points are called on the EDT by contract and cannot be moved
-        // off it -- ExecutionListener.processStarting is one, and that is where the Node/npm path
-        // starts mirrord. Still logged as an error, because doing this work on the EDT is a design
-        // fault we want to see and fix at the call site, not a state to settle for.
+        // Some extension points run on the EDT by platform contract and cannot be moved off it.
+        // `ExecutionListener.processStarting` is one, and that is where the Node path starts
+        // mirrord.
         val onEdt = ApplicationManager.getApplication()?.isDispatchThread == true
         if (onEdt) {
-            // WARN, not ERROR. `Logger.error` raises an IDE error report that names mirrord as the
-            // plugin to blame, which reads as a crash for a condition the user cannot act on.
+            // WARN, not ERROR: `Logger.error` raises an IDE error report naming mirrord, for a
+            // condition the user cannot act on.
             //
-            // First occurrence of each operation warns; later ones drop to debug. Silencing them
-            // entirely would hide the condition for every product after the first, because the set
-            // is per-session and keyed on the operation name rather than on the call site.
-            //
-            // `runWithModalProgressBlocking` below keeps the IDE responsive, but it does not make
-            // the call correct. The fix is to move the work off the EDT at the call site, and this
-            // line is how we know whether that has happened.
-            val message = "mirrord.bifrost: crossing '$operation' runs on the EDT — the IDE is " +
-                "blocked behind a modal dialog until it finishes. This should be moved to a " +
-                "background thread; see MirrordNpmExecutionListener.processStarting."
+            // First occurrence of each operation warns, later ones drop to debug. The modal
+            // dialog below keeps the IDE responsive but does not make the call correct.
+            val message = "mirrord.bifrost: crossing '$operation' runs on the EDT. " +
+                "Move it to a background thread; see MirrordNpmExecutionListener.processStarting."
 
             if (edtReported.add(operation)) {
                 MirrordLogger.logger.warn(message)
@@ -118,11 +109,10 @@ class MirrordBifrostTracer(
         fun elapsed() = (System.nanoTime() - started) / 1_000_000
 
         return try {
-            // `runBlockingCancellable` throws IllegalStateException on the EDT in build 262:
-            // "This method is forbidden on EDT because it does not pump the event queue." That
-            // killed every Node launch. A modal progress dialog is the platform's own prescribed
-            // answer -- it pumps the queue, keeps the IDE responsive, and gives the user a Cancel
-            // button instead of a frozen window while a cold container starts.
+            // EEL COMPAT 261/262: `runBlockingCancellable` became forbidden on the EDT in 262
+            // ("does not pump the event queue"), which killed every Node launch. A modal progress
+            // dialog is the platform's own answer: it pumps the queue and gives the user a Cancel
+            // button while a cold container starts.
             val result = if (onEdt) {
                 runWithModalProgressBlocking(ModalTaskOwner.guess(), "mirrord: $operation in $environment") {
                     withTimeout(hardMillis) { block() }
@@ -134,10 +124,8 @@ class MirrordBifrostTracer(
             }
             val took = elapsed()
 
-            // Compare before recording. `record` folds this sample into the moving average, so
-            // asking `isSlow` afterwards compares the sample against a baseline that has already
-            // absorbed it: with SMOOTHING 0.25 and SLOW_FACTOR 3 that turns the documented 3x
-            // threshold into an effective 9x, and ordinary outliers stop being reported.
+            // Compare before recording. `record` folds this sample into the average, so asking
+            // afterwards raises the effective threshold from 3x to 9x.
             val slow = baselines.isSlow(operation, took, softMillis)
             baselines.record(operation, took)
 
@@ -155,23 +143,17 @@ class MirrordBifrostTracer(
             MirrordLogger.logger.warn("mirrord.bifrost: TIMEOUT op=$operation id=$id env=$environment elapsed=${elapsed()}ms limit=${hardMillis}ms", e)
             throw bifrostFailure(environment, operation, e)
         } catch (e: CancellationException) {
-            // Cancellation is control flow, not a failure. The resolution chain in
-            // MirrordEnvironmentSource follows the same rule.
+            // Cancellation is control flow, not a failure: wrapping it in a MirrordError turns
+            // Cancel into an error popup. `ProcessCanceledException` extends this, so one arm
+            // covers the Cancel button and coroutine cancellation.
             //
-            // `ProcessCanceledException` extends `CancellationException`, so one arm covers both
-            // the platform's Cancel button and coroutine cancellation.
-            //
-            // Wrapping it in a MirrordError turned Cancel into an error popup, and into an IDE
-            // error report naming the plugin as the thing to blame.
-            //
-            // Declared after TimeoutCancellationException on purpose. That is a subclass, and a
-            // timeout genuinely is a failure.
+            // Declared after `TimeoutCancellationException`, a subclass that *is* a failure.
             MirrordLogger.logger.info("mirrord.bifrost: CANCEL  op=$operation id=$id env=$environment elapsed=${elapsed()}ms")
             throw e
         } catch (e: IOException) {
-            // Covers the platform's own "environment not reachable" signal without naming it:
-            // EelUnavailableException is an IOException, and it exists in build 261 but not 262.
-            // Referencing it directly made the plugin fail to load on newer IDEs entirely.
+            // EEL COMPAT 261/262: `EelUnavailableException` exists in 261 and not 262, and
+            // naming it made the plugin fail to load on newer IDEs. It is an `IOException`, so
+            // this arm catches it without a reference.
             MirrordLogger.logger.warn("mirrord.bifrost: UNAVAIL op=$operation id=$id env=$environment elapsed=${elapsed()}ms", e)
             throw bifrostFailure(environment, operation, e)
         } catch (e: MirrordError) {
@@ -179,9 +161,9 @@ class MirrordBifrostTracer(
             MirrordLogger.logger.warn("mirrord.bifrost: FAIL    op=$operation id=$id env=$environment elapsed=${elapsed()}ms: ${e.cause?.message ?: e.message}")
             throw e
         } catch (e: Throwable) {
-            // A LinkageError or ClassNotFoundException means a platform API moved between IDE
-            // builds. `bifrostFailure` already turns those into the version-mismatch message; the
-            // only thing that differs here is the log tag.
+            // EEL COMPAT 261/262: a `LinkageError` or `ClassNotFoundException` means a platform
+            // API moved between builds. `bifrostFailure` turns those into the version-mismatch
+            // message; only the log tag differs here.
             val tag = if (e is LinkageError || e is ClassNotFoundException) "MISMATCH" else "FAIL    "
             MirrordLogger.logger.warn("mirrord.bifrost: $tag op=$operation id=$id env=$environment elapsed=${elapsed()}ms: ${e.message}", e)
             throw bifrostFailure(environment, operation, e)
@@ -200,11 +182,7 @@ class MirrordBifrostTracer(
     }
 }
 
-/**
- * Turns a failed crossing into an error that names the environment and offers a way forward.
- *
- * Pure, so the message wording is unit-tested.
- */
+/** Turns a failed crossing into an error that names the environment and offers a way forward. */
 internal fun bifrostFailure(environment: String, operation: String, cause: Throwable): MirrordError = when (cause) {
     is TimeoutCancellationException -> MirrordError(
         "mirrord timed out reaching $environment while trying to $operation.",

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironment.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironment.kt
@@ -3,29 +3,12 @@ package com.metalbear.mirrord.bifrost
 import com.intellij.execution.process.ProcessOutput
 
 /**
- * The rainbow bridge: one span from the IDE to wherever the user's code actually runs.
- *
- * The far end might be this very machine, a WSL distribution, or a dev container. Callers are
- * not supposed to know which, and that is the entire design. Code that stops halfway across to
- * ask "am I local?" is code that will eventually answer wrong — which is precisely how COR-1385
- * happened, where the plugin asked the IDE's own machine what OS it was on and confidently
- * downloaded a macOS binary for a Linux container.
- *
- * The bridge is transparent in both senses. You cannot see it from the call sites, which is the
- * point. And nobody has to give anything up to cross it: local runs behave exactly as they
- * always have, WSL keeps its old road open right beside it, and dev containers finally get
- * across at all. Everyone reaches the other side, everyone stays happy, and nobody looks down.
- */
-
-/**
  * A complete description of a process to run in a [MirrordEnvironment].
  *
- * [env] is assembled in full *before* [MirrordEnvironment.spawn] is called, and that is the
- * whole reason this type exists rather than passing a command line around. The old code built a
- * `GeneralCommandLine`, patched it for WSL halfway through, and then kept adding environment
- * variables afterwards — so `MIRRORD_PROGRESS_MODE`, `MIRRORD_PROGRESS_SUPPORT_IDE`,
- * `MIRRORD_IDE_NAME` and `MIRRORD_BRANCH_NAME` were registered for WSL interop only if you were
- * lucky with statement order. With a spec there is no "halfway through" left to get wrong.
+ * [env] is assembled in full before [MirrordEnvironment.spawn] is called, which is why this is
+ * a spec rather than a command line. The code it replaces built a `GeneralCommandLine`, patched
+ * it for WSL partway through, then kept adding variables, so whether a variable reached the
+ * process depended on statement order.
  *
  * [env] is overlaid on the target's own environment, matching the `ParentEnvironmentType.CONSOLE`
  * behaviour of the `GeneralCommandLine` this replaces.
@@ -36,27 +19,30 @@ data class MirrordProcessSpec(
     val env: Map<String, String>,
     val workingDirectory: TargetPath?
 ) {
-    /** For logs. Deliberately omits environment *values* — they routinely carry credentials. */
+    /** For logs. Omits environment *values* — they routinely carry credentials. */
     fun describe(): String = "$executable ${args.joinToString(" ")} [${env.size} env vars]"
 }
 
 /**
- * Where mirrord runs.
+ * Where mirrord runs: this machine, a WSL distribution, a dev container, or an SSH host.
  *
- * Every method may perform I/O — reaching a dev container can mean starting and deploying an
- * agent — so **none of them may be called on the EDT**. [MirrordBifrostTracer] enforces that
- * with a tripwire and bounds each call with a timeout.
+ * Callers do not ask which. Code that stops to ask "am I local?" is code that answers wrong the
+ * first time a new environment kind appears — which is COR-1385, where the plugin asked the IDE's
+ * own machine what OS it was on and downloaded a macOS binary for a Linux container.
+ *
+ * Every method performs I/O, because reaching a dev container can mean starting and deploying an
+ * agent. **None of them may be called on the EDT.** [MirrordBifrostTracer] enforces that and
+ * bounds each call with a timeout.
  */
 interface MirrordEnvironment {
     /** Human-readable; appears in every log line and in user-facing errors. */
     val name: String
 
     /**
-     * True when the far end of the bridge is the IDE's own machine.
+     * True when the far end is the IDE's own machine.
      *
-     * Deliberately *not* used to branch the main path — JetBrains document that as an
-     * anti-pattern, and converting a local descriptor is instant anyway. It exists for the two
-     * cases they do sanction: work that genuinely belongs on the IDE host, and port forwarding.
+     * Not for branching the main path — JetBrains document that as an anti-pattern. It exists
+     * for the two cases they do sanction: work that belongs on the IDE host, and port forwarding.
      */
     val isLocal: Boolean
 
@@ -71,30 +57,32 @@ interface MirrordEnvironment {
     fun resolve(path: HostPath): TargetPath
 
     /**
-     * Makes a host file available at the far end, copying it across only if it is not already
-     * visible there, and returns its target path.
+     * Makes a host file available at the far end, copying it across only if the target cannot
+     * already see it, and returns its target path.
      *
-     * This is the step that makes dev containers work at all: the plugin-managed mirrord binary
-     * lives in the IDE's plugin directory, which a container cannot see at any path.
+     * This is what makes dev containers work: the plugin-managed mirrord binary lives in the
+     * IDE's plugin directory, which a container cannot see at any path.
      *
      * @param name basename to use if a copy is made.
-     * @param onCopy invoked with the file size, and only when bytes actually move. Callers that
-     *   warn the user about a slow transfer must use this rather than guessing beforehand: for a
-     *   local target, and for legacy WSL, this method copies nothing at all.
+     * @param onCopy invoked with the file size, and only when bytes actually move. A caller that
+     *   warns about a slow transfer must use this rather than guessing beforehand: for a local
+     *   target, and for legacy WSL, nothing is copied.
      */
     fun provide(path: HostPath, name: String, onCopy: (Long) -> Unit = {}): TargetPath
+
+    /** Finds [executable] on the target's `PATH`, or null when it is not there. */
+    fun locate(executable: String): TargetPath?
 
     /** Spawns [spec] at the far end. The returned process is an ordinary [Process]. */
     fun spawn(spec: MirrordProcessSpec): Process
 
     /**
-     * Runs a short command and waits for it — `mirrord --version`, `which mirrord`.
+     * Runs a short command and waits for it, such as `mirrord --version`.
      *
      * Separate from [spawn] because the legacy WSL path reaches these through `executeOnWsl`,
-     * whose defaults are the exact opposite of the ones it uses for long-running commands
+     * whose defaults are the opposite of the ones it uses for long-running commands
      * (`isExecuteCommandInShell = true`, `isLaunchWithWslExe = false`). Routing probes through
-     * [spawn] would quietly change WSL behaviour, and this refactor is meant to leave WSL
-     * bit-for-bit identical.
+     * [spawn] would change WSL behaviour, and this refactor leaves WSL bit-for-bit identical.
      */
     fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): ProcessOutput
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironment.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironment.kt
@@ -1,0 +1,98 @@
+package com.metalbear.mirrord.bifrost
+
+/**
+ * The rainbow bridge: one span from the IDE to wherever the user's code actually runs.
+ *
+ * The far end might be this very machine, a WSL distribution, or a dev container. Callers are
+ * not supposed to know which, and that is the entire design. Code that stops halfway across to
+ * ask "am I local?" is code that will eventually answer wrong — which is precisely how COR-1385
+ * happened, where the plugin asked the IDE's own machine what OS it was on and confidently
+ * downloaded a macOS binary for a Linux container.
+ *
+ * The bridge is transparent in both senses. You cannot see it from the call sites, which is the
+ * point. And nobody has to give anything up to cross it: local runs behave exactly as they
+ * always have, WSL keeps its old road open right beside it, and dev containers finally get
+ * across at all. Everyone reaches the other side, everyone stays happy, and nobody looks down.
+ */
+
+/**
+ * A complete description of a process to run in a [MirrordEnvironment].
+ *
+ * [env] is assembled in full *before* [MirrordEnvironment.spawn] is called, and that is the
+ * whole reason this type exists rather than passing a command line around. The old code built a
+ * `GeneralCommandLine`, patched it for WSL halfway through, and then kept adding environment
+ * variables afterwards — so `MIRRORD_PROGRESS_MODE`, `MIRRORD_PROGRESS_SUPPORT_IDE`,
+ * `MIRRORD_IDE_NAME` and `MIRRORD_BRANCH_NAME` were registered for WSL interop only if you were
+ * lucky with statement order. With a spec there is no "halfway through" left to get wrong.
+ *
+ * [env] is overlaid on the target's own environment, matching the `ParentEnvironmentType.CONSOLE`
+ * behaviour of the `GeneralCommandLine` this replaces.
+ */
+data class MirrordProcessSpec(
+    val executable: TargetPath,
+    val args: List<String>,
+    val env: Map<String, String>,
+    val workingDirectory: TargetPath?
+) {
+    /** For logs. Deliberately omits environment *values* — they routinely carry credentials. */
+    fun describe(): String = "$executable ${args.joinToString(" ")} [${env.size} env vars]"
+}
+
+/** Result of a short synchronous probe such as `mirrord --version` or `which mirrord`. */
+data class MirrordProbeOutput(val exitCode: Int, val stdout: String, val stderr: String)
+
+/**
+ * Where mirrord runs.
+ *
+ * Every method may perform I/O — reaching a dev container can mean starting and deploying an
+ * agent — so **none of them may be called on the EDT**. [MirrordBifrostTracer] enforces that
+ * with a tripwire and bounds each call with a timeout.
+ */
+interface MirrordEnvironment {
+    /** Human-readable; appears in every log line and in user-facing errors. */
+    val name: String
+
+    /**
+     * True when the far end of the bridge is the IDE's own machine.
+     *
+     * Deliberately *not* used to branch the main path — JetBrains document that as an
+     * anti-pattern, and converting a local descriptor is instant anyway. It exists for the two
+     * cases they do sanction: work that genuinely belongs on the IDE host, and port forwarding.
+     */
+    val isLocal: Boolean
+
+    /** OS and architecture at the far end. Cached after the first crossing. */
+    fun platform(): MirrordTargetPlatform
+
+    /**
+     * Translates a host path into the path the target uses for the same file.
+     *
+     * @throws com.metalbear.mirrord.MirrordError if the file is not visible from the target.
+     */
+    fun resolve(path: HostPath): TargetPath
+
+    /**
+     * Makes a host file available at the far end, copying it across only if it is not already
+     * visible there, and returns its target path.
+     *
+     * This is the step that makes dev containers work at all: the plugin-managed mirrord binary
+     * lives in the IDE's plugin directory, which a container cannot see at any path.
+     *
+     * @param name basename to use if a copy is made.
+     */
+    fun provide(path: HostPath, name: String): TargetPath
+
+    /** Spawns [spec] at the far end. The returned process is an ordinary [Process]. */
+    fun spawn(spec: MirrordProcessSpec): Process
+
+    /**
+     * Runs a short command and waits for it — `mirrord --version`, `which mirrord`.
+     *
+     * Separate from [spawn] because the legacy WSL path reaches these through `executeOnWsl`,
+     * whose defaults are the exact opposite of the ones it uses for long-running commands
+     * (`isExecuteCommandInShell = true`, `isLaunchWithWslExe = false`). Routing probes through
+     * [spawn] would quietly change WSL behaviour, and this refactor is meant to leave WSL
+     * bit-for-bit identical.
+     */
+    fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): MirrordProbeOutput
+}

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironment.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironment.kt
@@ -1,5 +1,7 @@
 package com.metalbear.mirrord.bifrost
 
+import com.intellij.execution.process.ProcessOutput
+
 /**
  * The rainbow bridge: one span from the IDE to wherever the user's code actually runs.
  *
@@ -37,9 +39,6 @@ data class MirrordProcessSpec(
     /** For logs. Deliberately omits environment *values* — they routinely carry credentials. */
     fun describe(): String = "$executable ${args.joinToString(" ")} [${env.size} env vars]"
 }
-
-/** Result of a short synchronous probe such as `mirrord --version` or `which mirrord`. */
-data class MirrordProbeOutput(val exitCode: Int, val stdout: String, val stderr: String)
 
 /**
  * Where mirrord runs.
@@ -79,8 +78,11 @@ interface MirrordEnvironment {
      * lives in the IDE's plugin directory, which a container cannot see at any path.
      *
      * @param name basename to use if a copy is made.
+     * @param onCopy invoked with the file size, and only when bytes actually move. Callers that
+     *   warn the user about a slow transfer must use this rather than guessing beforehand: for a
+     *   local target, and for legacy WSL, this method copies nothing at all.
      */
-    fun provide(path: HostPath, name: String): TargetPath
+    fun provide(path: HostPath, name: String, onCopy: (Long) -> Unit = {}): TargetPath
 
     /** Spawns [spec] at the far end. The returned process is an ordinary [Process]. */
     fun spawn(spec: MirrordProcessSpec): Process
@@ -94,5 +96,5 @@ interface MirrordEnvironment {
      * [spawn] would quietly change WSL behaviour, and this refactor is meant to leave WSL
      * bit-for-bit identical.
      */
-    fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): MirrordProbeOutput
+    fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): ProcessOutput
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironmentSource.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironmentSource.kt
@@ -19,10 +19,10 @@ import com.metalbear.mirrord.MirrordSettingsState
 import java.nio.file.Path
 
 /**
- * Everything a source is allowed to look at when deciding which end of the bridge to aim for.
+ * Everything a source is allowed to look at when deciding where mirrord runs.
  *
- * The project-derived descriptor sits behind a function rather than being a field so the whole
- * resolution chain can be exercised in a plain unit test, with no IDE and no open project.
+ * The project-derived descriptor is a function rather than a field, so the resolution chain runs
+ * in a plain unit test with no IDE and no open project.
  */
 class MirrordLaunchContext(
     val label: String,
@@ -45,24 +45,19 @@ interface MirrordEnvironmentSource {
     fun resolve(context: MirrordLaunchContext): MirrordEnvironment?
 }
 
-/**
- * Pulls a [WSLDistribution] out of a target request, if that is what it is.
- *
- * One null-safe expression, in one place. This replaces the same four-line `when` copy-pasted
- * across eleven product files, seven of which ended it with `!!`.
- */
+/** Pulls a [WSLDistribution] out of a target request, if that is what it is. */
 internal fun wslDistributionOf(request: TargetEnvironmentRequest?): WSLDistribution? =
     (request as? WslTargetEnvironmentRequest)?.configuration?.distribution
 
-/** Test seam, and a way to force an environment without a real container. */
+/** Uses the environment the caller passed in, if it passed one. */
 class ForcedEnvironmentSource : MirrordEnvironmentSource {
     override val id = "forced"
     override fun resolve(context: MirrordLaunchContext): MirrordEnvironment? = context.forced
 }
 
 /**
- * The opt-out. Declines unless the user has asked for legacy WSL *and* this really is a WSL
- * launch, so turning the setting on cannot affect anything else.
+ * Declines unless the user asked for legacy WSL *and* this is a WSL launch, so turning the
+ * setting on cannot affect anything else.
  */
 class LegacyWslEnvironmentSource(
     private val legacyEnabled: () -> Boolean = { MirrordSettingsState.instance.mirrordState.useLegacyWsl }
@@ -86,16 +81,16 @@ class TargetRequestEnvironmentSource : MirrordEnvironmentSource {
     override fun resolve(context: MirrordLaunchContext): MirrordEnvironment? {
         val request = context.targetRequest ?: return null
 
-        // The modern shape. WslTargetEnvironmentRequest is deprecated in favour of this.
+        // The modern shape; WslTargetEnvironmentRequest is deprecated in favour of it.
         (request as? EelTargetEnvironmentRequest)?.configuration?.descriptor?.let {
             return EelEnvironment(it)
         }
 
-        // WSL, reached through EEL rather than wsl.exe. The UNC root is a path the platform
-        // already knows how to map back to the distribution's descriptor.
+        // WSL through EEL rather than wsl.exe. The platform maps the UNC root back to the
+        // distribution's descriptor.
         //
-        // `getUNCRootPath` stays a method call: Kotlin does not synthesise a property for it,
-        // because two leading capitals mean the name never gets decapitalised.
+        // `getUNCRootPath` stays a method call: two leading capitals mean Kotlin never
+        // decapitalises the name into a property.
         wslDistributionOf(request)?.let { distribution ->
             @Suppress("DEPRECATION")
             val uncRoot: Path? = runCatching { distribution.getUNCRootPath() }.getOrNull()
@@ -109,10 +104,11 @@ class TargetRequestEnvironmentSource : MirrordEnvironmentSource {
 /**
  * Where the project itself lives.
  *
- * This is the one that makes native dev containers work: the project directory is inside the
- * container, so the platform hands back the container's descriptor. It is also the right answer
- * for Rider, whose extension point never sees the run configuration being launched and so has
- * nothing more specific to go on.
+ * This is what makes native dev containers work: the project directory is inside the container,
+ * so the platform hands back the container's descriptor.
+ *
+ * It is also the right answer for Rider, whose extension point never sees the run configuration
+ * and has nothing more specific to go on.
  */
 class ProjectDescriptorEnvironmentSource : MirrordEnvironmentSource {
     override val id = "project-descriptor"
@@ -133,10 +129,11 @@ class LocalEnvironmentSource : MirrordEnvironmentSource {
 /**
  * Resolves where mirrord runs, by asking each source in turn.
  *
- * The order is data, reviewable in one place, and a new kind of environment is a new source
- * rather than another branch in a growing `when`. The winner is logged at INFO, so a
- * misresolution is one grep rather than a debugging session — which matters because "which
- * environment did it pick" is not otherwise visible from the outside.
+ * The order is data in one place, so a new kind of environment is a new source rather than
+ * another branch in a `when`.
+ *
+ * The winner is logged at INFO, because which environment was picked is not visible from
+ * outside the plugin.
  */
 object MirrordEnvironments {
     internal val defaultSources: List<MirrordEnvironmentSource> = listOf(
@@ -152,9 +149,8 @@ object MirrordEnvironments {
     /**
      * Where the project lives. For extension points that never see a run configuration.
      *
-     * These three entry points exist so the launch context is built in exactly one place per
-     * shape. Spelling `resolve(MirrordLaunchContext(...))` at each call site was the same
-     * copy-paste that [wslDistributionOf] just removed, one layer up.
+     * This and the two below build the launch context in one place per shape, so no call site
+     * spells out `resolve(MirrordLaunchContext(...))`.
      */
     fun forProject(project: Project): MirrordEnvironment = resolve(MirrordLaunchContext(project))
 
@@ -173,8 +169,8 @@ object MirrordEnvironments {
             val environment = try {
                 source.resolve(context)
             } catch (e: ProcessCanceledException) {
-                // Cancellation is control flow, not a failure. Swallowing it here would turn a
-                // user pressing Cancel into a confusing error about environment resolution.
+                // Cancellation is control flow. Swallowing it turns Cancel into a confusing
+                // error about environment resolution.
                 throw e
             } catch (e: Throwable) {
                 MirrordLogger.logger.warn("mirrord.bifrost: source=${source.id} threw, skipping", e)
@@ -192,10 +188,9 @@ object MirrordEnvironments {
             MirrordLogger.logger.debug("mirrord.bifrost: source=${source.id} declined for=${context.label}")
         }
 
-        // The last source always returns an environment, so getting here means it threw. Report
-        // what actually went wrong rather than an "unreachable" that sends the reader hunting
-        // for a logic bug in the chain — the first time this fired, the real cause was a missing
-        // module dependency in plugin.xml and the message pointed nowhere near it.
+        // The last source always returns an environment, so reaching here means it threw.
+        // Report what went wrong rather than an "unreachable" that sends the reader hunting for
+        // a logic bug in the chain.
         val cause = failures.lastOrNull()
         throw MirrordError(
             "mirrord could not determine where to run.",

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironmentSource.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironmentSource.kt
@@ -2,8 +2,10 @@
 
 package com.metalbear.mirrord.bifrost
 
+import com.intellij.execution.configurations.RunProfile
 import com.intellij.execution.target.EelTargetEnvironmentRequest
 import com.intellij.execution.target.TargetEnvironmentRequest
+import com.intellij.execution.target.createEnvironmentRequest
 import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.openapi.progress.ProcessCanceledException
@@ -146,6 +148,23 @@ object MirrordEnvironments {
     )
 
     fun resolve(context: MirrordLaunchContext): MirrordEnvironment = resolve(context, defaultSources)
+
+    /**
+     * Where the project lives. For extension points that never see a run configuration.
+     *
+     * These three entry points exist so the launch context is built in exactly one place per
+     * shape. Spelling `resolve(MirrordLaunchContext(...))` at each call site was the same
+     * copy-paste that [wslDistributionOf] just removed, one layer up.
+     */
+    fun forProject(project: Project): MirrordEnvironment = resolve(MirrordLaunchContext(project))
+
+    /** For a caller that already holds the run configuration's target request. */
+    fun forRequest(project: Project, request: TargetEnvironmentRequest?): MirrordEnvironment =
+        resolve(MirrordLaunchContext(project, request))
+
+    /** For an extension point that has the run profile but must build the request itself. */
+    fun forRunProfile(project: Project, profile: RunProfile): MirrordEnvironment =
+        resolve(MirrordLaunchContext(project, createEnvironmentRequest(profile, project)))
 
     internal fun resolve(context: MirrordLaunchContext, sources: List<MirrordEnvironmentSource>): MirrordEnvironment {
         val failures = mutableListOf<Pair<String, Throwable>>()

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironmentSource.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironmentSource.kt
@@ -6,10 +6,12 @@ import com.intellij.execution.target.EelTargetEnvironmentRequest
 import com.intellij.execution.target.TargetEnvironmentRequest
 import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import com.intellij.platform.eel.EelDescriptor
 import com.intellij.platform.eel.provider.LocalEelDescriptor
 import com.intellij.platform.eel.provider.getEelDescriptor
+import com.metalbear.mirrord.MirrordError
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordSettingsState
 import java.nio.file.Path
@@ -146,11 +148,21 @@ object MirrordEnvironments {
     fun resolve(context: MirrordLaunchContext): MirrordEnvironment = resolve(context, defaultSources)
 
     internal fun resolve(context: MirrordLaunchContext, sources: List<MirrordEnvironmentSource>): MirrordEnvironment {
+        val failures = mutableListOf<Pair<String, Throwable>>()
+
         for (source in sources) {
-            val environment = runCatching { source.resolve(context) }.getOrElse {
-                MirrordLogger.logger.warn("mirrord.bifrost: source=${source.id} threw, skipping", it)
+            val environment = try {
+                source.resolve(context)
+            } catch (e: ProcessCanceledException) {
+                // Cancellation is control flow, not a failure. Swallowing it here would turn a
+                // user pressing Cancel into a confusing error about environment resolution.
+                throw e
+            } catch (e: Throwable) {
+                MirrordLogger.logger.warn("mirrord.bifrost: source=${source.id} threw, skipping", e)
+                failures += source.id to e
                 null
             }
+
             if (environment != null) {
                 MirrordLogger.logger.info(
                     "mirrord.bifrost: resolved via=${source.id} env=${environment.name} " +
@@ -160,6 +172,17 @@ object MirrordEnvironments {
             }
             MirrordLogger.logger.debug("mirrord.bifrost: source=${source.id} declined for=${context.label}")
         }
-        error("unreachable: LocalEnvironmentSource always resolves")
+
+        // The last source always returns an environment, so getting here means it threw. Report
+        // what actually went wrong rather than an "unreachable" that sends the reader hunting
+        // for a logic bug in the chain — the first time this fired, the real cause was a missing
+        // module dependency in plugin.xml and the message pointed nowhere near it.
+        val cause = failures.lastOrNull()
+        throw MirrordError(
+            "mirrord could not determine where to run.",
+            failures.joinToString("; ") { (id, e) -> "$id: ${e.message ?: e::class.java.simpleName}" }
+                .ifEmpty { "No environment source produced a result." },
+            cause?.second
+        )
     }
 }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironmentSource.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironmentSource.kt
@@ -1,0 +1,165 @@
+@file:Suppress("UnstableApiUsage")
+
+package com.metalbear.mirrord.bifrost
+
+import com.intellij.execution.target.EelTargetEnvironmentRequest
+import com.intellij.execution.target.TargetEnvironmentRequest
+import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
+import com.intellij.openapi.project.Project
+import com.intellij.platform.eel.EelDescriptor
+import com.intellij.platform.eel.provider.LocalEelDescriptor
+import com.intellij.platform.eel.provider.getEelDescriptor
+import com.metalbear.mirrord.MirrordLogger
+import com.metalbear.mirrord.MirrordSettingsState
+import java.nio.file.Path
+
+/**
+ * Everything a source is allowed to look at when deciding which end of the bridge to aim for.
+ *
+ * The project-derived descriptor sits behind a function rather than being a field so the whole
+ * resolution chain can be exercised in a plain unit test, with no IDE and no open project.
+ */
+class MirrordLaunchContext(
+    val label: String,
+    val targetRequest: TargetEnvironmentRequest?,
+    val forced: MirrordEnvironment?,
+    internal val project: Project?,
+    private val descriptorSupplier: () -> EelDescriptor?
+) {
+    constructor(project: Project, targetRequest: TargetEnvironmentRequest? = null, forced: MirrordEnvironment? = null) :
+        this(project.name, targetRequest, forced, project, { project.getEelDescriptor() })
+
+    fun projectDescriptor(): EelDescriptor? = descriptorSupplier()
+}
+
+/** One way of discovering where mirrord should run. */
+interface MirrordEnvironmentSource {
+    val id: String
+
+    /** Returns null to defer to the next source. */
+    fun resolve(context: MirrordLaunchContext): MirrordEnvironment?
+}
+
+/**
+ * Pulls a [WSLDistribution] out of a target request, if that is what it is.
+ *
+ * One null-safe expression, in one place. This replaces the same four-line `when` copy-pasted
+ * across eleven product files, seven of which ended it with `!!`.
+ */
+internal fun wslDistributionOf(request: TargetEnvironmentRequest?): WSLDistribution? =
+    (request as? WslTargetEnvironmentRequest)?.configuration?.distribution
+
+/** Test seam, and a way to force an environment without a real container. */
+class ForcedEnvironmentSource : MirrordEnvironmentSource {
+    override val id = "forced"
+    override fun resolve(context: MirrordLaunchContext): MirrordEnvironment? = context.forced
+}
+
+/**
+ * The opt-out. Declines unless the user has asked for legacy WSL *and* this really is a WSL
+ * launch, so turning the setting on cannot affect anything else.
+ */
+class LegacyWslEnvironmentSource(
+    private val legacyEnabled: () -> Boolean = { MirrordSettingsState.instance.mirrordState.useLegacyWsl }
+) : MirrordEnvironmentSource {
+    override val id = "legacy-wsl"
+
+    override fun resolve(context: MirrordLaunchContext): MirrordEnvironment? {
+        if (!legacyEnabled()) return null
+        val distribution = wslDistributionOf(context.targetRequest) ?: return null
+        return LegacyWslEnvironment(distribution, context.project)
+    }
+}
+
+/**
+ * The run configuration's own target, which is the most specific answer available: one project
+ * can hold configurations aimed at different environments.
+ */
+class TargetRequestEnvironmentSource : MirrordEnvironmentSource {
+    override val id = "target-request"
+
+    override fun resolve(context: MirrordLaunchContext): MirrordEnvironment? {
+        val request = context.targetRequest ?: return null
+
+        // The modern shape. WslTargetEnvironmentRequest is deprecated in favour of this.
+        (request as? EelTargetEnvironmentRequest)?.configuration?.descriptor?.let {
+            return EelEnvironment(it)
+        }
+
+        // WSL, reached through EEL rather than wsl.exe. The UNC root is a path the platform
+        // already knows how to map back to the distribution's descriptor.
+        //
+        // `getUNCRootPath` stays a method call: Kotlin does not synthesise a property for it,
+        // because two leading capitals mean the name never gets decapitalised.
+        wslDistributionOf(request)?.let { distribution ->
+            @Suppress("DEPRECATION")
+            val uncRoot: Path? = runCatching { distribution.getUNCRootPath() }.getOrNull()
+            uncRoot?.let { return EelEnvironment(it.getEelDescriptor()) }
+        }
+
+        return null
+    }
+}
+
+/**
+ * Where the project itself lives.
+ *
+ * This is the one that makes native dev containers work: the project directory is inside the
+ * container, so the platform hands back the container's descriptor. It is also the right answer
+ * for Rider, whose extension point never sees the run configuration being launched and so has
+ * nothing more specific to go on.
+ */
+class ProjectDescriptorEnvironmentSource : MirrordEnvironmentSource {
+    override val id = "project-descriptor"
+
+    override fun resolve(context: MirrordLaunchContext): MirrordEnvironment? {
+        val descriptor = runCatching { context.projectDescriptor() }.getOrNull() ?: return null
+        if (descriptor === LocalEelDescriptor) return null
+        return EelEnvironment(descriptor)
+    }
+}
+
+/** Always resolves, so the chain is total and callers never handle null. */
+class LocalEnvironmentSource : MirrordEnvironmentSource {
+    override val id = "local"
+    override fun resolve(context: MirrordLaunchContext): MirrordEnvironment = EelEnvironment(LocalEelDescriptor)
+}
+
+/**
+ * Resolves where mirrord runs, by asking each source in turn.
+ *
+ * The order is data, reviewable in one place, and a new kind of environment is a new source
+ * rather than another branch in a growing `when`. The winner is logged at INFO, so a
+ * misresolution is one grep rather than a debugging session — which matters because "which
+ * environment did it pick" is not otherwise visible from the outside.
+ */
+object MirrordEnvironments {
+    internal val defaultSources: List<MirrordEnvironmentSource> = listOf(
+        ForcedEnvironmentSource(),
+        LegacyWslEnvironmentSource(),
+        TargetRequestEnvironmentSource(),
+        ProjectDescriptorEnvironmentSource(),
+        LocalEnvironmentSource()
+    )
+
+    fun resolve(context: MirrordLaunchContext): MirrordEnvironment = resolve(context, defaultSources)
+
+    internal fun resolve(context: MirrordLaunchContext, sources: List<MirrordEnvironmentSource>): MirrordEnvironment {
+        for (source in sources) {
+            val environment = runCatching { source.resolve(context) }.getOrElse {
+                MirrordLogger.logger.warn("mirrord.bifrost: source=${source.id} threw, skipping", it)
+                null
+            }
+            if (environment != null) {
+                MirrordLogger.logger.info(
+                    "mirrord.bifrost: resolved via=${source.id} env=${environment.name} " +
+                        "local=${environment.isLocal} for=${context.label}"
+                )
+                return environment
+            }
+            MirrordLogger.logger.debug("mirrord.bifrost: source=${source.id} declined for=${context.label}")
+        }
+        error("unreachable: LocalEnvironmentSource always resolves")
+    }
+}

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordPaths.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordPaths.kt
@@ -1,0 +1,37 @@
+package com.metalbear.mirrord.bifrost
+
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * A path as the IDE host sees it.
+ *
+ * Valid for `java.nio`, the VFS, and `PathManager`. **Never hand one of these to the mirrord
+ * CLI.** Under a dev container the CLI runs somewhere the host filesystem does not exist, so a
+ * host path either names the wrong file or no file at all.
+ *
+ * Use [MirrordEnvironment.resolve] to cross into [TargetPath].
+ */
+data class HostPath(val path: Path) {
+    override fun toString(): String = path.toString()
+
+    companion object {
+        fun of(path: String): HostPath = HostPath(Paths.get(path))
+    }
+}
+
+/**
+ * A path as the *target* environment sees it: inside the container, inside the WSL distribution,
+ * or on the host when the target happens to be local.
+ *
+ * This is what the mirrord CLI receives — as an argument, as an environment variable, or as a
+ * working directory.
+ *
+ * [HostPath] and [TargetPath] are separate types on purpose. They were both `String` until
+ * COR-1385, where a host path reaching the CLI produced no error at all: mirrord simply ignored
+ * a config it could not find, fell back to defaults, and reported zero connected layers for four
+ * months. Mixing them is now a compile error rather than a silent runtime one.
+ */
+data class TargetPath(val value: String) {
+    override fun toString(): String = value
+}

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordPaths.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordPaths.kt
@@ -22,15 +22,10 @@ data class HostPath(val path: Path) {
 
 /**
  * A path as the *target* environment sees it: inside the container, inside the WSL distribution,
- * or on the host when the target happens to be local.
+ * or on the host when the target is local.
  *
- * This is what the mirrord CLI receives — as an argument, as an environment variable, or as a
- * working directory.
- *
- * [HostPath] and [TargetPath] are separate types on purpose. They were both `String` until
- * COR-1385, where a host path reaching the CLI produced no error at all: mirrord simply ignored
- * a config it could not find, fell back to defaults, and reported zero connected layers for four
- * months. Mixing them is now a compile error rather than a silent runtime one.
+ * This is what the mirrord CLI receives, as an argument, an environment variable, or a working
+ * directory. Separate from [HostPath] so that mixing the two is a compile error.
  */
 data class TargetPath(val value: String) {
     override fun toString(): String = value

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordTargetPlatform.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordTargetPlatform.kt
@@ -15,13 +15,12 @@ enum class MirrordTargetOs { LINUX, MACOS, WINDOWS }
 enum class MirrordTargetArch { X86_64, ARM64 }
 
 /**
- * OS and architecture of the environment mirrord will run in — the container, the WSL
+ * OS and architecture of the environment mirrord will run in: the container, the WSL
  * distribution, or the host.
  *
- * Deliberately not derived from [SystemInfo]. `SystemInfo` describes the machine the *IDE* runs
- * on, which under a dev container is routinely a different OS and a different architecture from
- * the one the user's process runs on. Asking `SystemInfo` which binary to download is what made
- * a macOS/arm64 build get selected for a linux/amd64 container in COR-1385.
+ * Relying on [SystemInfo] would not account for scenarios where the extension is running on the
+ * host, but execution is happening in another environment (WSL development, dev containers, and
+ * so on). We therefore use the EEL API to pick the right build of mirrord for the target.
  */
 data class MirrordTargetPlatform(val os: MirrordTargetOs, val arch: MirrordTargetArch) {
     val isLinux: Boolean get() = os == MirrordTargetOs.LINUX
@@ -49,10 +48,8 @@ data class MirrordTargetPlatform(val os: MirrordTargetOs, val arch: MirrordTarge
         /**
          * Reads the platform of an environment reached over EEL.
          *
-         * Pure, so every combination is unit-tested without an IDE.
-         *
-         * @throws MirrordError for platforms mirrord has no binary for, rather than the bare
-         * `RuntimeException` the old `SystemInfo`-based code threw — this one reaches the user.
+         * @throws MirrordError for a platform mirrord has no binary for. The message reaches the
+         * user, where the `RuntimeException` this replaces did not.
          */
         fun fromEel(platform: EelPlatform): MirrordTargetPlatform {
             val os = when {
@@ -78,10 +75,10 @@ data class MirrordTargetPlatform(val os: MirrordTargetOs, val arch: MirrordTarge
         /**
          * The IDE host's own platform.
          *
-         * Only correct for things that genuinely run on the host — the legacy WSL integration,
-         * which always targets Linux on the host's architecture, and host-side helper binaries
-         * such as Goland's `dlv`. Everything the user's process touches should come from
-         * [MirrordEnvironment.platform] instead.
+         * Correct only for work that runs on the host: the legacy WSL integration, which targets
+         * Linux on the host's architecture, and helper binaries such as Goland's `dlv`.
+         *
+         * Everything the user's process touches comes from [MirrordEnvironment.platform].
          */
         fun ofHost(): MirrordTargetPlatform {
             val os = when {

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordTargetPlatform.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/bifrost/MirrordTargetPlatform.kt
@@ -1,0 +1,101 @@
+package com.metalbear.mirrord.bifrost
+
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.platform.eel.EelPlatform
+import com.intellij.platform.eel.isArm64
+import com.intellij.platform.eel.isLinux
+import com.intellij.platform.eel.isMac
+import com.intellij.platform.eel.isWindows
+import com.intellij.platform.eel.isX86_64
+import com.intellij.util.system.CpuArch
+import com.metalbear.mirrord.MirrordError
+
+enum class MirrordTargetOs { LINUX, MACOS, WINDOWS }
+
+enum class MirrordTargetArch { X86_64, ARM64 }
+
+/**
+ * OS and architecture of the environment mirrord will run in — the container, the WSL
+ * distribution, or the host.
+ *
+ * Deliberately not derived from [SystemInfo]. `SystemInfo` describes the machine the *IDE* runs
+ * on, which under a dev container is routinely a different OS and a different architecture from
+ * the one the user's process runs on. Asking `SystemInfo` which binary to download is what made
+ * a macOS/arm64 build get selected for a linux/amd64 container in COR-1385.
+ */
+data class MirrordTargetPlatform(val os: MirrordTargetOs, val arch: MirrordTargetArch) {
+    val isLinux: Boolean get() = os == MirrordTargetOs.LINUX
+    val isMac: Boolean get() = os == MirrordTargetOs.MACOS
+    val isWindows: Boolean get() = os == MirrordTargetOs.WINDOWS
+
+    /** Matches the layout under the plugin directory, e.g. `linux`, `macos`, `windows`. */
+    val osDirectoryName: String
+        get() = when (os) {
+            MirrordTargetOs.LINUX -> "linux"
+            MirrordTargetOs.MACOS -> "macos"
+            MirrordTargetOs.WINDOWS -> "windows"
+        }
+
+    /** Matches the layout under the plugin directory, e.g. `x86-64`, `arm64`. */
+    val archDirectoryName: String
+        get() = when (arch) {
+            MirrordTargetArch.X86_64 -> "x86-64"
+            MirrordTargetArch.ARM64 -> "arm64"
+        }
+
+    override fun toString(): String = "$osDirectoryName/$archDirectoryName"
+
+    companion object {
+        /**
+         * Reads the platform of an environment reached over EEL.
+         *
+         * Pure, so every combination is unit-tested without an IDE.
+         *
+         * @throws MirrordError for platforms mirrord has no binary for, rather than the bare
+         * `RuntimeException` the old `SystemInfo`-based code threw — this one reaches the user.
+         */
+        fun fromEel(platform: EelPlatform): MirrordTargetPlatform {
+            val os = when {
+                platform.isLinux -> MirrordTargetOs.LINUX
+                platform.isMac -> MirrordTargetOs.MACOS
+                platform.isWindows -> MirrordTargetOs.WINDOWS
+                else -> throw MirrordError(
+                    "mirrord does not support $platform environments",
+                    "mirrord supports Linux, macOS and Windows targets."
+                )
+            }
+            val arch = when {
+                platform.isX86_64 -> MirrordTargetArch.X86_64
+                platform.isArm64 -> MirrordTargetArch.ARM64
+                else -> throw MirrordError(
+                    "mirrord does not support ${platform.arch} environments",
+                    "mirrord supports x86-64 and arm64 targets."
+                )
+            }
+            return MirrordTargetPlatform(os, arch)
+        }
+
+        /**
+         * The IDE host's own platform.
+         *
+         * Only correct for things that genuinely run on the host — the legacy WSL integration,
+         * which always targets Linux on the host's architecture, and host-side helper binaries
+         * such as Goland's `dlv`. Everything the user's process touches should come from
+         * [MirrordEnvironment.platform] instead.
+         */
+        fun ofHost(): MirrordTargetPlatform {
+            val os = when {
+                SystemInfo.isLinux -> MirrordTargetOs.LINUX
+                SystemInfo.isMac -> MirrordTargetOs.MACOS
+                SystemInfo.isWindows -> MirrordTargetOs.WINDOWS
+                else -> throw MirrordError("Unsupported platform: ${SystemInfo.OS_NAME}")
+            }
+            val arch = when {
+                CpuArch.isIntel64() -> MirrordTargetArch.X86_64
+                CpuArch.isArm64() -> MirrordTargetArch.ARM64
+                else -> throw MirrordError("Unsupported architecture: ${CpuArch.CURRENT.name}")
+            }
+            return MirrordTargetPlatform(os, arch)
+        }
+    }
+}

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordConfigRootTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordConfigRootTest.kt
@@ -7,11 +7,11 @@ import org.junit.jupiter.api.Test
 /**
  * Pins the rule that decides *where* mirrord looks for `.mirrord/mirrord.json`.
  *
- * This exists because getting it wrong is silent. When no config is found the CLI runs with
- * built-in defaults — mirror instead of steal, no HTTP filter, no port mapping — and reports
- * nothing. The plugin looked healthy, the app started, and only a traffic test would have shown
- * the difference. That is COR-1385's signature, and it is why the ordering below is asserted
- * rather than left to reviewer memory.
+ * Getting it wrong is silent. With no config the CLI runs with built-in defaults — mirror
+ * instead of steal, no HTTP filter, no port mapping — and reports nothing.
+ *
+ * The plugin looks healthy and the app starts, so only a traffic test shows the difference. That
+ * is why the ordering below is asserted.
  *
  * The candidate type is generic so the rule can be exercised with plain strings. The production
  * call passes `VirtualFile`, which needs a running IDE; the decision itself does not.

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordConfigRootTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordConfigRootTest.kt
@@ -1,0 +1,101 @@
+package com.metalbear.mirrord
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the rule that decides *where* mirrord looks for `.mirrord/mirrord.json`.
+ *
+ * This exists because getting it wrong is silent. When no config is found the CLI runs with
+ * built-in defaults — mirror instead of steal, no HTTP filter, no port mapping — and reports
+ * nothing. The plugin looked healthy, the app started, and only a traffic test would have shown
+ * the difference. That is COR-1385's signature, and it is why the ordering below is asserted
+ * rather than left to reviewer memory.
+ *
+ * The candidate type is generic so the rule can be exercised with plain strings. The production
+ * call passes `VirtualFile`, which needs a running IDE; the decision itself does not.
+ */
+class MirrordConfigRootTest {
+
+    private fun candidate(source: String, root: String?, mirrordDir: String?) =
+        ConfigRootCandidate(source, root, mirrordDir)
+
+    @Test
+    fun `content root wins when the file-derived heuristic points somewhere else`() {
+        // The dev-container case, and the one that shipped broken. Inside a JetBrains dev
+        // container the workspace file lives under the IDE's own configuration directory, so
+        // deriving the project root from it yields ~/.config/JetBrains/<IDE> — a real directory
+        // that simply has no `.mirrord` in it.
+        val chosen = chooseConfigRoot(
+            listOf(
+                candidate("contentRoot[0]", "/IdeaProjects/repro", "/IdeaProjects/repro/.mirrord"),
+                candidate("projectFileHeuristic", "/home/u/.config/JetBrains/IntelliJIdea2026.2", null)
+            )
+        )
+
+        assertEquals("contentRoot[0]", chosen?.source)
+        assertEquals("/IdeaProjects/repro/.mirrord", chosen?.mirrordDir)
+    }
+
+    @Test
+    fun `heuristic still answers when it is the only source that has the directory`() {
+        // The locally opened project. `.idea/workspace.xml` sits inside the project, so the
+        // heuristic is correct here. It stays a fallback rather than being deleted.
+        val chosen = chooseConfigRoot(
+            listOf(
+                candidate("contentRoot[0]", "/proj", null),
+                candidate("projectFileHeuristic", "/proj", "/proj/.mirrord")
+            )
+        )
+
+        assertEquals("projectFileHeuristic", chosen?.source)
+        assertEquals("/proj/.mirrord", chosen?.mirrordDir)
+    }
+
+    @Test
+    fun `order is by candidate position, not by which source is named`() {
+        // Guards against a refactor that sorts or reorders candidates. Whoever is listed first
+        // and has the directory wins; nothing inspects the source string to decide.
+        val chosen = chooseConfigRoot(
+            listOf(
+                candidate("contentRoot[0]", "/first", "/first/.mirrord"),
+                candidate("contentRoot[1]", "/second", "/second/.mirrord")
+            )
+        )
+
+        assertEquals("/first/.mirrord", chosen?.mirrordDir)
+    }
+
+    @Test
+    fun `a candidate without the directory is skipped, not treated as an answer`() {
+        // A root that exists but holds no `.mirrord` must not end the search. Returning it would
+        // reintroduce the original bug, because the IDE configuration directory does exist.
+        val chosen = chooseConfigRoot(
+            listOf(
+                candidate("contentRoot[0]", "/exists/but/empty", null),
+                candidate("contentRoot[1]", "/has/it", "/has/it/.mirrord")
+            )
+        )
+
+        assertEquals("/has/it/.mirrord", chosen?.mirrordDir)
+    }
+
+    @Test
+    fun `no candidate has the directory`() {
+        val chosen = chooseConfigRoot(
+            listOf(
+                candidate("contentRoot[0]", "/a", null),
+                candidate("projectFileHeuristic", "/b", null)
+            )
+        )
+
+        assertNull(chosen)
+    }
+
+    @Test
+    fun `an empty candidate list is not an error`() {
+        // Reachable when the project has no content roots and the heuristic throws.
+        assertNull(chooseConfigRoot(emptyList<ConfigRootCandidate<String>>()))
+    }
+}

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordPitmEnvTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordPitmEnvTest.kt
@@ -15,11 +15,11 @@ import java.util.Base64
  * Unlike [MirrordWslCharacterizationTest] these need no Windows host and no WSL — the payload
  * encoding and the command-line rewrite are pure functions. They run on every machine and in CI.
  *
- * This matters for the EEL migration for two reasons. `MIRRORD_CHILD_ENV` is an env-transport
- * mechanism that is independent of *where* the process runs, so it should survive the move to an
- * environment abstraction untouched — these tests are what proves that. And the wrap rewrites
- * `exePath` to the CLI path, which is one of the values that becomes environment-relative: today
- * both paths are host paths, and after the migration both must be target paths.
+ * `MIRRORD_CHILD_ENV` transports variables independently of *where* the process runs, so it
+ * survives the move to an environment abstraction untouched. These tests prove that.
+ *
+ * The wrap also rewrites `exePath` to the CLI path, which becomes environment-relative: today
+ * both are host paths, and after the migration both must be target paths.
  */
 class MirrordPitmEnvTest {
 

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordPitmEnvTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordPitmEnvTest.kt
@@ -2,6 +2,7 @@ package com.metalbear.mirrord
 
 import com.google.gson.JsonParser
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.metalbear.mirrord.bifrost.TargetPath
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -79,7 +80,7 @@ class MirrordPitmEnvTest {
 
         MirrordPitm.wrapCommandLine(
             commandLine,
-            cliPath = "C:\\plugins\\mirrord\\bin\\windows\\x86-64\\mirrord.exe",
+            cliPath = TargetPath("C:\\plugins\\mirrord\\bin\\windows\\x86-64\\mirrord.exe"),
             mirrordEnvVars = mapOf("MIRRORD_INTPROXY_ADDR" to "127.0.0.1:1"),
             envToUnset = null
         )
@@ -104,7 +105,7 @@ class MirrordPitmEnvTest {
 
         MirrordPitm.wrapCommandLine(
             commandLine,
-            cliPath = "mirrord.exe",
+            cliPath = TargetPath("mirrord.exe"),
             mirrordEnvVars = mapOf("MIRRORD_INTPROXY_ADDR" to "127.0.0.1:41234"),
             envToUnset = null
         )

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordPitmEnvTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordPitmEnvTest.kt
@@ -1,0 +1,128 @@
+package com.metalbear.mirrord
+
+import com.google.gson.JsonParser
+import com.intellij.execution.configurations.GeneralCommandLine
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.Base64
+
+/**
+ * Tests for the Windows `pitm` env-ferrying payload and command-line wrap.
+ *
+ * Unlike [MirrordWslCharacterizationTest] these need no Windows host and no WSL — the payload
+ * encoding and the command-line rewrite are pure functions. They run on every machine and in CI.
+ *
+ * This matters for the EEL migration for two reasons. `MIRRORD_CHILD_ENV` is an env-transport
+ * mechanism that is independent of *where* the process runs, so it should survive the move to an
+ * environment abstraction untouched — these tests are what proves that. And the wrap rewrites
+ * `exePath` to the CLI path, which is one of the values that becomes environment-relative: today
+ * both paths are host paths, and after the migration both must be target paths.
+ */
+class MirrordPitmEnvTest {
+
+    private fun decodePayload(encoded: String) =
+        JsonParser.parseString(String(Base64.getDecoder().decode(encoded))).asJsonObject
+
+    // ---------------------------------------------------------------- payload encoding
+
+    @Test
+    fun `payload carries the variables the child should receive`() {
+        val encoded = MirrordPitm.encodeChildEnv(
+            mapOf(
+                "MIRRORD_INTPROXY_ADDR" to "127.0.0.1:41234",
+                "MIRRORD_RESOLVED_CONFIG" to """{"feature":{"fs":"read"}}"""
+            ),
+            envToUnset = null
+        )
+
+        val set = decodePayload(encoded).getAsJsonObject("set")
+        assertEquals("127.0.0.1:41234", set.get("MIRRORD_INTPROXY_ADDR").asString)
+        assertEquals("""{"feature":{"fs":"read"}}""", set.get("MIRRORD_RESOLVED_CONFIG").asString)
+    }
+
+    @Test
+    fun `payload omits the unset key when there is nothing to unset`() {
+        val nullCase = decodePayload(MirrordPitm.encodeChildEnv(mapOf("A" to "1"), envToUnset = null))
+        val emptyCase = decodePayload(MirrordPitm.encodeChildEnv(mapOf("A" to "1"), envToUnset = emptyList()))
+
+        assertFalse(nullCase.has("unset"), "unset must be absent, not null, when there is nothing to unset")
+        assertFalse(emptyCase.has("unset"), "an empty unset list must not produce an empty array")
+    }
+
+    @Test
+    fun `payload carries variables the child should drop`() {
+        val encoded = MirrordPitm.encodeChildEnv(
+            mapOf("MIRRORD_INTPROXY_ADDR" to "127.0.0.1:1"),
+            envToUnset = listOf("DYLD_INSERT_LIBRARIES", "LD_PRELOAD")
+        )
+
+        val unset = decodePayload(encoded).getAsJsonArray("unset").map { it.asString }
+        assertEquals(listOf("DYLD_INSERT_LIBRARIES", "LD_PRELOAD"), unset)
+    }
+
+    @Test
+    fun `an empty environment still produces a well-formed payload`() {
+        val payload = decodePayload(MirrordPitm.encodeChildEnv(emptyMap(), envToUnset = null))
+
+        assertTrue(payload.has("set"), "the set object is always present, even when empty")
+        assertTrue(payload.getAsJsonObject("set").entrySet().isEmpty())
+    }
+
+    // ---------------------------------------------------------------- command line wrap
+
+    @Test
+    fun `wrapping launches the original command through pitm`() {
+        val commandLine = GeneralCommandLine("C:\\jdk\\bin\\java.exe")
+            .withParameters("-jar", "app.jar", "--port", "8080")
+
+        MirrordPitm.wrapCommandLine(
+            commandLine,
+            cliPath = "C:\\plugins\\mirrord\\bin\\windows\\x86-64\\mirrord.exe",
+            mirrordEnvVars = mapOf("MIRRORD_INTPROXY_ADDR" to "127.0.0.1:1"),
+            envToUnset = null
+        )
+
+        assertEquals("C:\\plugins\\mirrord\\bin\\windows\\x86-64\\mirrord.exe", commandLine.exePath)
+        assertEquals(
+            listOf("pitm", "--", "C:\\jdk\\bin\\java.exe", "-jar", "app.jar", "--port", "8080"),
+            commandLine.parametersList.list
+        )
+    }
+
+    /**
+     * The wrapper process must not inherit the layer's environment — only the child does, via the
+     * payload. If a mirrord variable stayed on the `mirrord.exe pitm` process itself, that process
+     * would try to load the layer into the wrapper.
+     */
+    @Test
+    fun `wrapping moves mirrord variables off the wrapper and into the payload`() {
+        val commandLine = GeneralCommandLine("app.exe")
+        commandLine.withEnvironment("MIRRORD_INTPROXY_ADDR", "127.0.0.1:41234")
+        commandLine.withEnvironment("PATH", "C:\\Windows\\System32")
+
+        MirrordPitm.wrapCommandLine(
+            commandLine,
+            cliPath = "mirrord.exe",
+            mirrordEnvVars = mapOf("MIRRORD_INTPROXY_ADDR" to "127.0.0.1:41234"),
+            envToUnset = null
+        )
+
+        assertFalse(
+            commandLine.environment.containsKey("MIRRORD_INTPROXY_ADDR"),
+            "mirrord vars must be stripped from the wrapper's own environment"
+        )
+        assertEquals(
+            "C:\\Windows\\System32",
+            commandLine.environment["PATH"],
+            "unrelated variables must survive the wrap"
+        )
+
+        val payload = decodePayload(commandLine.environment.getValue(MirrordPitm.CHILD_ENV_VAR))
+        assertEquals(
+            "127.0.0.1:41234",
+            payload.getAsJsonObject("set").get("MIRRORD_INTPROXY_ADDR").asString
+        )
+    }
+}

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordSettingsStateTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordSettingsStateTest.kt
@@ -34,6 +34,16 @@ class MirrordSettingsStateTest {
         assertTrue(settings.troubleshootingCliEnvVars().isEmpty())
     }
 
+    /**
+     * WSL runs through EEL by default; the legacy `wsl.exe` integration is an opt-out escape
+     * hatch for users hitting a regression. If this default ever flips silently, WSL users stop
+     * exercising the path we actually maintain.
+     */
+    @Test
+    fun legacyWslIsOptOutNotOptIn() {
+        assertEquals(false, MirrordSettingsState.MirrordState().useLegacyWsl)
+    }
+
     @Test
     fun troubleshootingLogPathCanBeTranslatedOrOmitted() {
         val settings = MirrordSettingsState.MirrordState().apply {

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordWslCharacterizationTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordWslCharacterizationTest.kt
@@ -1,0 +1,214 @@
+package com.metalbear.mirrord
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.wsl.WSLCommandLineOptions
+import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.execution.wsl.WslDistributionManager
+import com.intellij.openapi.util.SystemInfo
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Paths
+
+/**
+ * Characterization tests for the **current** WSL integration.
+ *
+ * These do not describe how WSL *should* work — they record how it *does* work today, before
+ * WSL is moved onto the IntelliJ Platform's execution environment layer (EEL). The point is to
+ * have something that fails loudly if the migration changes observable behaviour, because until
+ * now the WSL path has had no test coverage at all.
+ *
+ * After the migration, run this suite twice — once with "Use legacy WSL integration" on and once
+ * off. Identical results mean the swap was behaviour-preserving. Any difference is either a bug
+ * or a deliberate change that belongs in the changelog.
+ *
+ * **These tests require a Windows host with at least one installed WSL distribution.** On any
+ * other machine they report as *skipped*, never as passed — a vacuous pass would be worse than
+ * no test, since it would imply coverage that does not exist. (Note that the existing
+ * `MirrordPitmJdkTest` uses an early `return` instead, so it reports green on Linux while
+ * asserting nothing.)
+ */
+class MirrordWslCharacterizationTest {
+
+    /** Skips the calling test unless a real WSL distribution is available. */
+    private fun requireWsl(): WSLDistribution {
+        assumeTrue(SystemInfo.isWindows, "WSL tests require a Windows host")
+        val distributions = WslDistributionManager.getInstance().installedDistributions
+        assumeTrue(distributions.isNotEmpty(), "WSL tests require an installed WSL distribution")
+        return distributions.first()
+    }
+
+    private fun wslOptionsAsUsedByPlugin() = WSLCommandLineOptions().apply {
+        // Mirrors MirrordApi.prepareCommandLine. `isLaunchWithWslExe = true` deliberately steers
+        // patchCommandLine away from IJent and down the legacy wsl.exe path.
+        isLaunchWithWslExe = true
+        isExecuteCommandInShell = false
+    }
+
+    // ---------------------------------------------------------------- path translation
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `windows drive paths translate to mnt paths`() {
+        val wsl = requireWsl()
+
+        val translated = wsl.getWslPath("C:\\Users\\dev\\project\\.mirrord\\mirrord.json")
+
+        assertEquals("/mnt/c/Users/dev/project/.mirrord/mirrord.json", translated)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `already-linux paths are left alone by the plugin's fallback`() {
+        val wsl = requireWsl()
+
+        // MirrordExecManager.wslPath is `getWslPath(path) ?: path`. A path that already looks
+        // like a distro-side path has no Windows equivalent, so getWslPath returns null and the
+        // original survives. The custom-binary-path feature depends on this: a user pointing at
+        // /home/me/mirrord/target/debug/mirrord must not have it mangled.
+        val linuxPath = "/home/dev/mirrord/target/debug/mirrord"
+
+        assertEquals(linuxPath, wsl.getWslPath(linuxPath) ?: linuxPath)
+    }
+
+    // ---------------------------------------------------------------- binary selection
+
+    @Test
+    fun `a wsl target selects the linux binary even on a windows host`() {
+        val wsl = requireWsl()
+
+        val path = MirrordPathManager.getPath("mirrord", universalOnMac = true, wslDistribution = wsl)
+
+        // WSL runs Linux binaries regardless of the host OS, and inherits the host architecture.
+        assertTrue(
+            path.endsWith(Paths.get("bin", "linux", "x86-64", "mirrord")),
+            "expected a linux/x86-64 binary for a WSL target, got $path"
+        )
+        assertFalse(path.toString().endsWith(".exe"), "a WSL target must not get the .exe binary")
+    }
+
+    @Test
+    fun `no wsl distribution on windows selects the native exe`() {
+        assumeTrue(SystemInfo.isWindows, "requires a Windows host")
+
+        val path = MirrordPathManager.getPath("mirrord", universalOnMac = true, wslDistribution = null)
+
+        assertTrue(path.toString().endsWith("mirrord.exe"), "expected the native Windows binary, got $path")
+    }
+
+    // ---------------------------------------------------------------- classification
+
+    @Test
+    fun `a wsl target is not classified as windows-native`() {
+        val wsl = requireWsl()
+
+        // WSL takes the Linux LD_PRELOAD path, not pitm — even though the host is Windows.
+        assertFalse(isWinNative(wsl))
+        assertTrue(isWinNative(null), "no distribution on a Windows host means native injection")
+    }
+
+    // ---------------------------------------------------------------- command line patching
+
+    @Test
+    fun `patching rewrites the command to launch through wsl exe`() {
+        val wsl = requireWsl()
+
+        val commandLine = GeneralCommandLine("/home/dev/.local/bin/mirrord", "ext")
+            .withParameters("-t", "pod/api")
+
+        wsl.patchCommandLine(commandLine, null, wslOptionsAsUsedByPlugin())
+
+        assertTrue(
+            commandLine.exePath.endsWith("wsl.exe", ignoreCase = true),
+            "expected the command to be launched via wsl.exe, got ${commandLine.exePath}"
+        )
+
+        val params = commandLine.parametersList.list
+        assertEquals("--distribution", params[0])
+        assertEquals(wsl.msId, params[1])
+        assertEquals("--exec", params[2])
+        assertEquals("/home/dev/.local/bin/mirrord", params[3])
+        assertEquals(listOf("ext", "-t", "pod/api"), params.drop(4))
+    }
+
+    // ---------------------------------------------------------------- the WSLENV ordering question
+
+    /**
+     * Environment variables set *before* patching reach the distro.
+     *
+     * `patchCommandLine` builds `WSLENV` from the keys present on the command line at the moment
+     * it runs, so Win32/WSL interop forwards them. This is the case the plugin relies on for
+     * `MIRRORD_EXT_PRINT_CONFIG` and the run configuration's own variables.
+     */
+    @Test
+    fun `wslenv carries variables added before patching`() {
+        val wsl = requireWsl()
+
+        val commandLine = GeneralCommandLine("/usr/bin/mirrord", "ext")
+        commandLine.withEnvironment("MIRRORD_EXT_PRINT_CONFIG", "TRUE")
+
+        wsl.patchCommandLine(commandLine, null, wslOptionsAsUsedByPlugin())
+
+        val wslenv = commandLine.environment["WSLENV"].orEmpty()
+        assertTrue(
+            wslenv.contains("MIRRORD_EXT_PRINT_CONFIG"),
+            "expected MIRRORD_EXT_PRINT_CONFIG to be registered for interop, WSLENV was: $wslenv"
+        )
+    }
+
+    /**
+     * **This test encodes a hypothesis, not a known fact — read the failure message before "fixing" it.**
+     *
+     * `MirrordCliTask.prepareCommandLine` patches the command line at MirrordApi.kt:766-772, but
+     * then adds `MIRRORD_PROGRESS_MODE`, `MIRRORD_PROGRESS_SUPPORT_IDE`, `MIRRORD_IDE_NAME`
+     * (:800-802) and `MIRRORD_BRANCH_NAME` (:789) *after* it. If `WSLENV` is a snapshot taken at
+     * patch time, those four never reach the Linux `mirrord` process under WSL.
+     *
+     * - **Test passes** → the ordering bug is real, and `MIRRORD_PROGRESS_MODE=json` has not been
+     *   reaching the CLI under WSL. That is a shipped bug worth its own issue, and it means the
+     *   new abstraction must make env-vs-patch ordering explicit rather than positional.
+     * - **Test fails** → `WSLENV` is not a snapshot and the hypothesis is wrong. Good news. Delete
+     *   this test and correct `documents/COR-1385/architecture.md`, which currently records it as
+     *   a suspected live bug.
+     */
+    @Test
+    fun `wslenv omits variables added after patching`() {
+        val wsl = requireWsl()
+
+        val commandLine = GeneralCommandLine("/usr/bin/mirrord", "ext")
+        commandLine.withEnvironment("SET_BEFORE_PATCH", "1")
+
+        wsl.patchCommandLine(commandLine, null, wslOptionsAsUsedByPlugin())
+
+        // Exactly what prepareCommandLine does after patching.
+        commandLine.withEnvironment("MIRRORD_PROGRESS_MODE", "json")
+
+        val wslenv = commandLine.environment["WSLENV"].orEmpty()
+        assertTrue(wslenv.contains("SET_BEFORE_PATCH"), "sanity check: WSLENV was $wslenv")
+        assertFalse(
+            wslenv.contains("MIRRORD_PROGRESS_MODE"),
+            "WSLENV picked up a variable added after patching, so the suspected ordering bug " +
+                "does not exist. See this test's KDoc — update the architecture notes rather " +
+                "than changing this assertion. WSLENV was: $wslenv"
+        )
+    }
+
+    // ---------------------------------------------------------------- the second execution path
+
+    /**
+     * `MirrordBinaryManager` probes for a binary with `executeOnWsl`, which bypasses
+     * `GeneralCommandLine` and `ProcessBuilder` entirely. Any replacement for the WSL path has to
+     * cover this too, so it is worth pinning that it works at all.
+     */
+    @Test
+    fun `short probes run inside the distribution`() {
+        val wsl = requireWsl()
+
+        val output = wsl.executeOnWsl(5_000, "uname", "-s")
+
+        assertEquals(0, output.exitCode, "uname failed in WSL: ${output.stderr}")
+        assertEquals("Linux", output.stdout.trim())
+    }
+}

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordWslCharacterizationTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordWslCharacterizationTest.kt
@@ -19,20 +19,14 @@ import java.nio.file.Paths
 /**
  * Characterization tests for the **current** WSL integration.
  *
- * These do not describe how WSL *should* work — they record how it *does* work today, before
- * WSL is moved onto the IntelliJ Platform's execution environment layer (EEL). The point is to
- * have something that fails loudly if the migration changes observable behaviour, because until
- * now the WSL path has had no test coverage at all.
+ * They record how WSL works today, not how it should work, so that the move onto EEL fails
+ * loudly if it changes observable behaviour.
  *
- * After the migration, run this suite twice — once with "Use legacy WSL integration" on and once
- * off. Identical results mean the swap was behaviour-preserving. Any difference is either a bug
- * or a deliberate change that belongs in the changelog.
+ * Run the suite twice after the migration, with "Use legacy WSL integration" on and off.
+ * Identical results mean the swap preserved behaviour.
  *
- * **These tests require a Windows host with at least one installed WSL distribution.** On any
- * other machine they report as *skipped*, never as passed — a vacuous pass would be worse than
- * no test, since it would imply coverage that does not exist. (Note that the existing
- * `MirrordPitmJdkTest` uses an early `return` instead, so it reports green on Linux while
- * asserting nothing.)
+ * **Requires a Windows host with at least one installed WSL distribution.** Elsewhere they report
+ * as *skipped*, never as passed.
  */
 class MirrordWslCharacterizationTest {
 
@@ -45,7 +39,7 @@ class MirrordWslCharacterizationTest {
     }
 
     private fun wslOptionsAsUsedByPlugin() = WSLCommandLineOptions().apply {
-        // Mirrors MirrordApi.prepareCommandLine. `isLaunchWithWslExe = true` deliberately steers
+        // Mirrors MirrordApi.prepareCommandLine. `isLaunchWithWslExe = true` steers
         // patchCommandLine away from IJent and down the legacy wsl.exe path.
         isLaunchWithWslExe = true
         isExecuteCommandInShell = false
@@ -150,9 +144,8 @@ class MirrordWslCharacterizationTest {
     /**
      * Environment variables set *before* patching reach the distro.
      *
-     * `patchCommandLine` builds `WSLENV` from the keys present on the command line at the moment
-     * it runs, so Win32/WSL interop forwards them. This is the case the plugin relies on for
-     * `MIRRORD_EXT_PRINT_CONFIG` and the run configuration's own variables.
+     * `patchCommandLine` builds `WSLENV` from the keys on the command line when it runs, so
+     * interop forwards them. The plugin relies on this for `MIRRORD_EXT_PRINT_CONFIG`.
      */
     @Test
     fun `wslenv carries variables added before patching`() {
@@ -173,16 +166,13 @@ class MirrordWslCharacterizationTest {
     /**
      * **This test encodes a hypothesis, not a known fact — read the failure message before "fixing" it.**
      *
-     * `MirrordCliTask.prepareCommandLine` patches the command line at MirrordApi.kt:766-772, but
-     * then adds `MIRRORD_PROGRESS_MODE`, `MIRRORD_PROGRESS_SUPPORT_IDE`, `MIRRORD_IDE_NAME`
-     * (:800-802) and `MIRRORD_BRANCH_NAME` (:789) *after* it. If `WSLENV` is a snapshot taken at
-     * patch time, those four never reach the Linux `mirrord` process under WSL.
+     * `MirrordCliTask.prepareCommandLine` patches the command line, then adds four more
+     * variables after it. If `WSLENV` is a snapshot taken at patch time, those four never reach
+     * the Linux `mirrord` process.
      *
-     * - **Test passes** → the ordering bug is real, and `MIRRORD_PROGRESS_MODE=json` has not been
-     *   reaching the CLI under WSL. That is a shipped bug worth its own issue, and it means the
-     *   new abstraction must make env-vs-patch ordering explicit rather than positional.
-     * - **Test fails** → `WSLENV` is not a snapshot and the hypothesis is wrong. Good news.
-     *   Delete this test.
+     * - **Passes** → the ordering bug is real, and `MIRRORD_PROGRESS_MODE=json` has not reached
+     *   the CLI under WSL. File it, and make env-vs-patch ordering explicit.
+     * - **Fails** → `WSLENV` is not a snapshot. Delete this test.
      */
     @Test
     fun `wslenv omits variables added after patching`() {

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordWslCharacterizationTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordWslCharacterizationTest.kt
@@ -116,9 +116,9 @@ class MirrordWslCharacterizationTest {
         val wsl = requireWsl()
 
         // WSL takes the Linux LD_PRELOAD path, not pitm — even though the host is Windows.
-        // isWinNative now asks about the target, so this reads directly rather than by proxy.
-        assertFalse(isWinNative(LegacyWslEnvironment(wsl, null).platform()))
-        assertTrue(isWinNative(MirrordTargetPlatform(MirrordTargetOs.WINDOWS, MirrordTargetArch.X86_64)))
+        // isWinNative asks about the target, so this reads it directly rather than by proxy.
+        assertFalse(LegacyWslEnvironment(wsl, null).platform().isWinNative)
+        assertTrue(MirrordTargetPlatform(MirrordTargetOs.WINDOWS, MirrordTargetArch.X86_64).isWinNative)
     }
 
     // ---------------------------------------------------------------- command line patching
@@ -181,9 +181,8 @@ class MirrordWslCharacterizationTest {
      * - **Test passes** → the ordering bug is real, and `MIRRORD_PROGRESS_MODE=json` has not been
      *   reaching the CLI under WSL. That is a shipped bug worth its own issue, and it means the
      *   new abstraction must make env-vs-patch ordering explicit rather than positional.
-     * - **Test fails** → `WSLENV` is not a snapshot and the hypothesis is wrong. Good news. Delete
-     *   this test and correct `documents/COR-1385/architecture.md`, which currently records it as
-     *   a suspected live bug.
+     * - **Test fails** → `WSLENV` is not a snapshot and the hypothesis is wrong. Good news.
+     *   Delete this test.
      */
     @Test
     fun `wslenv omits variables added after patching`() {

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordWslCharacterizationTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordWslCharacterizationTest.kt
@@ -5,6 +5,10 @@ import com.intellij.execution.wsl.WSLCommandLineOptions
 import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.execution.wsl.WslDistributionManager
 import com.intellij.openapi.util.SystemInfo
+import com.metalbear.mirrord.bifrost.LegacyWslEnvironment
+import com.metalbear.mirrord.bifrost.MirrordTargetArch
+import com.metalbear.mirrord.bifrost.MirrordTargetOs
+import com.metalbear.mirrord.bifrost.MirrordTargetPlatform
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -79,7 +83,10 @@ class MirrordWslCharacterizationTest {
     fun `a wsl target selects the linux binary even on a windows host`() {
         val wsl = requireWsl()
 
-        val path = MirrordPathManager.getPath("mirrord", universalOnMac = true, wslDistribution = wsl)
+        // The platform now comes from the environment rather than from SystemInfo, so this
+        // asserts the same outcome through the new route.
+        val platform = LegacyWslEnvironment(wsl, null).platform()
+        val path = MirrordPathManager.getPath("mirrord", universalOnMac = true, platform = platform).path
 
         // WSL runs Linux binaries regardless of the host OS, and inherits the host architecture.
         assertTrue(
@@ -93,7 +100,11 @@ class MirrordWslCharacterizationTest {
     fun `no wsl distribution on windows selects the native exe`() {
         assumeTrue(SystemInfo.isWindows, "requires a Windows host")
 
-        val path = MirrordPathManager.getPath("mirrord", universalOnMac = true, wslDistribution = null)
+        val path = MirrordPathManager.getPath(
+            "mirrord",
+            universalOnMac = true,
+            platform = MirrordTargetPlatform(MirrordTargetOs.WINDOWS, MirrordTargetArch.X86_64)
+        ).path
 
         assertTrue(path.toString().endsWith("mirrord.exe"), "expected the native Windows binary, got $path")
     }
@@ -105,8 +116,9 @@ class MirrordWslCharacterizationTest {
         val wsl = requireWsl()
 
         // WSL takes the Linux LD_PRELOAD path, not pitm — even though the host is Windows.
-        assertFalse(isWinNative(wsl))
-        assertTrue(isWinNative(null), "no distribution on a Windows host means native injection")
+        // isWinNative now asks about the target, so this reads directly rather than by proxy.
+        assertFalse(isWinNative(LegacyWslEnvironment(wsl, null).platform()))
+        assertTrue(isWinNative(MirrordTargetPlatform(MirrordTargetOs.WINDOWS, MirrordTargetArch.X86_64)))
     }
 
     // ---------------------------------------------------------------- command line patching

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/bifrost/FakeMirrordEnvironment.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/bifrost/FakeMirrordEnvironment.kt
@@ -1,0 +1,36 @@
+package com.metalbear.mirrord.bifrost
+
+/**
+ * A [MirrordEnvironment] that records what it was asked to do, so the resolution chain and the
+ * spec builder can be tested with no IDE, no cluster and no container.
+ */
+class FakeMirrordEnvironment(
+    override val name: String = "fake",
+    override val isLocal: Boolean = true,
+    private val platform: MirrordTargetPlatform = MirrordTargetPlatform(MirrordTargetOs.LINUX, MirrordTargetArch.X86_64)
+) : MirrordEnvironment {
+
+    val resolved = mutableListOf<HostPath>()
+    val provided = mutableListOf<HostPath>()
+    val spawned = mutableListOf<MirrordProcessSpec>()
+
+    override fun platform(): MirrordTargetPlatform = platform
+
+    override fun resolve(path: HostPath): TargetPath {
+        resolved += path
+        return TargetPath("/target${path.path}")
+    }
+
+    override fun provide(path: HostPath, name: String): TargetPath {
+        provided += path
+        return TargetPath("/target/provided/$name")
+    }
+
+    override fun spawn(spec: MirrordProcessSpec): Process {
+        spawned += spec
+        throw UnsupportedOperationException("FakeMirrordEnvironment does not start real processes")
+    }
+
+    override fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): MirrordProbeOutput =
+        MirrordProbeOutput(0, "mirrord 3.247.0", "")
+}

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/bifrost/FakeMirrordEnvironment.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/bifrost/FakeMirrordEnvironment.kt
@@ -1,5 +1,7 @@
 package com.metalbear.mirrord.bifrost
 
+import com.intellij.execution.process.ProcessOutput
+
 /**
  * A [MirrordEnvironment] that records what it was asked to do, so the resolution chain and the
  * spec builder can be tested with no IDE, no cluster and no container.
@@ -21,7 +23,7 @@ class FakeMirrordEnvironment(
         return TargetPath("/target${path.path}")
     }
 
-    override fun provide(path: HostPath, name: String): TargetPath {
+    override fun provide(path: HostPath, name: String, onCopy: (Long) -> Unit): TargetPath {
         provided += path
         return TargetPath("/target/provided/$name")
     }
@@ -31,6 +33,6 @@ class FakeMirrordEnvironment(
         throw UnsupportedOperationException("FakeMirrordEnvironment does not start real processes")
     }
 
-    override fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): MirrordProbeOutput =
-        MirrordProbeOutput(0, "mirrord 3.247.0", "")
+    override fun probe(executable: TargetPath, args: List<String>, timeoutMillis: Long): ProcessOutput =
+        ProcessOutput(0).apply { appendStdout("mirrord 3.247.0") }
 }

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/bifrost/FakeMirrordEnvironment.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/bifrost/FakeMirrordEnvironment.kt
@@ -15,6 +15,10 @@ class FakeMirrordEnvironment(
     val resolved = mutableListOf<HostPath>()
     val provided = mutableListOf<HostPath>()
     val spawned = mutableListOf<MirrordProcessSpec>()
+    val located = mutableListOf<String>()
+
+    /** What [locate] answers. Null means "not on the target's PATH". */
+    var locatable: String? = null
 
     override fun platform(): MirrordTargetPlatform = platform
 
@@ -26,6 +30,11 @@ class FakeMirrordEnvironment(
     override fun provide(path: HostPath, name: String, onCopy: (Long) -> Unit): TargetPath {
         provided += path
         return TargetPath("/target/provided/$name")
+    }
+
+    override fun locate(executable: String): TargetPath? {
+        located += executable
+        return locatable?.let { TargetPath(it) }
     }
 
     override fun spawn(spec: MirrordProcessSpec): Process {

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/bifrost/MirrordBifrostTraceTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/bifrost/MirrordBifrostTraceTest.kt
@@ -1,0 +1,83 @@
+package com.metalbear.mirrord.bifrost
+
+import com.intellij.platform.eel.provider.EelUnavailableException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * "Slow" has to be measured rather than guessed: a cold dev container legitimately takes
+ * seconds, a warm one milliseconds. A fixed threshold would either warn on every first run or
+ * never warn at all.
+ */
+class MirrordBifrostTraceTest {
+
+    @Test
+    fun `nothing is slow before there is a baseline`() {
+        val baselines = MirrordBifrostBaselines()
+
+        assertNull(baselines.baselineMillis("spawn"))
+        assertFalse(baselines.isSlow("spawn", elapsedMillis = 60_000, floorMillis = 100))
+    }
+
+    @Test
+    fun `the baseline follows observed timings`() {
+        val baselines = MirrordBifrostBaselines()
+
+        repeat(20) { baselines.record("spawn", 100) }
+
+        val baseline = baselines.baselineMillis("spawn")!!
+        assertTrue(baseline in 95..105, "expected the baseline to settle near 100ms, was ${baseline}ms")
+        assertEquals(20L, baselines.sampleCount("spawn"))
+    }
+
+    @Test
+    fun `a large outlier against a settled baseline is slow`() {
+        val baselines = MirrordBifrostBaselines()
+        repeat(20) { baselines.record("connect", 1_000) }
+
+        assertTrue(baselines.isSlow("connect", elapsedMillis = 10_000, floorMillis = 5_000))
+    }
+
+    @Test
+    fun `a fast operation is not slow just for tripling`() {
+        // 6ms against a 2ms baseline is 3x, but nobody wants a warning balloon about it.
+        val baselines = MirrordBifrostBaselines()
+        repeat(20) { baselines.record("resolve", 2) }
+
+        assertFalse(baselines.isSlow("resolve", elapsedMillis = 6, floorMillis = 5_000))
+    }
+
+    @Test
+    fun `baselines are tracked per operation`() {
+        val baselines = MirrordBifrostBaselines()
+        repeat(10) { baselines.record("connect", 5_000) }
+        repeat(10) { baselines.record("resolve", 1) }
+
+        assertTrue(baselines.baselineMillis("connect")!! > baselines.baselineMillis("resolve")!!)
+        assertNull(baselines.baselineMillis("never-run"))
+    }
+
+    @Test
+    fun `an unreachable environment is named in the error`() {
+        val error = bifrostFailure(
+            environment = "devcontainer:javascript-node",
+            operation = "connect",
+            cause = EelUnavailableException("not running", null)
+        )
+
+        // The user has to be able to tell which environment failed, and be told what to do
+        // instead. "mirrord failed" on its own is what made this ticket take four months.
+        assertTrue(error.toString().isNotEmpty())
+        assertTrue(error.cause is EelUnavailableException)
+    }
+
+    @Test
+    fun `an unexpected failure still produces a mirrord error`() {
+        val error = bifrostFailure("local", "spawn", IllegalStateException("kaboom"))
+
+        assertTrue(error.cause is IllegalStateException)
+    }
+}

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/bifrost/MirrordBifrostTraceTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/bifrost/MirrordBifrostTraceTest.kt
@@ -1,11 +1,11 @@
 package com.metalbear.mirrord.bifrost
 
-import com.intellij.platform.eel.provider.EelUnavailableException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.io.IOException
 
 /**
  * "Slow" has to be measured rather than guessed: a cold dev container legitimately takes
@@ -65,13 +65,13 @@ class MirrordBifrostTraceTest {
         val error = bifrostFailure(
             environment = "devcontainer:javascript-node",
             operation = "connect",
-            cause = EelUnavailableException("not running", null)
+            cause = IOException("environment not running")
         )
 
         // The user has to be able to tell which environment failed, and be told what to do
         // instead. "mirrord failed" on its own is what made this ticket take four months.
         assertTrue(error.toString().isNotEmpty())
-        assertTrue(error.cause is EelUnavailableException)
+        assertTrue(error.cause is IOException)
     }
 
     @Test

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironmentSourceTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/bifrost/MirrordEnvironmentSourceTest.kt
@@ -1,0 +1,115 @@
+package com.metalbear.mirrord.bifrost
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+/**
+ * The resolution chain replaces the same four-line `when` that was copy-pasted across eleven
+ * product files. These tests are what make that trade worthwhile: the decision is now in one
+ * place and can be exercised without an IDE.
+ */
+class MirrordEnvironmentSourceTest {
+
+    private fun context(
+        label: String = "test",
+        forced: MirrordEnvironment? = null
+    ) = MirrordLaunchContext(
+        label = label,
+        targetRequest = null,
+        forced = forced,
+        project = null,
+        descriptorSupplier = { null }
+    )
+
+    private fun source(id: String, result: MirrordEnvironment?) = object : MirrordEnvironmentSource {
+        override val id = id
+        override fun resolve(context: MirrordLaunchContext): MirrordEnvironment? = result
+    }
+
+    @Test
+    fun `first source to answer wins`() {
+        val first = FakeMirrordEnvironment("first")
+        val second = FakeMirrordEnvironment("second")
+
+        val resolved = MirrordEnvironments.resolve(
+            context(),
+            listOf(source("a", null), source("b", first), source("c", second))
+        )
+
+        assertSame(first, resolved, "a later source must not override an earlier one")
+    }
+
+    @Test
+    fun `a source that throws is skipped rather than fatal`() {
+        val fallback = FakeMirrordEnvironment("fallback")
+        val exploding = object : MirrordEnvironmentSource {
+            override val id = "exploding"
+            override fun resolve(context: MirrordLaunchContext): MirrordEnvironment =
+                throw IllegalStateException("boom")
+        }
+
+        val resolved = MirrordEnvironments.resolve(context(), listOf(exploding, source("ok", fallback)))
+
+        // One environment kind failing to introspect itself must not stop mirrord from running
+        // at all — it should fall through to something that works.
+        assertSame(fallback, resolved)
+    }
+
+    @Test
+    fun `forced environment beats everything`() {
+        val forced = FakeMirrordEnvironment("forced")
+        val other = FakeMirrordEnvironment("other")
+
+        val resolved = MirrordEnvironments.resolve(
+            context(forced = forced),
+            listOf(ForcedEnvironmentSource(), source("other", other))
+        )
+
+        assertSame(forced, resolved)
+    }
+
+    @Test
+    fun `legacy wsl declines when the opt-out is off`() {
+        val source = LegacyWslEnvironmentSource(legacyEnabled = { false })
+
+        assertNull(source.resolve(context()))
+    }
+
+    @Test
+    fun `legacy wsl declines when the launch is not wsl even if the opt-out is on`() {
+        // The setting must be inert outside WSL. A user who turns it on to work around a WSL
+        // problem should not thereby change how their dev container behaves.
+        val source = LegacyWslEnvironmentSource(legacyEnabled = { true })
+
+        assertNull(source.resolve(context()))
+    }
+
+    @Test
+    fun `target request source declines when there is no request`() {
+        assertNull(TargetRequestEnvironmentSource().resolve(context()))
+    }
+
+    @Test
+    fun `project descriptor source declines when the project has no descriptor`() {
+        assertNull(ProjectDescriptorEnvironmentSource().resolve(context()))
+    }
+
+    @Test
+    fun `wslDistributionOf is null for a non-wsl request`() {
+        assertNull(wslDistributionOf(null))
+    }
+
+    @Test
+    fun `the chain is total`() {
+        // Every source declining must still produce an environment: callers never handle null,
+        // and "mirrord silently did nothing" is the failure mode this whole change exists to end.
+        val resolved = MirrordEnvironments.resolve(
+            context(),
+            listOf(source("a", null), source("b", null), LocalEnvironmentSource())
+        )
+
+        assertEquals(true, resolved.isLocal)
+    }
+}

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/bifrost/MirrordTargetPlatformTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/bifrost/MirrordTargetPlatformTest.kt
@@ -1,0 +1,77 @@
+package com.metalbear.mirrord.bifrost
+
+import com.intellij.platform.eel.EelPlatform
+import com.metalbear.mirrord.MirrordError
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Binary selection is where COR-1385 actually bit: the plugin asked `SystemInfo` what OS it was
+ * on, got "macOS/arm64" from the IDE host, and downloaded that build for a linux/amd64
+ * container. These tests pin the replacement — the platform now comes from the environment.
+ */
+class MirrordTargetPlatformTest {
+
+    @Test
+    fun `linux x86-64 maps to the linux binary directory`() {
+        val platform = MirrordTargetPlatform.fromEel(EelPlatform.Linux(EelPlatform.Arch.X86_64))
+
+        assertEquals(MirrordTargetOs.LINUX, platform.os)
+        assertEquals(MirrordTargetArch.X86_64, platform.arch)
+        assertEquals("linux", platform.osDirectoryName)
+        assertEquals("x86-64", platform.archDirectoryName)
+    }
+
+    @Test
+    fun `linux arm64 maps to arm64`() {
+        val platform = MirrordTargetPlatform.fromEel(EelPlatform.Linux(EelPlatform.Arch.ARM_64))
+
+        assertTrue(platform.isLinux)
+        assertEquals(MirrordTargetArch.ARM64, platform.arch)
+    }
+
+    @Test
+    fun `darwin maps to macos`() {
+        val platform = MirrordTargetPlatform.fromEel(EelPlatform.Darwin(EelPlatform.Arch.ARM_64))
+
+        assertTrue(platform.isMac)
+        assertEquals("macos", platform.osDirectoryName)
+    }
+
+    @Test
+    fun `windows maps to windows`() {
+        val platform = MirrordTargetPlatform.fromEel(EelPlatform.Windows(EelPlatform.Arch.X86_64))
+
+        assertTrue(platform.isWindows)
+        assertEquals("windows", platform.osDirectoryName)
+    }
+
+    @Test
+    fun `the exact case from the ticket - a mac host does not decide a linux target`() {
+        // Ari's IDE ran on macOS/arm64; the container was linux/amd64. The old code consulted
+        // SystemInfo and got the first of those. This asserts the platform is now read from the
+        // environment, so the host's answer cannot leak in.
+        val target = MirrordTargetPlatform.fromEel(EelPlatform.Linux(EelPlatform.Arch.X86_64))
+
+        assertEquals("linux/x86-64", target.toString())
+    }
+
+    @Test
+    fun `unsupported architectures fail with a user-facing error`() {
+        // Not a bare RuntimeException: this reaches the user, so it has to read like a sentence.
+        val error = assertThrows<MirrordError> {
+            MirrordTargetPlatform.fromEel(EelPlatform.Linux(EelPlatform.Arch.ARM_32))
+        }
+
+        assertTrue(error.cause == null || error.cause is Throwable)
+    }
+
+    @Test
+    fun `unsupported operating systems fail with a user-facing error`() {
+        assertThrows<MirrordError> {
+            MirrordTargetPlatform.fromEel(EelPlatform.FreeBSD(EelPlatform.Arch.X86_64))
+        }
+    }
+}

--- a/modules/products/bazel/src/main/kotlin/com/metalbear/mirrord/products/bazel/BazelExecutionListener.kt
+++ b/modules/products/bazel/src/main/kotlin/com/metalbear/mirrord/products/bazel/BazelExecutionListener.kt
@@ -3,13 +3,11 @@ package com.metalbear.mirrord.products.bazel
 import com.intellij.execution.ExecutionListener
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.execution.target.createEnvironmentRequest
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.service
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordProjectService
 import com.metalbear.mirrord.bifrost.MirrordEnvironments
-import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.String
 
@@ -67,9 +65,7 @@ class BazelExecutionListener : ExecutionListener {
 
         MirrordLogger.logger.debug("[${this.javaClass.name}] processStartScheduled: wsl check")
         @Suppress("UnstableApiUsage") // `createEnvironmentRequest`
-        val environment = MirrordEnvironments.resolve(
-            MirrordLaunchContext(env.project, createEnvironmentRequest(env.runProfile, env.project))
-        )
+        val environment = MirrordEnvironments.forRunProfile(env.project, env.runProfile)
 
         try {
             service.execManager.wrapper("bazel", originalEnv, environment).apply {

--- a/modules/products/bazel/src/main/kotlin/com/metalbear/mirrord/products/bazel/BazelExecutionListener.kt
+++ b/modules/products/bazel/src/main/kotlin/com/metalbear/mirrord/products/bazel/BazelExecutionListener.kt
@@ -4,11 +4,12 @@ import com.intellij.execution.ExecutionListener
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.target.createEnvironmentRequest
-import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.service
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordProjectService
+import com.metalbear.mirrord.bifrost.MirrordEnvironments
+import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.String
 
@@ -66,14 +67,12 @@ class BazelExecutionListener : ExecutionListener {
 
         MirrordLogger.logger.debug("[${this.javaClass.name}] processStartScheduled: wsl check")
         @Suppress("UnstableApiUsage") // `createEnvironmentRequest`
-        val wsl = when (val request = createEnvironmentRequest(env.runProfile, env.project)) {
-            is WslTargetEnvironmentRequest -> request.configuration.distribution!!
-            else -> null
-        }
+        val environment = MirrordEnvironments.resolve(
+            MirrordLaunchContext(env.project, createEnvironmentRequest(env.runProfile, env.project))
+        )
 
         try {
-            service.execManager.wrapper("bazel", originalEnv).apply {
-                this.wsl = wsl
+            service.execManager.wrapper("bazel", originalEnv, environment).apply {
                 this.executable = binaryToPatch
             }.start()?.let { executionInfo ->
                 MirrordLogger.logger.debug("[${this.javaClass.name}] processStartScheduled: adding ${executionInfo.environment.size} environment variables")

--- a/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
+++ b/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
@@ -15,7 +15,6 @@ import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordPathManager
 import com.metalbear.mirrord.MirrordProjectService
 import com.metalbear.mirrord.bifrost.MirrordEnvironments
-import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import java.nio.file.Paths
 
 class GolandRunConfigurationExtension : GoRunConfigurationExtension() {
@@ -42,9 +41,7 @@ class GolandRunConfigurationExtension : GoRunConfigurationExtension() {
         if (commandLineType == GoRunningState.CommandLineType.RUN) {
             val service = configuration.getProject().service<MirrordProjectService>()
 
-            val environment = MirrordEnvironments.resolve(
-                MirrordLaunchContext(configuration.project, state.targetEnvironmentRequest)
-            )
+            val environment = MirrordEnvironments.forRequest(configuration.project, state.targetEnvironmentRequest)
 
             service.execManager.wrapper("goland", configuration.getCustomEnvironment(), environment)
                 .start()?.let { executionInfo ->

--- a/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
+++ b/modules/products/goland/src/main/kotlin/com/metalbear/mirrord/products/goland/GolandRunConfigurationExtension.kt
@@ -8,13 +8,14 @@ import com.goide.util.GoCommandLineParameter.PathParameter
 import com.goide.util.GoExecutor
 import com.intellij.execution.configurations.RunnerSettings
 import com.intellij.execution.target.TargetedCommandLineBuilder
-import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.openapi.components.service
 import com.intellij.openapi.util.SystemInfo
 import com.metalbear.mirrord.MirrordError
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordPathManager
 import com.metalbear.mirrord.MirrordProjectService
+import com.metalbear.mirrord.bifrost.MirrordEnvironments
+import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import java.nio.file.Paths
 
 class GolandRunConfigurationExtension : GoRunConfigurationExtension() {
@@ -41,29 +42,24 @@ class GolandRunConfigurationExtension : GoRunConfigurationExtension() {
         if (commandLineType == GoRunningState.CommandLineType.RUN) {
             val service = configuration.getProject().service<MirrordProjectService>()
 
-            val wsl = state.targetEnvironmentRequest?.let {
-                if (it is WslTargetEnvironmentRequest) {
-                    it.configuration.distribution
-                } else {
-                    null
-                }
-            }
+            val environment = MirrordEnvironments.resolve(
+                MirrordLaunchContext(configuration.project, state.targetEnvironmentRequest)
+            )
 
-            service.execManager.wrapper("goland", configuration.getCustomEnvironment()).apply {
-                this.wsl = wsl
-            }.start()?.let { executionInfo ->
+            service.execManager.wrapper("goland", configuration.getCustomEnvironment(), environment)
+                .start()?.let { executionInfo ->
 
-                for (entry in executionInfo.environment.entries.iterator()) {
-                    cmdLine.addEnvironmentVariable(entry.key, entry.value)
-                }
-                cmdLine.addEnvironmentVariable("MIRRORD_SKIP_PROCESSES", "dlv;debugserver;go")
+                    for (entry in executionInfo.environment.entries.iterator()) {
+                        cmdLine.addEnvironmentVariable(entry.key, entry.value)
+                    }
+                    cmdLine.addEnvironmentVariable("MIRRORD_SKIP_PROCESSES", "dlv;debugserver;go")
 
-                executionInfo.envToUnset?.let { keys ->
-                    for (key in keys.iterator()) {
-                        cmdLine.removeEnvironmentVariable(key)
+                    executionInfo.envToUnset?.let { keys ->
+                        for (key in keys.iterator()) {
+                            cmdLine.removeEnvironmentVariable(key)
+                        }
                     }
                 }
-            }
         }
         super.patchCommandLine(configuration, runnerSettings, cmdLine, runnerId, state, commandLineType)
     }
@@ -145,7 +141,7 @@ class GolandRunConfigurationExtension : GoRunConfigurationExtension() {
      * Return path to custom delve bundled with mirrord plugin.
      */
     private fun getCustomDelvePath(): String {
-        return MirrordPathManager.getBinary("dlv", false)!!
+        return MirrordPathManager.getHostBinary("dlv", false)!!.path.toString()
     }
 
     /**

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaExecutionListener.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaExecutionListener.kt
@@ -7,10 +7,11 @@ import com.intellij.execution.configurations.RunConfigurationBase
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.target.createEnvironmentRequest
-import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.openapi.components.service
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordProjectService
+import com.metalbear.mirrord.bifrost.MirrordEnvironments
+import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 
 class IdeaExecutionListener : ExecutionListener {
     override fun processStartScheduled(executorId: String, env: ExecutionEnvironment) {
@@ -29,16 +30,14 @@ class IdeaExecutionListener : ExecutionListener {
         if (!alreadyContainsInitTask) {
             configuration.beforeRunTasks = configuration.beforeRunTasks + IdeaBeforeRunTaskProvider.IdeaBeforeRunTask {
                 val service = env.project.service<MirrordProjectService>()
-                val wsl = when (val request = createEnvironmentRequest(env.runProfile, env.project)) {
-                    is WslTargetEnvironmentRequest -> request.configuration.distribution
-                    else -> null
-                }
+                val environment = MirrordEnvironments.resolve(
+                    MirrordLaunchContext(env.project, createEnvironmentRequest(env.runProfile, env.project))
+                )
 
-                service.execManager.wrapper("idea", getIdeaConfigurationEnv(configuration)).apply {
-                    this.wsl = wsl
-                }.start()?.let { executionInfo ->
-                    IdeaMirrordPreparationStore.put(configuration, executionInfo)
-                }
+                service.execManager.wrapper("idea", getIdeaConfigurationEnv(configuration), environment)
+                    .start()?.let { executionInfo ->
+                        IdeaMirrordPreparationStore.put(configuration, executionInfo)
+                    }
             }
         }
 

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaExecutionListener.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaExecutionListener.kt
@@ -6,12 +6,10 @@ import com.intellij.execution.ExecutionListener
 import com.intellij.execution.configurations.RunConfigurationBase
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.execution.target.createEnvironmentRequest
 import com.intellij.openapi.components.service
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordProjectService
 import com.metalbear.mirrord.bifrost.MirrordEnvironments
-import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 
 class IdeaExecutionListener : ExecutionListener {
     override fun processStartScheduled(executorId: String, env: ExecutionEnvironment) {
@@ -30,13 +28,11 @@ class IdeaExecutionListener : ExecutionListener {
         if (!alreadyContainsInitTask) {
             configuration.beforeRunTasks = configuration.beforeRunTasks + IdeaBeforeRunTaskProvider.IdeaBeforeRunTask {
                 val service = env.project.service<MirrordProjectService>()
-                val environment = MirrordEnvironments.resolve(
-                    MirrordLaunchContext(env.project, createEnvironmentRequest(env.runProfile, env.project))
-                )
+                val environment = MirrordEnvironments.forRunProfile(env.project, env.runProfile)
 
                 service.execManager.wrapper("idea", getIdeaConfigurationEnv(configuration), environment)
                     .start()?.let { executionInfo ->
-                        IdeaMirrordPreparationStore.put(configuration, executionInfo)
+                        IdeaMirrordPreparationStore.put(configuration, executionInfo, environment)
                     }
             }
         }

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaMirrordPreparationStore.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaMirrordPreparationStore.kt
@@ -2,26 +2,42 @@ package com.metalbear.mirrord.products.idea
 
 import com.intellij.execution.configurations.RunConfigurationBase
 import com.metalbear.mirrord.MirrordExecution
+import com.metalbear.mirrord.bifrost.MirrordEnvironment
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
+
+/**
+ * What the before-run task prepared: the mirrord execution, and the environment it ran in.
+ *
+ * The environment travels with the execution deliberately. `updateJavaParameters` runs under a
+ * read lock and cannot afford to resolve one itself — and even if it could, re-resolving there
+ * has no access to the run configuration's target request, so it could legitimately pick a
+ * *different* environment than the one `mirrord ext` actually ran in. Injection-strategy gating
+ * and binary selection would then be deciding about the wrong machine.
+ */
+internal data class IdeaMirrordPreparation(
+    val execution: MirrordExecution,
+    val environment: MirrordEnvironment
+)
 
 /**
  * Stores mirrord execution info prepared in before-run tasks until Java parameters are created.
  */
 internal object IdeaMirrordPreparationStore {
-    private val queueByConfiguration = ConcurrentHashMap<RunConfigurationBase<*>, ConcurrentLinkedQueue<MirrordExecution>>()
+    private val queueByConfiguration = ConcurrentHashMap<RunConfigurationBase<*>, ConcurrentLinkedQueue<IdeaMirrordPreparation>>()
 
-    fun put(configuration: RunConfigurationBase<*>, execution: MirrordExecution) {
-        queueByConfiguration.computeIfAbsent(configuration) { ConcurrentLinkedQueue() }.add(execution)
+    fun put(configuration: RunConfigurationBase<*>, execution: MirrordExecution, environment: MirrordEnvironment) {
+        queueByConfiguration.computeIfAbsent(configuration) { ConcurrentLinkedQueue() }
+            .add(IdeaMirrordPreparation(execution, environment))
     }
 
-    fun consume(configuration: RunConfigurationBase<*>): MirrordExecution? {
+    fun consume(configuration: RunConfigurationBase<*>): IdeaMirrordPreparation? {
         val queue = queueByConfiguration[configuration] ?: return null
-        val execution = queue.poll()
+        val preparation = queue.poll()
         if (queue.isEmpty()) {
             queueByConfiguration.remove(configuration, queue)
         }
-        return execution
+        return preparation
     }
 
     fun clear(configuration: RunConfigurationBase<*>) {

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaMirrordPreparationStore.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaMirrordPreparationStore.kt
@@ -9,11 +9,11 @@ import java.util.concurrent.ConcurrentLinkedQueue
 /**
  * What the before-run task prepared: the mirrord execution, and the environment it ran in.
  *
- * The environment travels with the execution deliberately. `updateJavaParameters` runs under a
- * read lock and cannot afford to resolve one itself — and even if it could, re-resolving there
- * has no access to the run configuration's target request, so it could legitimately pick a
- * *different* environment than the one `mirrord ext` actually ran in. Injection-strategy gating
- * and binary selection would then be deciding about the wrong machine.
+ * The environment travels with the execution because `updateJavaParameters` runs under a read
+ * lock and cannot resolve one itself.
+ *
+ * It also has no access to the run configuration's target request, so resolving there would
+ * pick a different environment than the one `mirrord ext` ran in.
  */
 internal data class IdeaMirrordPreparation(
     val execution: MirrordExecution,

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
@@ -11,8 +11,6 @@ import com.intellij.execution.configurations.RunnerSettings
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessListener
-import com.intellij.execution.target.createEnvironmentRequest
-import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.service
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemRunConfiguration
@@ -22,6 +20,8 @@ import com.metalbear.mirrord.MirrordBinaryManager
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordPitm
 import com.metalbear.mirrord.MirrordProjectService
+import com.metalbear.mirrord.bifrost.MirrordEnvironments
+import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import com.metalbear.mirrord.isWinNative
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
@@ -158,15 +158,15 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
             "updateJavaParameters: executionInfo consumed, mirrordEnv size=${mirrordEnv.size}, envToUnset size=${envToUnset?.size ?: 0}"
         )
 
-        // Resolve WSL for platform gating (Windows-native-only pitm paths).
-        @Suppress("UnstableApiUsage")
-        val wsl = when (val request = createEnvironmentRequest(configuration, configuration.project)) {
-            is WslTargetEnvironmentRequest -> request.configuration.distribution!!
-            else -> null
-        }
-        val winNative = isWinNative(wsl)
+        // Gating only: which injection mechanism this target needs.
+        //
+        // Deliberately reads the *stored* platform rather than resolving an environment here.
+        // This method runs under a read lock, and resolving would mean blocking on a possibly
+        // cold dev container from inside it — a good way to deadlock the IDE.
+        val environment = MirrordEnvironments.resolve(MirrordLaunchContext(configuration.project))
+        val winNative = isWinNative(environment.platform())
         MirrordLogger.logger.info(
-            "updateJavaParameters: platform gating winNative=$winNative wsl=${wsl?.presentableName ?: "null"} isDebug=$isDebug"
+            "updateJavaParameters: platform gating winNative=$winNative env=${environment.name} isDebug=$isDebug"
         )
 
         // On Windows native, try to wrap the JDK with mirrord pitm. When that
@@ -299,7 +299,7 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
         }
 
         val mirrordExe = try {
-            File(service<MirrordBinaryManager>().getBinary("idea", null, project))
+            File(service<MirrordBinaryManager>().getBinary("idea", MirrordEnvironments.resolve(MirrordLaunchContext(project)), project).value)
         } catch (e: Exception) {
             MirrordLogger.logger.warn("wrapJdkWithPitm: failed to resolve mirrord binary: ${e.message}", e)
             project.service<MirrordProjectService>().notifier.notifySimple(

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
@@ -161,10 +161,10 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
         // Gating only: which injection mechanism this target needs.
         //
         // Reuses the environment the before-run task resolved. This method runs under a read
-        // lock, so resolving here would mean blocking on a possibly cold dev container from
-        // inside it — a good way to deadlock the IDE. It would also be resolving without the
-        // run configuration's target request, so it could pick a different environment than
-        // the one `mirrord ext` actually ran in.
+        // lock, so resolving here risks blocking on a cold dev container from inside it.
+        //
+        // It would also resolve without the run configuration's target request, and pick a
+        // different environment than the one `mirrord ext` ran in.
         val environment = preparation.environment
         val winNative = environment.platform().isWinNative
         MirrordLogger.logger.info(

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/IdeaRunConfigurationExtension.kt
@@ -20,8 +20,7 @@ import com.metalbear.mirrord.MirrordBinaryManager
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordPitm
 import com.metalbear.mirrord.MirrordProjectService
-import com.metalbear.mirrord.bifrost.MirrordEnvironments
-import com.metalbear.mirrord.bifrost.MirrordLaunchContext
+import com.metalbear.mirrord.bifrost.MirrordEnvironment
 import com.metalbear.mirrord.isWinNative
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
@@ -145,12 +144,13 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
             "isExternal=${configuration.isExternalBuildSystem()}"
         MirrordLogger.logger.info("updateJavaParameters: ENTER $configSummary")
 
-        val executionInfo = IdeaMirrordPreparationStore.consume(configuration) ?: run {
+        val preparation = IdeaMirrordPreparationStore.consume(configuration) ?: run {
             // Main mirrord initialization is prepared by a before-run task to avoid blocking here under read lock.
             MirrordLogger.logger.info("updateJavaParameters: no prepared executionInfo for `${configuration.name}`, skipping (check IdeaExecutionListener/BeforeRunTask ran)")
             return
         }
 
+        val executionInfo = preparation.execution
         val isDebug = runnerSettings.isJvmDebug
         val mirrordEnv = executionInfo.environment + ("MIRRORD_DETECT_DEBUGGER_PORT" to "javaagent")
         val envToUnset = executionInfo.envToUnset
@@ -160,11 +160,13 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
 
         // Gating only: which injection mechanism this target needs.
         //
-        // Deliberately reads the *stored* platform rather than resolving an environment here.
-        // This method runs under a read lock, and resolving would mean blocking on a possibly
-        // cold dev container from inside it — a good way to deadlock the IDE.
-        val environment = MirrordEnvironments.resolve(MirrordLaunchContext(configuration.project))
-        val winNative = isWinNative(environment.platform())
+        // Reuses the environment the before-run task resolved. This method runs under a read
+        // lock, so resolving here would mean blocking on a possibly cold dev container from
+        // inside it — a good way to deadlock the IDE. It would also be resolving without the
+        // run configuration's target request, so it could pick a different environment than
+        // the one `mirrord ext` actually ran in.
+        val environment = preparation.environment
+        val winNative = environment.platform().isWinNative
         MirrordLogger.logger.info(
             "updateJavaParameters: platform gating winNative=$winNative env=${environment.name} isDebug=$isDebug"
         )
@@ -181,7 +183,7 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
         val usesWinGradlePitm = winNative && configuration.isGradleRunConfiguration()
         val pitmWrapped = if (winNative && !configuration.isExternalBuildSystem()) {
             MirrordLogger.logger.info("updateJavaParameters: branch=NON_GRADLE_WIN, attempting wrapJdkWithPitm")
-            wrapJdkWithPitm(configuration.project, params, mirrordEnv, envToUnset)
+            wrapJdkWithPitm(configuration.project, params, mirrordEnv, envToUnset, environment)
         } else {
             false
         }
@@ -235,7 +237,7 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
                     // preserves that late argument and hands its port to the layer through
                     // MIRRORD_IGNORE_DEBUGGER_PORTS, leaving the debugger's loopback
                     // connection unmanaged.
-                    MirrordWinGradleInjector.wrap(configuration, mirrordEnv, envToUnset, isDebug)
+                    MirrordWinGradleInjector.wrap(configuration, mirrordEnv, envToUnset, isDebug, environment)
                 }
                 else -> {
                     // Non-Windows: set env vars directly on the config.
@@ -272,7 +274,8 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
         project: Project,
         params: JavaParameters,
         mirrordEnvVars: Map<String, String>,
-        envToUnset: List<String>?
+        envToUnset: List<String>?,
+        environment: MirrordEnvironment
     ): Boolean {
         MirrordLogger.logger.info(
             "wrapJdkWithPitm: ENTER jdk=${params.jdk?.name ?: "null"} jdkHome=${params.jdk?.homePath ?: "null"} " +
@@ -299,7 +302,7 @@ class IdeaRunConfigurationExtension : RunConfigurationExtension() {
         }
 
         val mirrordExe = try {
-            File(service<MirrordBinaryManager>().getBinary("idea", MirrordEnvironments.resolve(MirrordLaunchContext(project)), project).value)
+            File(service<MirrordBinaryManager>().getBinary("idea", environment, project).value)
         } catch (e: Exception) {
             MirrordLogger.logger.warn("wrapJdkWithPitm: failed to resolve mirrord binary: ${e.message}", e)
             project.service<MirrordProjectService>().notifier.notifySimple(

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/MirrordSbtRunConfiguration.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/MirrordSbtRunConfiguration.kt
@@ -12,6 +12,8 @@ import com.metalbear.mirrord.MirrordExecution
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordLogsService
 import com.metalbear.mirrord.MirrordProjectService
+import com.metalbear.mirrord.bifrost.MirrordEnvironments
+import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import org.jetbrains.sbt.runner.SbtCommandLineState
 import org.jetbrains.sbt.runner.SbtRunConfiguration
 import scala.Function1
@@ -182,7 +184,8 @@ class MirrordSbtRunConfiguration(
         }
 
         val service = project.service<MirrordProjectService>()
-        return service.execManager.wrapper("idea", getSbtConfigurationEnv(this)).start()
+        val environment = MirrordEnvironments.resolve(MirrordLaunchContext(project))
+        return service.execManager.wrapper("idea", getSbtConfigurationEnv(this), environment).start()
     }
 
     private fun createDirectLaunchState(

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/MirrordSbtRunConfiguration.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/MirrordSbtRunConfiguration.kt
@@ -13,7 +13,6 @@ import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordLogsService
 import com.metalbear.mirrord.MirrordProjectService
 import com.metalbear.mirrord.bifrost.MirrordEnvironments
-import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import org.jetbrains.sbt.runner.SbtCommandLineState
 import org.jetbrains.sbt.runner.SbtRunConfiguration
 import scala.Function1
@@ -184,7 +183,7 @@ class MirrordSbtRunConfiguration(
         }
 
         val service = project.service<MirrordProjectService>()
-        val environment = MirrordEnvironments.resolve(MirrordLaunchContext(project))
+        val environment = MirrordEnvironments.forProject(project)
         return service.execManager.wrapper("idea", getSbtConfigurationEnv(this), environment).start()
     }
 

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/MirrordWinGradleInjector.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/MirrordWinGradleInjector.kt
@@ -7,8 +7,7 @@ import com.metalbear.mirrord.MirrordBinaryManager
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordPitm
 import com.metalbear.mirrord.MirrordProjectService
-import com.metalbear.mirrord.bifrost.MirrordEnvironments
-import com.metalbear.mirrord.bifrost.MirrordLaunchContext
+import com.metalbear.mirrord.bifrost.MirrordEnvironment
 import java.io.File
 import java.util.Base64
 
@@ -59,7 +58,8 @@ internal object MirrordWinGradleInjector {
         configuration: ExternalSystemRunConfiguration,
         mirrordEnvVars: Map<String, String>,
         envToUnset: List<String>?,
-        debugExpected: Boolean
+        debugExpected: Boolean,
+        environment: MirrordEnvironment
     ) {
         MirrordLogger.logger.info(
             "MirrordWinGradleInjector.wrap: ENTER taskNames=${configuration.settings.taskNames} " +
@@ -69,7 +69,7 @@ internal object MirrordWinGradleInjector {
 
         val project = configuration.project
         val cliPath = service<MirrordBinaryManager>()
-            .getCliPath("idea", MirrordEnvironments.resolve(MirrordLaunchContext(project)), project)
+            .getCliPath("idea", environment, project)
             .value
             .replace("\\", "/")
         val childEnvPayload = MirrordPitm.encodeChildEnv(mirrordEnvVars, envToUnset)

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/MirrordWinGradleInjector.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/MirrordWinGradleInjector.kt
@@ -7,6 +7,8 @@ import com.metalbear.mirrord.MirrordBinaryManager
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordPitm
 import com.metalbear.mirrord.MirrordProjectService
+import com.metalbear.mirrord.bifrost.MirrordEnvironments
+import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import java.io.File
 import java.util.Base64
 
@@ -67,7 +69,8 @@ internal object MirrordWinGradleInjector {
 
         val project = configuration.project
         val cliPath = service<MirrordBinaryManager>()
-            .getCliPath("idea", null, project)
+            .getCliPath("idea", MirrordEnvironments.resolve(MirrordLaunchContext(project)), project)
+            .value
             .replace("\\", "/")
         val childEnvPayload = MirrordPitm.encodeChildEnv(mirrordEnvVars, envToUnset)
 

--- a/modules/products/nodejs/src/main/kotlin/com/metalbear/mirrord/products/nodejs/NodeRunConfigurationExtension.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/metalbear/mirrord/products/nodejs/NodeRunConfigurationExtension.kt
@@ -1,7 +1,6 @@
 package com.metalbear.mirrord.products.nodejs
 
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.javascript.nodejs.execution.AbstractNodeTargetRunProfile
 import com.intellij.javascript.nodejs.execution.NodeTargetRun
 import com.intellij.javascript.nodejs.execution.runConfiguration.AbstractNodeRunConfigurationExtension
@@ -10,6 +9,8 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.options.SettingsEditor
 import com.jetbrains.nodejs.run.NodeJsRunConfiguration
 import com.metalbear.mirrord.MirrordProjectService
+import com.metalbear.mirrord.bifrost.MirrordEnvironments
+import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import javax.swing.JPanel
 
 class NodeRunConfigurationExtension : AbstractNodeRunConfigurationExtension() {
@@ -32,10 +33,19 @@ class NodeRunConfigurationExtension : AbstractNodeRunConfigurationExtension() {
         return object : NodeRunConfigurationLaunchSession() {
             override fun addNodeOptionsTo(targetRun: NodeTargetRun) {
                 val service = targetRun.project.service<MirrordProjectService>()
-                val wsl = when (val request = targetRun.request) {
-                    is WslTargetEnvironmentRequest -> request.configuration.distribution
-                    else -> null
-                }
+
+                // This single expression is where COR-1385 began. `targetRun.request` already
+                // describes where the IDE is about to launch Node — a dev container, a WSL
+                // distribution, or nothing at all — but the old code recognised exactly one of
+                // those and treated every other answer as "local". A dev container fell into
+                // `else -> null`, so mirrord ran on the host while Node ran in the container.
+                //
+                // Nothing below this line needed to change: `commandLineBuilder` is already
+                // target-aware, so the environment variables mirrord returns are applied
+                // wherever the IDE launches. Only the producer was ever on the wrong machine.
+                val environment = MirrordEnvironments.resolve(
+                    MirrordLaunchContext(targetRun.project, targetRun.request)
+                )
 
                 // following try-catch is to maintain backward compatibility with older versions of webstorm
                 val extraEnvVars = try {
@@ -45,9 +55,7 @@ class NodeRunConfigurationExtension : AbstractNodeRunConfigurationExtension() {
                     config.envs
                 }
 
-                service.execManager.wrapper("nodejs", extraEnvVars).apply {
-                    this.wsl = wsl
-                }.start()?.let { executionInfo ->
+                service.execManager.wrapper("nodejs", extraEnvVars, environment).start()?.let { executionInfo ->
                     executionInfo.environment.forEach { (key, value) ->
                         targetRun.commandLineBuilder.addEnvironmentVariable(key, value)
                     }

--- a/modules/products/nodejs/src/main/kotlin/com/metalbear/mirrord/products/nodejs/NodeRunConfigurationExtension.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/metalbear/mirrord/products/nodejs/NodeRunConfigurationExtension.kt
@@ -33,15 +33,6 @@ class NodeRunConfigurationExtension : AbstractNodeRunConfigurationExtension() {
             override fun addNodeOptionsTo(targetRun: NodeTargetRun) {
                 val service = targetRun.project.service<MirrordProjectService>()
 
-                // This single expression is where COR-1385 began. `targetRun.request` already
-                // describes where the IDE is about to launch Node — a dev container, a WSL
-                // distribution, or nothing at all — but the old code recognised exactly one of
-                // those and treated every other answer as "local". A dev container fell into
-                // `else -> null`, so mirrord ran on the host while Node ran in the container.
-                //
-                // Nothing below this line needed to change: `commandLineBuilder` is already
-                // target-aware, so the environment variables mirrord returns are applied
-                // wherever the IDE launches. Only the producer was ever on the wrong machine.
                 val environment = MirrordEnvironments.forRequest(targetRun.project, targetRun.request)
 
                 // following try-catch is to maintain backward compatibility with older versions of webstorm

--- a/modules/products/nodejs/src/main/kotlin/com/metalbear/mirrord/products/nodejs/NodeRunConfigurationExtension.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/metalbear/mirrord/products/nodejs/NodeRunConfigurationExtension.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.options.SettingsEditor
 import com.jetbrains.nodejs.run.NodeJsRunConfiguration
 import com.metalbear.mirrord.MirrordProjectService
 import com.metalbear.mirrord.bifrost.MirrordEnvironments
-import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import javax.swing.JPanel
 
 class NodeRunConfigurationExtension : AbstractNodeRunConfigurationExtension() {
@@ -43,9 +42,7 @@ class NodeRunConfigurationExtension : AbstractNodeRunConfigurationExtension() {
                 // Nothing below this line needed to change: `commandLineBuilder` is already
                 // target-aware, so the environment variables mirrord returns are applied
                 // wherever the IDE launches. Only the producer was ever on the wrong machine.
-                val environment = MirrordEnvironments.resolve(
-                    MirrordLaunchContext(targetRun.project, targetRun.request)
-                )
+                val environment = MirrordEnvironments.forRequest(targetRun.project, targetRun.request)
 
                 // following try-catch is to maintain backward compatibility with older versions of webstorm
                 val extraEnvVars = try {

--- a/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonCommandLineProvider.kt
+++ b/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonCommandLineProvider.kt
@@ -1,7 +1,6 @@
 package com.metalbear.mirrord.products.pycharm
 
 import com.intellij.execution.target.TargetEnvironmentRequest
-import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.jetbrains.python.run.AbstractPythonRunConfiguration
@@ -10,6 +9,8 @@ import com.jetbrains.python.run.PythonRunParams
 import com.jetbrains.python.run.target.HelpersAwareTargetEnvironmentRequest
 import com.jetbrains.python.run.target.PythonCommandLineTargetEnvironmentProvider
 import com.metalbear.mirrord.MirrordProjectService
+import com.metalbear.mirrord.bifrost.MirrordEnvironments
+import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 
 class PythonCommandLineProvider : PythonCommandLineTargetEnvironmentProvider {
     // Wrapper for docker variant of TargetEnvironmentRequest because the variant is dynamically loaded from another
@@ -35,7 +36,9 @@ class PythonCommandLineProvider : PythonCommandLineTargetEnvironmentProvider {
     private fun extendContainerTargetEnvironment(project: Project, runParams: PythonRunParams, docker: DockerRuntimeConfig) {
         val service = project.service<MirrordProjectService>()
 
-        service.execManager.wrapper("pycharm", runParams.getEnvs()).containerStart()?.let { executionInfo ->
+        val environment = MirrordEnvironments.resolve(MirrordLaunchContext(project))
+
+        service.execManager.wrapper("pycharm", runParams.getEnvs(), environment).containerStart()?.let { executionInfo ->
             docker.runCliOptions?.let {
                 executionInfo.extraArgs.add(it)
             }
@@ -64,17 +67,11 @@ class PythonCommandLineProvider : PythonCommandLineTargetEnvironmentProvider {
             if (docker != null) {
                 extendContainerTargetEnvironment(project, runParams, docker)
             } else {
-                val wsl = helpersAwareTargetRequest.targetEnvironmentRequest.let {
-                    if (it is WslTargetEnvironmentRequest) {
-                        it.configuration.distribution
-                    } else {
-                        null
-                    }
-                }
+                val environment = MirrordEnvironments.resolve(
+                    MirrordLaunchContext(project, helpersAwareTargetRequest.targetEnvironmentRequest)
+                )
 
-                service.execManager.wrapper("pycharm", runParams.getEnvs()).apply {
-                    this.wsl = wsl
-                }.start()?.let { executionInfo ->
+                service.execManager.wrapper("pycharm", runParams.getEnvs(), environment).start()?.let { executionInfo ->
                     for (entry in executionInfo.environment.entries.iterator()) {
                         pythonExecution.addEnvironmentVariable(entry.key, entry.value)
                     }

--- a/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonCommandLineProvider.kt
+++ b/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonCommandLineProvider.kt
@@ -10,7 +10,6 @@ import com.jetbrains.python.run.target.HelpersAwareTargetEnvironmentRequest
 import com.jetbrains.python.run.target.PythonCommandLineTargetEnvironmentProvider
 import com.metalbear.mirrord.MirrordProjectService
 import com.metalbear.mirrord.bifrost.MirrordEnvironments
-import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 
 class PythonCommandLineProvider : PythonCommandLineTargetEnvironmentProvider {
     // Wrapper for docker variant of TargetEnvironmentRequest because the variant is dynamically loaded from another
@@ -36,7 +35,7 @@ class PythonCommandLineProvider : PythonCommandLineTargetEnvironmentProvider {
     private fun extendContainerTargetEnvironment(project: Project, runParams: PythonRunParams, docker: DockerRuntimeConfig) {
         val service = project.service<MirrordProjectService>()
 
-        val environment = MirrordEnvironments.resolve(MirrordLaunchContext(project))
+        val environment = MirrordEnvironments.forProject(project)
 
         service.execManager.wrapper("pycharm", runParams.getEnvs(), environment).containerStart()?.let { executionInfo ->
             docker.runCliOptions?.let {
@@ -67,9 +66,7 @@ class PythonCommandLineProvider : PythonCommandLineTargetEnvironmentProvider {
             if (docker != null) {
                 extendContainerTargetEnvironment(project, runParams, docker)
             } else {
-                val environment = MirrordEnvironments.resolve(
-                    MirrordLaunchContext(project, helpersAwareTargetRequest.targetEnvironmentRequest)
-                )
+                val environment = MirrordEnvironments.forRequest(project, helpersAwareTargetRequest.targetEnvironmentRequest)
 
                 service.execManager.wrapper("pycharm", runParams.getEnvs(), environment).start()?.let { executionInfo ->
                     for (entry in executionInfo.environment.entries.iterator()) {

--- a/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonRunConfigurationExtension.kt
+++ b/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonRunConfigurationExtension.kt
@@ -3,11 +3,12 @@ package com.metalbear.mirrord.products.pycharm
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.RunnerSettings
 import com.intellij.execution.target.createEnvironmentRequest
-import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.openapi.components.service
 import com.jetbrains.python.run.AbstractPythonRunConfiguration
 import com.jetbrains.python.run.PythonRunConfigurationExtension
 import com.metalbear.mirrord.MirrordProjectService
+import com.metalbear.mirrord.bifrost.MirrordEnvironments
+import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 
 class PythonRunConfigurationExtension : PythonRunConfigurationExtension() {
     override fun isApplicableFor(configuration: AbstractPythonRunConfiguration<*>): Boolean {
@@ -29,15 +30,13 @@ class PythonRunConfigurationExtension : PythonRunConfigurationExtension() {
     ) {
         val service = configuration.project.service<MirrordProjectService>()
 
-        val wsl = when (val request = createEnvironmentRequest(configuration, configuration.project)) {
-            is WslTargetEnvironmentRequest -> request.configuration.distribution!!
-            else -> null
-        }
+        val environment = MirrordEnvironments.resolve(
+            MirrordLaunchContext(configuration.project, createEnvironmentRequest(configuration, configuration.project))
+        )
 
         val currentEnv = cmdLine.environment
 
-        service.execManager.wrapper("pycharm", currentEnv).apply {
-            this.wsl = wsl
+        service.execManager.wrapper("pycharm", currentEnv, environment).apply {
         }.start()?.let { executionInfo ->
             for (entry in executionInfo.environment.entries.iterator()) {
                 currentEnv[entry.key] = entry.value

--- a/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonRunConfigurationExtension.kt
+++ b/modules/products/pycharm/src/main/kotlin/com/metalbear/mirrord/products/pycharm/PythonRunConfigurationExtension.kt
@@ -2,13 +2,11 @@ package com.metalbear.mirrord.products.pycharm
 
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.RunnerSettings
-import com.intellij.execution.target.createEnvironmentRequest
 import com.intellij.openapi.components.service
 import com.jetbrains.python.run.AbstractPythonRunConfiguration
 import com.jetbrains.python.run.PythonRunConfigurationExtension
 import com.metalbear.mirrord.MirrordProjectService
 import com.metalbear.mirrord.bifrost.MirrordEnvironments
-import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 
 class PythonRunConfigurationExtension : PythonRunConfigurationExtension() {
     override fun isApplicableFor(configuration: AbstractPythonRunConfiguration<*>): Boolean {
@@ -30,14 +28,11 @@ class PythonRunConfigurationExtension : PythonRunConfigurationExtension() {
     ) {
         val service = configuration.project.service<MirrordProjectService>()
 
-        val environment = MirrordEnvironments.resolve(
-            MirrordLaunchContext(configuration.project, createEnvironmentRequest(configuration, configuration.project))
-        )
+        val environment = MirrordEnvironments.forRunProfile(configuration.project, configuration)
 
         val currentEnv = cmdLine.environment
 
-        service.execManager.wrapper("pycharm", currentEnv, environment).apply {
-        }.start()?.let { executionInfo ->
+        service.execManager.wrapper("pycharm", currentEnv, environment).start()?.let { executionInfo ->
             for (entry in executionInfo.environment.entries.iterator()) {
                 currentEnv[entry.key] = entry.value
             }

--- a/modules/products/rider/src/main/kotlin/com/metalbear/mirrord/products/rider/RiderPatchCommandLineExtension.kt
+++ b/modules/products/rider/src/main/kotlin/com/metalbear/mirrord/products/rider/RiderPatchCommandLineExtension.kt
@@ -23,7 +23,6 @@ import com.metalbear.mirrord.MirrordPitm
 import com.metalbear.mirrord.MirrordProjectService
 import com.metalbear.mirrord.bifrost.MirrordEnvironment
 import com.metalbear.mirrord.bifrost.MirrordEnvironments
-import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import com.metalbear.mirrord.bifrost.TargetPath
 import com.metalbear.mirrord.isWinNative
 import org.jetbrains.concurrency.Promise
@@ -38,7 +37,7 @@ class RiderPatchCommandLineExtension : PatchCommandLineExtension {
      * dropdown, right or not. Asking the project where it lives has no such failure mode.
      */
     private fun resolveEnvironment(project: Project): MirrordEnvironment =
-        MirrordEnvironments.resolve(MirrordLaunchContext(project))
+        MirrordEnvironments.forProject(project)
 
     private fun resolveCliPath(project: Project, environment: MirrordEnvironment): TargetPath =
         service<MirrordBinaryManager>().getCliPath("rider", environment, project)
@@ -85,7 +84,7 @@ class RiderPatchCommandLineExtension : PatchCommandLineExtension {
         val executionInfo = startMirrordExt(workerRunInfo.commandLine, project, environment)
         workerRunInfo.commandLine.withEnvironment("MIRRORD_DETECT_DEBUGGER_PORT", "resharper")
 
-        val winNative = isWinNative(environment.platform())
+        val winNative = environment.platform().isWinNative
         MirrordLogger.logger.info(
             "patchDebugCommandLine: decision winNative=$winNative executionInfoPresent=${executionInfo != null}"
         )
@@ -251,7 +250,7 @@ class RiderPatchCommandLineExtension : PatchCommandLineExtension {
             return null
         }
 
-        val winNative = isWinNative(environment.platform())
+        val winNative = environment.platform().isWinNative
         MirrordLogger.logger.info("patchRunCommandLine: decision winNative=$winNative")
 
         // On Windows native, wrap with `mirrord pitm` for zero-race DLL injection.

--- a/modules/products/rider/src/main/kotlin/com/metalbear/mirrord/products/rider/RiderPatchCommandLineExtension.kt
+++ b/modules/products/rider/src/main/kotlin/com/metalbear/mirrord/products/rider/RiderPatchCommandLineExtension.kt
@@ -1,12 +1,8 @@
 package com.metalbear.mirrord.products.rider
 
-import com.intellij.execution.RunManager
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.ProcessInfo
 import com.intellij.execution.process.ProcessListener
-import com.intellij.execution.target.createEnvironmentRequest
-import com.intellij.execution.wsl.WSLDistribution
-import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
@@ -25,24 +21,27 @@ import com.metalbear.mirrord.MirrordExecution
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordPitm
 import com.metalbear.mirrord.MirrordProjectService
+import com.metalbear.mirrord.bifrost.MirrordEnvironment
+import com.metalbear.mirrord.bifrost.MirrordEnvironments
+import com.metalbear.mirrord.bifrost.MirrordLaunchContext
+import com.metalbear.mirrord.bifrost.TargetPath
 import com.metalbear.mirrord.isWinNative
 import org.jetbrains.concurrency.Promise
 import org.jetbrains.concurrency.resolvedPromise
 
 class RiderPatchCommandLineExtension : PatchCommandLineExtension {
 
-    private fun resolveWsl(project: Project): WSLDistribution? {
-        return RunManager.getInstance(project).selectedConfiguration?.configuration?.let {
-            @Suppress("UnstableApiUsage")
-            when (val request = createEnvironmentRequest(it, project)) {
-                is WslTargetEnvironmentRequest -> request.configuration.distribution!!
-                else -> null
-            }
-        }
-    }
+    /**
+     * Rider's extension point hands us a [WorkerRunInfo] and a [Project], never the run
+     * configuration being launched — which is why the old code reached for
+     * `RunManager.selectedConfiguration` and read whatever happened to be selected in the
+     * dropdown, right or not. Asking the project where it lives has no such failure mode.
+     */
+    private fun resolveEnvironment(project: Project): MirrordEnvironment =
+        MirrordEnvironments.resolve(MirrordLaunchContext(project))
 
-    private fun resolveCliPath(project: Project): String =
-        service<MirrordBinaryManager>().getCliPath("rider", null, project)
+    private fun resolveCliPath(project: Project, environment: MirrordEnvironment): TargetPath =
+        service<MirrordBinaryManager>().getCliPath("rider", environment, project)
 
     /**
      * Runs `mirrord ext` and sets the resulting env vars on the command line.
@@ -52,13 +51,11 @@ class RiderPatchCommandLineExtension : PatchCommandLineExtension {
     private fun startMirrordExt(
         commandLine: GeneralCommandLine,
         project: Project,
-        wsl: WSLDistribution?
+        environment: MirrordEnvironment
     ): MirrordExecution? {
         val service = project.service<MirrordProjectService>()
 
-        val executionInfo = service.execManager.wrapper("rider", commandLine.environment).apply {
-            this.wsl = wsl
-        }.start()
+        val executionInfo = service.execManager.wrapper("rider", commandLine.environment, environment).start()
 
         executionInfo?.let { info ->
             for (entry in info.environment.entries) {
@@ -83,12 +80,12 @@ class RiderPatchCommandLineExtension : PatchCommandLineExtension {
             "RiderPatchCommandLineExtension.patchDebugCommandLine: ENTER exe=${workerRunInfo.commandLine.exePath} " +
                 "argsCount=${workerRunInfo.commandLine.parametersList.list.size}"
         )
-        val wsl = resolveWsl(project)
-        MirrordLogger.logger.info("patchDebugCommandLine: wsl=${wsl?.presentableName ?: "null"}")
-        val executionInfo = startMirrordExt(workerRunInfo.commandLine, project, wsl)
+        val environment = resolveEnvironment(project)
+        MirrordLogger.logger.info("patchDebugCommandLine: env=${environment.name}")
+        val executionInfo = startMirrordExt(workerRunInfo.commandLine, project, environment)
         workerRunInfo.commandLine.withEnvironment("MIRRORD_DETECT_DEBUGGER_PORT", "resharper")
 
-        val winNative = isWinNative(wsl)
+        val winNative = isWinNative(environment.platform())
         MirrordLogger.logger.info(
             "patchDebugCommandLine: decision winNative=$winNative executionInfoPresent=${executionInfo != null}"
         )
@@ -105,7 +102,7 @@ class RiderPatchCommandLineExtension : PatchCommandLineExtension {
         // CLI injection flow:
         // https://github.com/metalbear-co/mirrord/blob/main/mirrord/cli/src/attach.rs
         if (winNative && executionInfo != null) {
-            armRiderTargetReadyAttach(project, lifetime, workerRunInfo.commandLine.environment.toMap())
+            armRiderTargetReadyAttach(project, lifetime, workerRunInfo.commandLine.environment.toMap(), environment)
         } else {
             MirrordLogger.logger.info("patchDebugCommandLine: skipping armRiderTargetReadyAttach (not Windows-native or no executionInfo)")
         }
@@ -117,9 +114,10 @@ class RiderPatchCommandLineExtension : PatchCommandLineExtension {
     private fun armRiderTargetReadyAttach(
         project: Project,
         launchLifetime: Lifetime,
-        envVars: Map<String, String>
+        envVars: Map<String, String>,
+        environment: MirrordEnvironment
     ) {
-        val cliPath = resolveCliPath(project)
+        val cliPath = resolveCliPath(project, environment)
         MirrordLogger.logger.info("armRiderTargetReadyAttach: wiring listener, cliPath=$cliPath")
 
         // connect(project) + lifetime.onTermination gives belt-and-suspenders
@@ -182,7 +180,7 @@ class RiderPatchCommandLineExtension : PatchCommandLineExtension {
                                 try {
                                     project.service<MirrordProjectService>()
                                         .execManager
-                                        .attach(cliPath, envVars, pid)
+                                        .attach(cliPath, envVars, pid, environment)
                                     MirrordLogger.logger.info(
                                         "armRiderTargetReadyAttach: attach completed for pid $pid, dispatching session.resume() on EDT"
                                     )
@@ -246,20 +244,20 @@ class RiderPatchCommandLineExtension : PatchCommandLineExtension {
             "RiderPatchCommandLineExtension.patchRunCommandLine: ENTER exe=${commandLine.exePath} " +
                 "argsCount=${commandLine.parametersList.list.size}"
         )
-        val wsl = resolveWsl(project)
-        MirrordLogger.logger.info("patchRunCommandLine: wsl=${wsl?.presentableName ?: "null"}")
-        val executionInfo = startMirrordExt(commandLine, project, wsl) ?: run {
+        val environment = resolveEnvironment(project)
+        MirrordLogger.logger.info("patchRunCommandLine: env=${environment.name}")
+        val executionInfo = startMirrordExt(commandLine, project, environment) ?: run {
             MirrordLogger.logger.info("patchRunCommandLine: startMirrordExt returned null — mirrord disabled or cancelled, exiting")
             return null
         }
 
-        val winNative = isWinNative(wsl)
+        val winNative = isWinNative(environment.platform())
         MirrordLogger.logger.info("patchRunCommandLine: decision winNative=$winNative")
 
         // On Windows native, wrap with `mirrord pitm` for zero-race DLL injection.
         // The process' execution is proxied, suspended, layer injected, then resumed.
         if (winNative) {
-            val cliPath = resolveCliPath(project)
+            val cliPath = resolveCliPath(project, environment)
             MirrordLogger.logger.info("patchRunCommandLine: wrapping with pitm cliPath=$cliPath")
             MirrordPitm.wrapCommandLine(commandLine, cliPath, executionInfo.environment, executionInfo.envToUnset)
         } else {

--- a/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
+++ b/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
@@ -4,14 +4,12 @@ package com.metalbear.mirrord.products.rubymine
 
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.RunnerSettings
-import com.intellij.execution.target.createEnvironmentRequest
 import com.intellij.openapi.components.service
 import com.intellij.openapi.util.SystemInfo
 import com.metalbear.mirrord.MirrordError
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordProjectService
 import com.metalbear.mirrord.bifrost.MirrordEnvironments
-import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import org.jetbrains.plugins.ruby.ruby.run.configuration.AbstractRubyRunConfiguration
 import org.jetbrains.plugins.ruby.ruby.run.configuration.RubyRunConfigurationExtension
 import kotlin.io.path.createTempFile
@@ -41,9 +39,7 @@ class RubyMineRunConfigurationExtension : RubyRunConfigurationExtension() {
 
         val isMac = SystemInfo.isMac
 
-        val environment = MirrordEnvironments.resolve(
-            MirrordLaunchContext(configuration.project, createEnvironmentRequest(configuration, configuration.project))
-        )
+        val environment = MirrordEnvironments.forRunProfile(configuration.project, configuration)
 
         val currentEnv = cmdLine.environment
         service.execManager.wrapper("rubymine", configuration.envs, environment).apply {

--- a/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
+++ b/modules/products/rubymine/src/main/kotlin/com/metalbear/mirrord/products/rubymine/RubyMineRunConfigurationExtension.kt
@@ -5,12 +5,13 @@ package com.metalbear.mirrord.products.rubymine
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.RunnerSettings
 import com.intellij.execution.target.createEnvironmentRequest
-import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.openapi.components.service
 import com.intellij.openapi.util.SystemInfo
 import com.metalbear.mirrord.MirrordError
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordProjectService
+import com.metalbear.mirrord.bifrost.MirrordEnvironments
+import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import org.jetbrains.plugins.ruby.ruby.run.configuration.AbstractRubyRunConfiguration
 import org.jetbrains.plugins.ruby.ruby.run.configuration.RubyRunConfigurationExtension
 import kotlin.io.path.createTempFile
@@ -40,14 +41,12 @@ class RubyMineRunConfigurationExtension : RubyRunConfigurationExtension() {
 
         val isMac = SystemInfo.isMac
 
-        val wsl = when (val request = createEnvironmentRequest(configuration, configuration.project)) {
-            is WslTargetEnvironmentRequest -> request.configuration.distribution!!
-            else -> null
-        }
+        val environment = MirrordEnvironments.resolve(
+            MirrordLaunchContext(configuration.project, createEnvironmentRequest(configuration, configuration.project))
+        )
 
         val currentEnv = cmdLine.environment
-        service.execManager.wrapper("rubymine", configuration.envs).apply {
-            this.wsl = wsl
+        service.execManager.wrapper("rubymine", configuration.envs, environment).apply {
             if (isMac) {
                 this.executable = cmdLine.exePath
             }

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -6,7 +6,6 @@ import com.intellij.execution.ExecutionListener
 import com.intellij.execution.configurations.RunConfigurationBase
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.execution.target.createEnvironmentRequest
 import com.intellij.execution.util.EnvironmentVariable
 import com.intellij.javaee.appServers.integration.impl.ApplicationServerImpl
 import com.intellij.javaee.appServers.run.configuration.CommonStrategy
@@ -21,7 +20,6 @@ import com.intellij.openapi.util.SystemInfo
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordProjectService
 import com.metalbear.mirrord.bifrost.MirrordEnvironments
-import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import org.jetbrains.idea.tomcat.server.TomcatPersistentData
 import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
@@ -161,9 +159,7 @@ class TomcatExecutionListener : ExecutionListener {
         val originalEnvVars = config.first.envVariables
 
         MirrordLogger.logger.debug("[${this.javaClass.name}] processStartScheduled: wsl check")
-        val environment = MirrordEnvironments.resolve(
-            MirrordLaunchContext(env.project, createEnvironmentRequest(env.runProfile, env.project))
-        )
+        val environment = MirrordEnvironments.forRunProfile(env.project, env.runProfile)
 
         val startupInfo = config.first.startupInfo
         val scriptAndArgs = if (SystemInfo.isMac) {

--- a/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
+++ b/modules/products/tomcat/src/main/kotlin/com/metalbear/mirrord/products/tomcat/TomcatExecutionListener.kt
@@ -8,7 +8,6 @@ import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.target.createEnvironmentRequest
 import com.intellij.execution.util.EnvironmentVariable
-import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.javaee.appServers.integration.impl.ApplicationServerImpl
 import com.intellij.javaee.appServers.run.configuration.CommonStrategy
 import com.intellij.javaee.appServers.run.configuration.RunnerSpecificLocalConfigurationBit
@@ -21,6 +20,8 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.util.SystemInfo
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordProjectService
+import com.metalbear.mirrord.bifrost.MirrordEnvironments
+import com.metalbear.mirrord.bifrost.MirrordLaunchContext
 import org.jetbrains.idea.tomcat.server.TomcatPersistentData
 import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
@@ -160,10 +161,9 @@ class TomcatExecutionListener : ExecutionListener {
         val originalEnvVars = config.first.envVariables
 
         MirrordLogger.logger.debug("[${this.javaClass.name}] processStartScheduled: wsl check")
-        val wsl = when (val request = createEnvironmentRequest(env.runProfile, env.project)) {
-            is WslTargetEnvironmentRequest -> request.configuration.distribution!!
-            else -> null
-        }
+        val environment = MirrordEnvironments.resolve(
+            MirrordLaunchContext(env.project, createEnvironmentRequest(env.runProfile, env.project))
+        )
 
         val startupInfo = config.first.startupInfo
         val scriptAndArgs = if (SystemInfo.isMac) {
@@ -194,8 +194,7 @@ class TomcatExecutionListener : ExecutionListener {
                 }
 
                 val envVarsMap = originalEnvVars.associate { it.NAME to it.VALUE }
-                service.execManager.wrapper("tomcat", envVarsMap).apply {
-                    this.wsl = wsl
+                service.execManager.wrapper("tomcat", envVarsMap, environment).apply {
                     this.executable = scriptAndArgs?.command
                 }.start()?.let { executionInfo ->
                     // `MIRRORD_IGNORE_DEBUGGER_PORTS` should allow clean shutdown of the app


### PR DESCRIPTION
## Linear

https://linear.app/metalbear/issue/COR-1385/intellij-plugin-fails-inside-jetbrains-dev-containers

## FUN AND WHIMSY

![happy crying face in a rainbow meadow](https://raw.githubusercontent.com/cristeigabriela/pr-assets/main/cor-1385-whimsy-1.jpg)

![dog in a propeller cap holding a lollipop](https://raw.githubusercontent.com/cristeigabriela/pr-assets/main/cor-1385-whimsy-2.jpg)

## Summary

- JetBrains extensions like ours run **on the host**, even when your project runs somewhere else.
- So when we downloaded, located, or started mirrord, we did it on the **wrong machine**.
- We already hit this with WSL. We handled it by `if`-`else`-ing each site where WSL differs — **eleven** of them, seven ending in `!!`.

To understand this, we first have to establish some details, such as, where JetBrains extensions such as ours run. Well, in most cases (except, for example, Gateway stuff, which if you don't know about, then you don't need to), they run natively, on the machine which hosts the instance of the JetBrains IDE.

And, to interact with files on the system, it goes the normal route for a Java program. That is, native Java libraries running against the local environment.

But, JetBrains allow acting in the context of different environments: SSH, WSL (Weasels and SeaLions, not to be mistaken for Windows Subsystem for Linux), DevContainers, and others I don't know about.

That, in turn, breaks some of our code and assumptions.

But, if I try to download or locate mirrord, I'll be downloading or locating mirrord on my *host* environment. I'll be trying to start mirrord on my *host* environment, when the extension notifies me of an application beginning to be ran or debugged in JetBrains.

I'm sure you're aware of this though, at least for WSL, which we already supported. The problem is that, previously, we had to manually if-else each scenario where WSL would act any different than the host environment (eg. selecting which mirrord version to download).

Bifrost tries to offer a generalized solution within the codebase to this whole class of issues, by hiding away the environment against which we might, for example, copy a file, or the such.

<details>
<summary><b>Why this is so easy to get wrong — EEL hands you Java primitives</b></summary>

The way JetBrains support these remote environments doesn't *feel* fully intuitive. A lot of our code is just simply saved, the remote environments still hit the right EPs and whatnot. They still return Java-level primitives that *feel* like they must've came from interacting with the local environment, if you're following casual convention.

Take `EelPath`. Call `.asNioPath()` on one and you get back a `java.nio.file.Path`. You can then hand that to `Files.exists(...)` like any other path — except it isn't any other path, and the check runs inside the container:

```kotlin
Files.exists(EelPath.parse(candidate.value, descriptor).asNioPath())
```

It goes the other way too: `path.asEelPath()` takes a host `Path` and gives you the target's view of it.

Processes are the same trick. `api.exec.spawnProcess(...)` builds an EEL process, and `.convertToJavaProcess()` hands you a plain `java.lang.Process`:

```kotlin
api.exec.spawnProcess(spec.executable.value)
    .args(spec.args)
    .env(baseEnvironment + spec.env)
    .eelIt()
    .convertToJavaProcess()
```

That's genuinely why this refactor stayed as small as it did.

Our JSON progress parser, the stdout/stderr readers, `computeWithResponsiveCancel`, `process.destroy()` on cancel — none of them know or care that the process is in a container.

`MirrordCliTask` kept its entire body.

**The flip side is the trap.** A `Path` that *looks* local and a `Process` that *looks* local are exactly what let the old code compile, run, and quietly do the wrong thing.

</details>

<details>
<summary><b>Before and after, in real code</b></summary>

This block, or a near-copy of it, appeared **eleven times** across the product modules — seven of those ending in `!!`:

```kotlin
// NodeRunConfigurationExtension.kt, on main
val wsl = when (val request = targetRun.request) {
    is WslTargetEnvironmentRequest -> request.configuration.distribution
    else -> null                     // <- a dev container lands here
}
```

`else -> null` is the whole bug in one line. A dev container isn't WSL, so we fell through to "no WSL", which the rest of the code reads as "everything is local". All eleven become:

```kotlin
val environment = MirrordEnvironments.forRequest(targetRun.project, targetRun.request)
```

And the two path worlds stop being `String`:

```kotlin
fun resolve(path: HostPath): TargetPath
fun provide(path: HostPath, name: String, onCopy: (Long) -> Unit = {}): TargetPath
fun spawn(spec: MirrordProcessSpec): Process
```

Mixing them is now a compile error.

That matters more than it sounds, because the old failure was silent. mirrord ignored a config it couldn't find, fell back to defaults, and reported zero connected layers for four months.

`provide` is worth showing, because "copy the binary over" is only half of it:

```kotlin
runCatching { resolve(path) }.getOrNull()?.let { candidate ->
    val reachable = runCatching {
        Files.exists(EelPath.parse(candidate.value, descriptor).asNioPath())
    }.getOrDefault(false)

    if (reachable) return candidate   // already visible from the target, nothing to copy
}
```

`resolve` only tells you whether a path can be *expressed* in the target's terms, not whether the file is actually there. For a dev container it will happily hand back a host path that exists nowhere inside the container.

Trusting it skipped the transfer entirely, and left mirrord looking for a binary that had never been copied across.

Local and WSL take the early return, so only containers ever pay for a transfer.

</details>

<details>
<summary><b>The layout of Bifrost — eight files, and that's the whole of it</b></summary>

| File | What it is |
|---|---|
| `MirrordPaths.kt` | `HostPath` and `TargetPath`. Nothing converts between them implicitly. |
| `MirrordEnvironment.kt` | The interface, plus `MirrordProcessSpec`. |
| `MirrordTargetPlatform.kt` | OS and arch of the **target**, read from `api.platform`. |
| `EelEnvironment.kt` | The real implementation. Local, WSL, Docker, dev containers, SSH. |
| `LegacyWslEnvironment.kt` | Today's WSL code, unchanged, behind the same interface. |
| `MirrordEnvironmentSource.kt` | How we decide which environment you get. |
| `MirrordBifrostTrace.kt` | Every crossing is logged and bounded. |
| `EelTransferCompat.java` | One Java file. See the next section. |

**`MirrordEnvironment`** has eight members: `name`, `isLocal`, `platform()`, `resolve()`, `provide()`, `locate()`, `spawn()`, `probe()`.

`isLocal` is deliberately *not* used to branch the main path — JetBrains call that an anti-pattern, and they're right. It survives for the two cases they do sanction: work that genuinely belongs on the IDE host, and port forwarding.

**`MirrordTargetPlatform`** is what replaced `SystemInfo` for every decision about the other machine: which binary to download, which injection path to use.

**`EelEnvironment`** has no `if (isLocal)` branch on the main path, so the local case is exercised on every developer's machine rather than being a second code path nobody runs.

**`LegacyWslEnvironment`** does not move WSL behaviour in this PR. WSL just stops being *special*, and becomes one implementation instead of a `WSLDistribution?` threaded through seven files.

**`MirrordEnvironmentSource`** is an ordered chain, first non-null wins:

1. `ForcedEnvironmentSource` — settings override, and the test escape hatch.
2. `LegacyWslEnvironmentSource` — only if you turned the legacy setting on, and only for a real WSL launch.
3. `TargetRequestEnvironmentSource` — the run configuration's own target. Most specific answer available.
4. `ProjectDescriptorEnvironmentSource` — where the project lives. This is the one that makes native dev containers work.
5. `LocalEnvironmentSource` — always answers, so callers never handle null.

The order is data in one place. A new environment kind is a new source, not another arm of a growing `when`.

The winner is logged, so a misresolution is one grep instead of a debugger session.

**`MirrordBifrostTrace`** — nothing touches EEL directly.

It logs BEGIN/OK/SLOW/TIMEOUT/UNAVAIL/FAIL with a correlation id, bounds each call with a timeout, and keeps a per-operation moving average so "slow" is measured rather than guessed.

`grep mirrord.bifrost: idea.log` should tell you the whole story without attaching a debugger. That's the acceptance bar, and it's a direct response to this bug taking four months to find.

</details>

<details>
<summary><b>How a process actually starts</b></summary>

Worth spelling out, because this is the part that stayed intact.

`MirrordCliTask.prepareSpec` builds a complete `MirrordProcessSpec` — command, args, and the **entire** environment map.

That completeness is deliberate. The old code built a `GeneralCommandLine`, patched it for WSL partway through, and then kept adding variables. So `MIRRORD_PROGRESS_MODE` and friends were registered for WSL interop only if statement order happened to cooperate.

With a spec there's no "partway through" left to get wrong.

Then one call, at `MirrordApi.kt:870`:

```kotlin
val process = environment.spawn(spec)
```

The two implementations differ completely and the caller can't tell:

- `EelEnvironment` → `api.exec.spawnProcess(...).eelIt().convertToJavaProcess()`. A process *in* the container, via ijent.
- `LegacyWslEnvironment` → `GeneralCommandLine` + `patchCommandLine`. A host `wsl.exe` process proxying stdio into the distro.

Different objects, same downstream contract: both are a `java.lang.Process` whose stdout our existing parser reads.

Everything after that line — the progress task, cancel handling, the JSON parser — is untouched.

</details>

## Experimental API warning

> **EEL is experimental, and this plugin now depends on it.** We did not pick it freely. JetBrains told us that split mode is not the answer for dev containers in native mode, and that EEL is.

- EEL **moves between IDE builds**. It already cost real time in this branch.
- **Three guards** are in this PR against that.
- **One decision is still open**: the verifier reports 5 problems, all in SBT, all older than this branch.

<details>
<summary><b>The concrete breakage</b></summary>

The file-transfer attribute strategy is `EelPathUtils.FileTransferAttributesStrategy` in 2026.1, and a top-level `EelFileTransferAttributesStrategy` in 2026.2. The type name is part of the method descriptor, so a plugin compiled against one build fails on the other at run time.

The same churn already applies to `EelUnavailableException`, which exists in build 261 and not in 262.

`sinceBuild` is 253 with no upper bound. The gap between that claim and the compile target is exactly where this class of fault lives.

</details>

<details>
<summary><b>The three guards</b></summary>

- **`EelTransferCompat.java`** binds the two-argument `transferLocalContentToRemote` overload from Java. Kotlin cannot do this, because a Kotlin call site always compiles to the synthetic `$default` bridge, and that bridge names the moved type. The two-argument overload is byte-identical in both builds.
- **`MirrordBifrostTracer`** maps `LinkageError` and `ClassNotFoundException` to a named version-mismatch error. A moved API then tells the user to update the plugin, instead of raising an IDE error report that blames mirrord.
- **The plugin verifier configuration is repaired.** The nightly job called `runPluginVerifier`, which is the 1.x task name and does not exist in 2.x. It also set `IDE`, where the build reads `PLATFORMTYPE`. There was no `ides { }` block, so the verifier had no IDE to check against. The verifier reads bytecode descriptors, so it finds this class of fault before release.

</details>

<details>
<summary><b>Still open — the verifier's 5 SBT problems</b></summary>

The verifier now reports 5 compatibility problems against build 262. All 5 are in SBT support and pre-date this branch.

Three ways to go, and this is not decided:

- Fix them for 262.
- Keep the gate and exclude the known SBT problems, so new faults still fail the build.
- Lower `failureLevel` so the report is informational.

</details>

## Future maintenance

- **`LegacyWslEnvironment` is deletable in one commit** — once somebody runs WSL end to end on Windows.
- **`MirrordEnvironment.probe` goes with it.**
- **`SystemInfo` must stay out of target decisions** — four sites still ask the host.
- **`isWinNative` wants to become `InjectionStrategy`.**
- **The EDT work is unfinished** — the modal dialog is not the real fix.
- **Known cost, not yet paid** — three efficiency items, deliberately deferred.
- **Two design-note items are still unverified.**

<details>
<summary><b>Details on each</b></summary>

**`LegacyWslEnvironment` is deletable in one commit.**

It wraps today's WSL code with no behaviour change, behind a user-visible setting. `MirrordWslCharacterizationTest` pins it, and skips rather than passing vacuously off Windows.

Delete the file once somebody runs WSL end to end on a Windows machine.

**`MirrordEnvironment.probe` goes with it.** It exists only because legacy WSL reaches short commands through `executeOnWsl`, whose defaults are the opposite of the ones it uses for long-running commands. When the legacy file goes, `probe` collapses into `spawn`.

**`SystemInfo` must stay out of target decisions.** Some sites still ask the host a question that belongs to the target.

The macOS SIP rule is the clearest one: `MirrordNpmExecutionListener` asks the target, and Bazel, Goland, Tomcat and RubyMine still ask the host.

A named predicate on `MirrordTargetPlatform` fixes all of them at once.

**`isWinNative` wants to become `InjectionStrategy`.** The design notes define a sealed type — `Preload`, `PreloadWithSipPatch`, `Pitm`, `Attach` — keyed on the target. The current boolean is the seed of that, and it is deliberately not the finished shape.

**The EDT work is unfinished.** `ExecutionListener.processStarting` runs on the EDT by platform contract, and the Node path starts mirrord there.

`runWithModalProgressBlocking` keeps the IDE responsive and satisfies the platform, but it is not the real fix. The tracer warns once per operation so that this stays visible.

Moving the work to a before-run task, the way the IDEA path already does, removes the warning and the dialog together.

**Known cost, not yet paid.** Three things:

- The content hash is recomputed on every `provide`.
- `getBinary` resolves the binary twice.
- The startup task stages the CLI into the container at every project open.

These are behaviour changes rather than cleanups, so they belong in their own pass.

**Two items from the design notes are still unverified.**

- The `WSLENV` ordering hypothesis needs a Windows machine.
- Whether `provide` caches per session or per machine is open. `EelMachine` is the documented cache key when several descriptors share one machine.

</details>
