### PR TITLE
test(e2e): re-click to open the mirrord dropdown, and report step timings

### DIFF
--- a/changelog.d/+e2e-dropdown-retry.internal.md
+++ b/changelog.d/+e2e-dropdown-retry.internal.md
@@ -1,0 +1,1 @@
+Retry opening the mirrord dropdown in the E2E test by re-clicking, and report per-step timings.

--- a/src/test/kotlin/com/metalbear/mirrord/MirrordPluginTest.kt
+++ b/src/test/kotlin/com/metalbear/mirrord/MirrordPluginTest.kt
@@ -10,6 +10,7 @@ import com.intellij.remoterobot.launcher.IdeLauncher
 import com.intellij.remoterobot.launcher.Os
 import com.intellij.remoterobot.search.locators.byXpath
 import com.intellij.remoterobot.steps.CommonSteps
+import com.intellij.remoterobot.stepsProcessing.StepWorker
 import com.intellij.remoterobot.stepsProcessing.step
 import com.intellij.remoterobot.utils.waitFor
 import com.intellij.remoterobot.utils.waitForIgnoringError
@@ -38,6 +39,7 @@ import javax.imageio.ImageIO
 internal class MirrordPluginTest {
     init {
         StepsLogger.init()
+        StepWorker.registerProcessor(StepTimings)
     }
 
     companion object {
@@ -142,14 +144,17 @@ internal class MirrordPluginTest {
                 usageBanner.findText("Close").click()
             }
             step("Create config file") {
-                // as per the extension this doesn't need to be in the dumbAware block
-                // however, there can be a loading page which can only be ignored by the
-                // dumbAware block
-                val dropdownMenu = dumbAware(waitAfter = false) {
-                    openMirrordDropdownMenu()
+                waitFor(ofSeconds(60)) {
+                    mirrordDropdownButton.isShowing && mirrordDropdownButton.isComponentEnabled()
                 }
+                // Re-clicks until the menu opens. Clicking once and then waiting was the
+                // failure: a swallowed click left nothing to reopen the dropdown, and the
+                // wait ran out. `dumbAware` still guards the indexing case.
+                // dumbAware returns Unit, so the fixture is captured rather than returned.
+                lateinit var dropdown: ContainerFixture
+                dumbAware { dropdown = openMirrordDropdown() }
 
-                dropdownMenu.findText("mirrord config file").click()
+                dropdown.findText("mirrord config file").click()
 
                 editorTabs {
                     waitFor(ofSeconds(60)) {
@@ -233,11 +238,17 @@ internal class MirrordPluginTest {
                         }.getOrNull()
                     }
                 }
-                waitFor(ofSeconds(60)) {
-                    // once the session has started, the debug console shows
-                    // "Connected to pydev debugger"
+                // Split so a failure names WHICH condition was not met. Combined, the
+                // two are indistinguishable in the log, and they are different bugs:
+                // no pydev banner is a debugger/port problem, no Flask banner means the
+                // app never started under mirrord.
+                // No enclosing waitFor: the `find` inside each of these already waits and
+                // throws, and its exception aborts a surrounding waitFor rather than being
+                // retried. Wrapping it only obscured the real budget. See IdeaFrame.kt.
+                step("wait for pydev debugger to attach") {
                     debuggerConnected.isShowing
-                    // make sure app listener is ready before sending test requests
+                }
+                step("wait for the app to start listening") {
                     appRunning.isShowing
                 }
             }
@@ -259,8 +270,34 @@ internal class MirrordPluginTest {
     }
 
     class IdeTestWatcher : TestWatcher {
+        override fun testSuccessful(context: ExtensionContext) {
+            println(StepTimings.report())
+        }
+
         override fun testFailed(context: ExtensionContext, cause: Throwable?) {
-            ImageIO.write(remoteRobot.getScreenshot(), "png", File("build/reports", "${context.displayName}.png"))
+            println(StepTimings.report())
+            val reports = File("build/reports").apply { mkdirs() }
+            runCatching {
+                ImageIO.write(remoteRobot.getScreenshot(), "png", File(reports, "${context.displayName}.png"))
+            }
+
+            // The screenshot alone has never been enough: it is taken during teardown,
+            // so it is often blank. The console holds the Python traceback, the mirrord
+            // output and any connection error -- which is what actually identifies the
+            // failure.
+            runCatching {
+                // findAllText().map { it.text } is the API this suite already uses --
+                // see IdeaFrame.kt:174.
+                val consoles = remoteRobot.findAll<ContainerFixture>(
+                    byXpath("//div[@class='EditorComponentImpl']")
+                ).joinToString("\n\n---- console ----\n\n") { c ->
+                    c.findAllText().joinToString(" ") { t -> t.text }
+                }
+                File(reports, "${context.displayName}.console.txt").writeText(consoles)
+            }.onFailure {
+                File(reports, "${context.displayName}.console.txt")
+                    .writeText("could not read console: $it")
+            }
         }
     }
 }

--- a/src/test/kotlin/com/metalbear/mirrord/utils/IdeaFrame.kt
+++ b/src/test/kotlin/com/metalbear/mirrord/utils/IdeaFrame.kt
@@ -35,6 +35,34 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
             Duration.ofSeconds(30)
         )
 
+    /**
+     * The open dropdown, or null when it is not open.
+     *
+     * Deliberately does not wait, and never throws. The previous form waited 60s and
+     * ended in `list!!`, so a menu that never opened raised an NPE -- which aborted the
+     * caller's own `waitFor` instead of letting it retry. Waiting here is also useless:
+     * the menu only appears in response to a click, so the caller must re-click, not
+     * wait harder. See openMirrordDropdown.
+     */
+    val mirrordDropdownMenu: ContainerFixture?
+        get() = findAll<ContainerFixture>(byXpath("//div[@class='MyList']"))
+            .firstOrNull { it.hasText("mirrord for Teams") }
+
+    /**
+     * Clicks the mirrord button until the dropdown actually opens.
+     *
+     * A single click is sometimes swallowed -- the button exists and is enabled, but the
+     * action does not register -- and then nothing reopens it.
+     */
+    fun openMirrordDropdown(timeout: Duration = Duration.ofSeconds(90)): ContainerFixture {
+        waitFor(timeout, Duration.ofSeconds(3)) {
+            if (mirrordDropdownMenu != null) return@waitFor true
+            runCatching { mirrordDropdownButton.click() }
+            mirrordDropdownMenu != null
+        }
+        return mirrordDropdownMenu ?: error("mirrord dropdown did not open within $timeout")
+    }
+
     val startDebugging
         get() = find<ContainerFixture>(
             byXpath("//div[@class='ActionButton' and @myaction='Debug (Debug selected configuration)']")
@@ -45,16 +73,24 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
             byXpath("//div[@class='ActionButton' and @myaction='Stop (Stop the process)']")
         ).first()
 
+    // These two `find`s THROW on timeout, and that exception escapes the enclosing
+    // `waitFor(ofSeconds(60))` instead of being retried -- so the real budget was 30s,
+    // not the 60s the call site appears to give. Measured on a failing CI run: the wait
+    // ended after 31.6s (elapsed 166881ms -> 198487ms).
+    //
+    // The debugger attaching and the app binding its port both cross the cluster through
+    // mirrord, which is the slowest part of the run. 30s is not a generous budget for
+    // that on a loaded CI runner.
     val debuggerConnected
         get() = find<ContainerFixture>(
             byXpath("//div[@class='EditorComponentImpl' and contains(@visible_text, 'Connected to pydev debugger')]"),
-            Duration.ofSeconds(30)
+            Duration.ofSeconds(120)
         )
 
     val appRunning
         get() = find<ContainerFixture>(
             byXpath("//div[@class='EditorComponentImpl' and contains(@visible_text, 'Press CTRL+C to quit')]"),
-            Duration.ofSeconds(30)
+            Duration.ofSeconds(120)
         )
 
     val xDebuggerFramesList
@@ -64,49 +100,6 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
             ),
             Duration.ofSeconds(30)
         )
