### PR TITLE
Improve CLI startup failure notifications

### DIFF
--- a/changelog.d/28.fixed.md
+++ b/changelog.d/28.fixed.md
@@ -1,0 +1,1 @@
+Improved mirrord CLI startup failure notifications so empty stderr and timeouts use clearer initialization messages without duplicating CLI-provided IDE messages.

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -392,6 +392,8 @@ class MirrordApi(private val service: MirrordProjectService, private val project
             setText(MIRRORD_STARTING_MESSAGE)
             logsService.logInfo(MIRRORD_STARTING_MESSAGE)
 
+            var reportedIdeMessage = false
+
             for (line in bufferedReader.lines()) {
                 val message = parser.parse(line, Message::class.java)
                 when {
@@ -428,7 +430,10 @@ class MirrordApi(private val service: MirrordProjectService, private val project
                             logsService.logInfo("IDE Message: $this")
                             val ideMessage = Gson().fromJson(Gson().toJsonTree(this), IdeMessage::class.java)
                             val service = project.service<MirrordProjectService>()
-                            ideMessage?.handleIdeMessage(service)
+                            ideMessage?.let {
+                                it.handleIdeMessage(service)
+                                reportedIdeMessage = true
+                            }
                         }
                     }
 
@@ -445,7 +450,14 @@ class MirrordApi(private val service: MirrordProjectService, private val project
 
             process.waitFor()
             if (process.exitValue() != 0) {
-                failFromExit(logsService, process, endsExecution = true, message = ::getProcessFailedStderrError)
+                failFromExit(
+                    logsService,
+                    process,
+                    endsExecution = true,
+                    fallbackMessage = MIRRORD_INITIALIZATION_UNKNOWN_ERROR,
+                    alreadyReported = reportedIdeMessage,
+                    message = ::getProcessFailedStderrError
+                )
             } else {
                 logsService.logError("Invalid output from mirrord binary")
                 logsService.onMirrordExecutionEnd()
@@ -466,6 +478,8 @@ class MirrordApi(private val service: MirrordProjectService, private val project
 
             setText(MIRRORD_CONTAINER_STARTING_MESSAGE)
             logsService.logInfo(MIRRORD_CONTAINER_STARTING_MESSAGE)
+
+            var reportedIdeMessage = false
 
             for (line in bufferedReader.lines()) {
                 val message = parser.parse(line, Message::class.java)
@@ -502,7 +516,10 @@ class MirrordApi(private val service: MirrordProjectService, private val project
                         message.message?.run {
                             val ideMessage = Gson().fromJson(Gson().toJsonTree(this), IdeMessage::class.java)
                             val service = project.service<MirrordProjectService>()
-                            ideMessage?.handleIdeMessage(service)
+                            ideMessage?.let {
+                                it.handleIdeMessage(service)
+                                reportedIdeMessage = true
+                            }
                             logsService.logInfo("IDE Message: ${ideMessage?.text ?: "Unknown message"}")
                         }
                     }
@@ -520,7 +537,14 @@ class MirrordApi(private val service: MirrordProjectService, private val project
 
             process.waitFor()
             if (process.exitValue() != 0) {
-                failFromExit(logsService, process, endsExecution = true, message = ::getContainerProcessFailedStderrError)
+                failFromExit(
+                    logsService,
+                    process,
+                    endsExecution = true,
+                    fallbackMessage = MIRRORD_INITIALIZATION_UNKNOWN_ERROR,
+                    alreadyReported = reportedIdeMessage,
+                    message = ::getContainerProcessFailedStderrError
+                )
             } else {
                 logsService.logError("Invalid output from mirrord container binary")
                 logsService.onMirrordExecutionEnd()
@@ -751,6 +775,8 @@ private abstract class MirrordCliTask<T>(
         logsService: MirrordLogsService,
         process: Process,
         endsExecution: Boolean = false,
+        fallbackMessage: String? = null,
+        alreadyReported: Boolean = false,
         message: (String) -> String
     ): Nothing {
         if (abortedByPlugin) {
@@ -762,7 +788,7 @@ private abstract class MirrordCliTask<T>(
         if (endsExecution) {
             logsService.onMirrordExecutionEnd()
         }
-        throw MirrordError.fromStdErr(stdErr)
+        throw MirrordError.fromStdErr(stdErr, fallbackMessage, alreadyReported)
     }
 
     var target: String? = null
@@ -922,7 +948,7 @@ private abstract class MirrordCliTask<T>(
                 abort(process)
                 val errorMessage = getMirrordTaskTimedOutError(spec.describe())
                 logErrorToBoth(logsService, errorMessage)
-                throw MirrordError("mirrord process timed out")
+                throw MirrordError.initializationTimedOut()
             }
         } else {
             // Not on the EDT thread and under a read lock.
@@ -936,7 +962,7 @@ private abstract class MirrordCliTask<T>(
                 abort(process)
                 val errorMessage = getMirrordTaskTimedOutUnderReadLockError(spec.describe())
                 logErrorToBoth(logsService, errorMessage)
-                throw MirrordError("mirrord process timed out")
+                throw MirrordError.initializationTimedOut()
             }
         }
     }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordApi.kt
@@ -125,6 +125,12 @@ sealed class IdeAction {
 data class IdeMessage(val id: String, val level: NotificationLevel, val text: String, val actions: Set<JsonObject>) {
 
     /**
+     * The CLI uses this id for notifications that explain why initialization is about to fail.
+     * Other IDE messages are informational and must not hide a later process error.
+     */
+    internal fun isFailureNotification() = id == "upgrade_cta"
+
+    /**
      * Handles the `IdeMessage` that we received from mirrord.
      *
      * @param service Used to build the notification.
@@ -379,7 +385,8 @@ class MirrordApi(private val service: MirrordProjectService, private val project
         return task.run(service.project)
     }
 
-    private class MirrordExtTask(cli: TargetPath, projectEnvVars: Map<String, String>?, environment: MirrordEnvironment) : MirrordCliTask<MirrordExecution>(cli, "ext", null, projectEnvVars, environment) {
+    private class MirrordExtTask(cli: TargetPath, projectEnvVars: Map<String, String>?, environment: MirrordEnvironment) :
+        MirrordCliTask<MirrordExecution>(cli, "ext", null, projectEnvVars, environment, initializationTask = true) {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): MirrordExecution {
             val parser = SafeParser()
             val bufferedReader = process.inputStream.reader().buffered()
@@ -392,7 +399,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
             setText(MIRRORD_STARTING_MESSAGE)
             logsService.logInfo(MIRRORD_STARTING_MESSAGE)
 
-            var reportedIdeMessage = false
+            var reportedFailure = false
 
             for (line in bufferedReader.lines()) {
                 val message = parser.parse(line, Message::class.java)
@@ -432,7 +439,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
                             val service = project.service<MirrordProjectService>()
                             ideMessage?.let {
                                 it.handleIdeMessage(service)
-                                reportedIdeMessage = true
+                                reportedFailure = reportedFailure || it.isFailureNotification()
                             }
                         }
                     }
@@ -455,7 +462,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
                     process,
                     endsExecution = true,
                     fallbackMessage = MIRRORD_INITIALIZATION_UNKNOWN_ERROR,
-                    alreadyReported = reportedIdeMessage,
+                    alreadyReported = reportedFailure,
                     message = ::getProcessFailedStderrError
                 )
             } else {
@@ -466,7 +473,8 @@ class MirrordApi(private val service: MirrordProjectService, private val project
         }
     }
 
-    private class MirrordContainerExtTask(cli: TargetPath, projectEnvVars: Map<String, String>?, environment: MirrordEnvironment) : MirrordCliTask<MirrordContainerExecution>(cli, "container-ext", null, projectEnvVars, environment) {
+    private class MirrordContainerExtTask(cli: TargetPath, projectEnvVars: Map<String, String>?, environment: MirrordEnvironment) :
+        MirrordCliTask<MirrordContainerExecution>(cli, "container-ext", null, projectEnvVars, environment, initializationTask = true) {
         override fun compute(project: Project, process: Process, setText: (String) -> Unit): MirrordContainerExecution {
             val parser = SafeParser()
             val bufferedReader = process.inputStream.reader().buffered()
@@ -479,7 +487,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
             setText(MIRRORD_CONTAINER_STARTING_MESSAGE)
             logsService.logInfo(MIRRORD_CONTAINER_STARTING_MESSAGE)
 
-            var reportedIdeMessage = false
+            var reportedFailure = false
 
             for (line in bufferedReader.lines()) {
                 val message = parser.parse(line, Message::class.java)
@@ -518,7 +526,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
                             val service = project.service<MirrordProjectService>()
                             ideMessage?.let {
                                 it.handleIdeMessage(service)
-                                reportedIdeMessage = true
+                                reportedFailure = reportedFailure || it.isFailureNotification()
                             }
                             logsService.logInfo("IDE Message: ${ideMessage?.text ?: "Unknown message"}")
                         }
@@ -542,7 +550,7 @@ class MirrordApi(private val service: MirrordProjectService, private val project
                     process,
                     endsExecution = true,
                     fallbackMessage = MIRRORD_INITIALIZATION_UNKNOWN_ERROR,
-                    alreadyReported = reportedIdeMessage,
+                    alreadyReported = reportedFailure,
                     message = ::getContainerProcessFailedStderrError
                 )
             } else {
@@ -744,7 +752,8 @@ private abstract class MirrordCliTask<T>(
     private val command: String,
     private val args: List<String>?,
     private val projectEnvVars: Map<String, String>?,
-    private val environment: MirrordEnvironment
+    private val environment: MirrordEnvironment,
+    private val initializationTask: Boolean = false
 ) {
     /**
      * Set when the plugin itself kills the process.
@@ -948,7 +957,7 @@ private abstract class MirrordCliTask<T>(
                 abort(process)
                 val errorMessage = getMirrordTaskTimedOutError(spec.describe())
                 logErrorToBoth(logsService, errorMessage)
-                throw MirrordError.initializationTimedOut()
+                throw MirrordError.timedOut(initializationTask)
             }
         } else {
             // Not on the EDT thread and under a read lock.
@@ -962,7 +971,7 @@ private abstract class MirrordCliTask<T>(
                 abort(process)
                 val errorMessage = getMirrordTaskTimedOutUnderReadLockError(spec.describe())
                 logErrorToBoth(logsService, errorMessage)
-                throw MirrordError.initializationTimedOut()
+                throw MirrordError.timedOut(initializationTask)
             }
         }
     }

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordError.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordError.kt
@@ -6,11 +6,31 @@ import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 
-open class MirrordError(private val richMessage: String, private val help: String?, override val cause: Throwable?) : ExecutionException(cause) {
+const val MIRRORD_INITIALIZATION_TIMEOUT_ERROR =
+    "mirrord initialization timed out. Check that your Kubernetes cluster and target are reachable, " +
+        "or increase the mirrord task timeout in Settings > Tools > mirrord."
+
+const val MIRRORD_INITIALIZATION_UNKNOWN_ERROR =
+    "mirrord initialization failed, but mirrord did not provide a detailed error. Check the mirrord logs for details."
+
+open class MirrordError(
+    private val richMessage: String,
+    private val help: String?,
+    override val cause: Throwable?,
+    private val alreadyReported: Boolean = false
+) : ExecutionException(cause) {
     override val message: String = "mirrord failed"
 
     companion object {
-        fun fromStdErr(processStdErr: String): MirrordError {
+        fun fromStdErr(
+            processStdErr: String,
+            fallbackMessage: String? = null,
+            alreadyReported: Boolean = false
+        ): MirrordError {
+            if (alreadyReported) {
+                return MirrordError("", null, null, true)
+            }
+
             val info = try {
                 val trimmedError = processStdErr.removePrefix("Error: ")
                 val gson = Gson()
@@ -21,17 +41,31 @@ open class MirrordError(private val richMessage: String, private val help: Strin
                 Pair(processStdErr, null)
             }
 
-            return MirrordError(info.first, info.second, null)
+            return MirrordError(
+                info.first.takeIf { it.isNotBlank() } ?: fallbackMessage.orEmpty(),
+                info.second,
+                null
+            )
         }
+
+        fun initializationTimedOut() = MirrordError(MIRRORD_INITIALIZATION_TIMEOUT_ERROR)
     }
 
-    constructor(richMessage: String) : this(richMessage, null, null)
+    constructor(richMessage: String) : this(richMessage, null, null, false)
 
-    constructor(richMessage: String, help: String) : this(richMessage, help, null)
+    constructor(richMessage: String, help: String) : this(richMessage, help, null, false)
 
-    constructor(richMessage: String, cause: Throwable) : this(richMessage, null, cause)
+    constructor(richMessage: String, cause: Throwable) : this(richMessage, null, cause, false)
+
+    internal fun richMessageForTest() = richMessage
+
+    internal fun helpForTest() = help
 
     fun showHelp(project: Project) {
+        if (alreadyReported) {
+            return
+        }
+
         val notifier = project
             .service<MirrordProjectService>()
             .notifier

--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordError.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordError.kt
@@ -48,7 +48,9 @@ open class MirrordError(
             )
         }
 
-        fun initializationTimedOut() = MirrordError(MIRRORD_INITIALIZATION_TIMEOUT_ERROR)
+        fun timedOut(duringInitialization: Boolean) = MirrordError(
+            if (duringInitialization) MIRRORD_INITIALIZATION_TIMEOUT_ERROR else "mirrord process timed out"
+        )
     }
 
     constructor(richMessage: String) : this(richMessage, null, null, false)

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordErrorTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordErrorTest.kt
@@ -7,9 +7,16 @@ class MirrordErrorTest {
 
     @Test
     fun `timeout uses user-facing initialization message`() {
-        val error = MirrordError.initializationTimedOut()
+        val error = MirrordError.timedOut(duringInitialization = true)
 
         assertEquals(MIRRORD_INITIALIZATION_TIMEOUT_ERROR, error.richMessageForTest())
+    }
+
+    @Test
+    fun `non-initialization timeout keeps generic task message`() {
+        val error = MirrordError.timedOut(duringInitialization = false)
+
+        assertEquals("mirrord process timed out", error.richMessageForTest())
     }
 
     @Test
@@ -47,6 +54,46 @@ class MirrordErrorTest {
     @Test
     fun `already reported ide message suppresses fallback notification`() {
         val error = MirrordError.fromStdErr("", MIRRORD_INITIALIZATION_UNKNOWN_ERROR, alreadyReported = true)
+
+        assertEquals("", error.richMessageForTest())
+        assertEquals(null, error.helpForTest())
+    }
+
+    @Test
+    fun `informational ide message does not suppress later process failure`() {
+        val ideMessage = IdeMessage("queue_splitting_hint", NotificationLevel.Info, "Try queue splitting", emptySet())
+
+        val error = MirrordError.fromStdErr(
+            "deployment deploy/doesnotexist not found",
+            MIRRORD_INITIALIZATION_UNKNOWN_ERROR,
+            alreadyReported = ideMessage.isFailureNotification()
+        )
+
+        assertEquals("deployment deploy/doesnotexist not found", error.richMessageForTest())
+    }
+
+    @Test
+    fun `informational ide message does not suppress empty stderr fallback`() {
+        val ideMessage = IdeMessage("queue_splitting_hint", NotificationLevel.Info, "Try queue splitting", emptySet())
+
+        val error = MirrordError.fromStdErr(
+            "",
+            MIRRORD_INITIALIZATION_UNKNOWN_ERROR,
+            alreadyReported = ideMessage.isFailureNotification()
+        )
+
+        assertEquals(MIRRORD_INITIALIZATION_UNKNOWN_ERROR, error.richMessageForTest())
+    }
+
+    @Test
+    fun `failure ide message still suppresses duplicate process failure`() {
+        val ideMessage = IdeMessage("upgrade_cta", NotificationLevel.Warning, "mirrord operator was not found", emptySet())
+
+        val error = MirrordError.fromStdErr(
+            "operator not installed",
+            MIRRORD_INITIALIZATION_UNKNOWN_ERROR,
+            alreadyReported = ideMessage.isFailureNotification()
+        )
 
         assertEquals("", error.richMessageForTest())
         assertEquals(null, error.helpForTest())

--- a/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordErrorTest.kt
+++ b/modules/core/src/test/kotlin/com/metalbear/mirrord/MirrordErrorTest.kt
@@ -1,0 +1,54 @@
+package com.metalbear.mirrord
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MirrordErrorTest {
+
+    @Test
+    fun `timeout uses user-facing initialization message`() {
+        val error = MirrordError.initializationTimedOut()
+
+        assertEquals(MIRRORD_INITIALIZATION_TIMEOUT_ERROR, error.richMessageForTest())
+    }
+
+    @Test
+    fun `empty stderr uses initialization fallback when provided`() {
+        val error = MirrordError.fromStdErr("", MIRRORD_INITIALIZATION_UNKNOWN_ERROR)
+
+        assertEquals(MIRRORD_INITIALIZATION_UNKNOWN_ERROR, error.richMessageForTest())
+    }
+
+    @Test
+    fun `structured stderr keeps mirrord message and help`() {
+        val error = MirrordError.fromStdErr(
+            "Error: {" +
+                "\"message\":\"target not found\"," +
+                "\"severity\":\"error\"," +
+                "\"causes\":[]," +
+                "\"help\":\"check the target path\"," +
+                "\"labels\":[]," +
+                "\"related\":[]" +
+                "}",
+            MIRRORD_INITIALIZATION_UNKNOWN_ERROR
+        )
+
+        assertEquals("target not found", error.richMessageForTest())
+        assertEquals("check the target path", error.helpForTest())
+    }
+
+    @Test
+    fun `plain stderr remains the user-facing failure detail`() {
+        val error = MirrordError.fromStdErr("deployment deploy/doesnotexist not found", MIRRORD_INITIALIZATION_UNKNOWN_ERROR)
+
+        assertEquals("deployment deploy/doesnotexist not found", error.richMessageForTest())
+    }
+
+    @Test
+    fun `already reported ide message suppresses fallback notification`() {
+        val error = MirrordError.fromStdErr("", MIRRORD_INITIALIZATION_UNKNOWN_ERROR, alreadyReported = true)
+
+        assertEquals("", error.richMessageForTest())
+        assertEquals(null, error.helpForTest())
+    }
+}


### PR DESCRIPTION
## Summary
- Improve user-facing notifications when mirrord CLI startup fails during initialization.
- Preserve process-failure diagnostics after informational IDE messages while avoiding duplicate notifications for failures already reported by the CLI.

## Changes
- Track only failure-specific `upgrade_cta` IDE notifications in both `mirrord ext` and `mirrord container-ext` startup paths when deciding whether to suppress fallback notifications.
- Preserve structured stderr, plain stderr, and empty-stderr fallback diagnostics after informational IDE messages.
- Scope initialization-specific timeout guidance to `ext` and `container-ext`; unrelated CLI tasks retain the generic timeout message.
- Add focused regression coverage for informational versus failure IDE messages, timeout scope, and existing stderr/fallback behavior.
- Add a towncrier fixed changelog fragment.

## Testing
- `./gradlew :mirrord-core:test --tests '*MirrordErrorTest' --rerun-tasks --console=plain`
- `./gradlew :mirrord-core:test --rerun-tasks --console=plain`
- `./gradlew ktlintCheck --rerun-tasks --console=plain`
- `uvx towncrier check`
- `git diff origin/main...HEAD --check`

`buildPlugin` was not run because the locally built mirrord binaries required by `CONTRIBUTING.md` are not available in this environment.

## Related Issue
Fixes #28