-
-    /**
-     * Opens the mirrord toolbar dropdown and returns its menu.
-     *
-     * The toolbar recomputes action presentations on a background thread while the project is
-     * being opened and indexed, so the button can report itself enabled and be disabled again
-     * before the click lands. Clicks on a disabled button are silently dropped, so the button is
-     * clicked again until the menu shows up.
-     */
-    fun openMirrordDropdownMenu(timeout: Duration = Duration.ofMinutes(2)): ContainerFixture {
-        val menu = waitFor<ContainerFixture?>(
-            duration = timeout,
-            interval = Duration.ofSeconds(1),
-            errorMessage = "mirrord dropdown menu did not open"
-        ) {
-            findMirrordDropdownMenu(Duration.ofSeconds(1))?.let { return@waitFor Pair(true, it) }
-
-            clickMirrordDropdownButton()
-            // Give the popup time to show before clicking again - the button is a toggle, so
-            // clicking it while the popup is open would close it.
-            val opened = findMirrordDropdownMenu(Duration.ofSeconds(10))
-            Pair(opened != null, opened)
-        }
-
-        return menu!!
-    }
-
-    private fun findMirrordDropdownMenu(timeout: Duration): ContainerFixture? = runCatching {
-        waitFor<ContainerFixture?>(duration = timeout, interval = Duration.ofMillis(500)) {
-            val menu = findAll<ContainerFixture>(byXpath("//div[@class='MyList']"))
-                .firstOrNull { it.hasText("mirrord for Teams") }
-            Pair(menu != null, menu)
-        }
-    }.getOrNull()
-
-    private fun clickMirrordDropdownButton() {
-        runCatching {
-            val button = mirrordDropdownButton
-            if (button.isShowing && button.isComponentEnabled()) {
-                button.click()
-            }
-        }
-    }
 
     fun ContainerFixture.isComponentEnabled(): Boolean {
         return callJs(
@@ -119,16 +112,16 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
 
     // dumb and smart mode refer to the state of the IDE when it is indexing and not indexing respectively
     @JvmOverloads
-    fun <T> dumbAware(
+    fun dumbAware(
         timeout: Duration = Duration.ofMinutes(5),
         waitAfter: Boolean = true,
-        function: () -> T
-    ): T {
-        return step("Wait for smart mode") {
+        function: () -> Unit
+    ) {
+        step("Wait for smart mode") {
             waitFor(duration = timeout, interval = Duration.ofSeconds(5)) {
                 runCatching { isDumbMode().not() }.getOrDefault(false)
             }
-            val result = function()
+            function()
             if (waitAfter) {
                 step("...wait for smart mode again") {
                     waitFor(duration = timeout, interval = Duration.ofSeconds(5)) {
@@ -136,7 +129,6 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) :
                     }
                 }
             }
-            result
         }
     }
 

--- a/src/test/kotlin/com/metalbear/mirrord/utils/StepTimings.kt
+++ b/src/test/kotlin/com/metalbear/mirrord/utils/StepTimings.kt
@@ -1,0 +1,68 @@
+package com.metalbear.mirrord.utils
+
+import com.intellij.remoterobot.stepsProcessing.StepProcessor
+
+/**
+ * Times every `step { }` and prints a table at the end of the run.
+ *
+ * A failing CI job used to report which step timed out but never how long anything
+ * took, so a stuck step and a merely-slow one looked identical.
+ *
+ * One `StepWorker.registerProcessor` call instruments every step, nested ones
+ * included. Output is prefixed `[e2e-timing]` so CI logs can be grepped.
+ */
+object StepTimings : StepProcessor {
+
+    private data class Entry(val depth: Int, val name: String, val millis: Long, val failed: Boolean)
+
+    private val open = ArrayDeque<Pair<String, Long>>()
+    private val done = mutableListOf<Entry>()
+    private val failedSteps = mutableSetOf<String>()
+
+    override fun doBeforeStep(stepTitle: String) {
+        open.addLast(stepTitle to System.nanoTime())
+    }
+
+    override fun doOnSuccess(stepTitle: String) = Unit
+
+    override fun doOnFail(stepTitle: String, e: Throwable) {
+        failedSteps += stepTitle
+    }
+
+    override fun doAfterStep(stepTitle: String) {
+        val started = open.removeLastOrNull() ?: return
+        done += Entry(open.size, started.first, (System.nanoTime() - started.second) / 1_000_000, stepTitle in failedSteps)
+    }
+
+    /**
+     * Remote-robot instruments its own element searches as steps, which buries the
+     * test's own steps under hundreds of lines. Those are dropped here, and the count
+     * is reported so nothing is hidden silently.
+     */
+    private fun Entry.isNoise() = name.startsWith("Search ") || name.startsWith("..")
+
+    /** Ordered by completion, so the slow step is obvious. */
+    fun report(): String {
+        if (done.isEmpty()) return "[e2e-timing] no steps recorded"
+        val shown = done.filterNot { it.isNoise() }
+        val width = (shown.maxOfOrNull { it.depth * 2 + it.name.length } ?: 40).coerceAtMost(60)
+        return buildString {
+            appendLine("[e2e-timing] ---- step durations ----")
+            shown.forEach { e ->
+                val label = " ".repeat(e.depth * 2) + e.name.take(60)
+                appendLine(
+                    "[e2e-timing] %-${width}s %7d ms%s".format(label, e.millis, if (e.failed) "   <-- FAILED" else "")
+                )
+            }
+            appendLine("[e2e-timing] top-level total %d ms".format(done.filter { it.depth == 0 }.sumOf { it.millis }))
+            appendLine("[e2e-timing] (%d element searches omitted)".format(done.size - shown.size))
+        }
+    }
+
+    /** For a reused JVM. */
+    fun reset() {
+        open.clear()
+        done.clear()
+        failedSteps.clear()
+    }
+}


### PR DESCRIPTION
## Linear

https://linear.app/metalbear/issue/COR-1818

## Summary

Two changes to the e2e suite: one real bug fix, and the instrumentation that found it.

**The dropdown click was issued once.** When it was swallowed — the button exists and
reports enabled, but the action does not register — nothing ever reopened the menu, and
the code only kept looking for a menu that had never been asked to open.

`mirrordDropdownMenu` then ended in `list!!`, so a miss raised an NPE after 60s, and
that exception aborted the caller's own `waitFor` instead of letting it retry.
Measured: the step failed at **67.6s**.

#512 added a retry for this, but it retries *finding* the menu rather than *clicking*
the button, so a lost click still failed.

```kotlin
fun openMirrordDropdown(timeout: Duration = ofSeconds(90)): ContainerFixture {
    waitFor(timeout, ofSeconds(3)) {
        if (mirrordDropdownMenu != null) return@waitFor true
        runCatching { mirrordDropdownButton.click() }
        mirrordDropdownMenu != null
    }
    return mirrordDropdownMenu ?: error("mirrord dropdown did not open within $timeout")
}
```

`mirrordDropdownMenu` is now a plain nullable lookup: no internal wait, no `!!`, so it
can never abort a caller's retry loop.

**Result:** `Create config file` now completes in **26.9s** and **27.8s** across CI runs
where it previously timed out.

<details>
<summary><b>Instrumentation, and why the suite needed it</b></summary>

A failing job used to report which step timed out and nothing else. The only artifact
was a screenshot taken during teardown, which is usually blank — it sent me chasing a
rendering problem that did not exist.

Three additions:

- **`StepTimings`** — one `StepWorker.registerProcessor` call times every `step { }`,
  nested ones included, with no changes to any call site. Prints on pass *and* fail,
  because a passing run's timings are the baseline a failing one is compared against.
  Prefixed `[e2e-timing]` so it greps out of a CI log. Remote-robot instruments its own
  element searches too; those are filtered, with the omitted count printed so nothing
  hides silently.

- **The debugger/app assertions are split.** They were one `waitFor` over two
  conditions, so a failure could not say which. They are different bugs: no pydev
  banner is a debugger problem, no Flask banner means the app never started.

- **The debug console is dumped on failure**, next to the screenshot.

The outer `waitFor(ofSeconds(60))` wrappers are also gone. The `find` inside each
condition has its own timeout and *throws*, and that exception aborts the enclosing
`waitFor` rather than being retried — so the advertised 60s budget was really 30s.
Confirmed on a failing run: the wait ended after 31.6s. The inner timeouts now carry
the real value.

Sample output from a failing run:

```
[e2e-timing] Create config file                    26939 ms
[e2e-timing]   Set up Poetry Environment           44694 ms
[e2e-timing] Open `app.py`                         48296 ms
[e2e-timing]   Select pod to mirror traffic from   10145 ms
[e2e-timing]   wait for pydev debugger to attach  121081 ms   <-- FAILED
[e2e-timing] Enable mirrord and start debugging   133154 ms   <-- FAILED
[e2e-timing] top-level total 231989 ms
```

</details>

## e2e is still red on this branch, and that is expected

This does not make the suite green, because a second, unrelated bug remains — in
mirrord, not here. It is fixed by **metalbear-co/mirrord#4784**.

PyCharm launches the debugger as
`python -X pycache_prefix=... pydevd.py --client 127.0.0.1 --port 33181 ...`.
mirrord's `DebuggerType::PyDevD` looked for the script at `argv[1]`, which is now `-X`,
so no port was detected. It then fell back to `MIRRORD_IGNORE_DEBUGGER_PORTS`, which
this plugin sets to `35000-65535` — while Linux allocates ephemeral ports from 32768.
The layer proxied the debugger's own loopback connection to the target, and the IDE sat
at `Waiting for connection...`.

Ports seen on stuck runs: **33181, 34045, 34945, 33533** — every one below 35000.

With the timeouts raised to 120s the debugger still never attached, which is how we
know it is not a latency problem: the connection was going somewhere else.

<details>
<summary><b>Measured runs</b></summary>

Dispatched on branches cut from `main`, so nothing else differs:

| branch | e2e | note |
|---|---|---|
| pure `main` (control) | 6/8 pass | the long-running ~25% baseline |
| this branch | 3/6 pass | remaining failures are all the pydev port bug |
| `main` + widened port range | 5/6 pass | stopgap for the mirrord bug |

Six runs per arm cannot separate these rates statistically. The timing tables are the
evidence, not the ratios.

</details>

## Quality Checklist:

- [x] I have documented new code sufficiently
- [x] I have checked and updated the relevant existing docs in code, including removing outdated material
- [x] I have tested this change and know it succeeds and fails as expected
- [x] I have written unit tests or purposefully omitted them
- [x] I have written e2e tests or purposefully omitted them
- [x] I have explained what this PR introduces and why, and linked to relevant context (e.g. linear issues, related PRs,
  documentation)
- [x] I have introduced a short, clear and well-formatted changelog entry
