### PR TITLE
COR-1870 Fix SBT run config extension and bump since build version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,7 +118,7 @@ intellijPlatform {
     pluginConfiguration {
         version = providers.gradleProperty("pluginVersion")
         ideaVersion {
-            sinceBuild = "253"
+            sinceBuild = "261"
         }
 
         description = providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
@@ -151,10 +151,6 @@ intellijPlatform {
 
         // Without this block the verifier has no IDE to check against, so the weekly job
         // proves nothing.
-        //
-        // The compile target is `platformVersion` while sinceBuild claims 253 and upwards. That
-        // gap is real: a platform class that moves between builds resolves at compile time and
-        // fails at run time, and only a verifier run against the newer build catches it.
         ides {
             // `-PverifierLocalIde=<path>` checks an IDE already on disk, which needs no download
             // and is the quickest way to test one specific build. CI has no such install, so it

--- a/changelog.d/+raise-since-build.changed.md
+++ b/changelog.d/+raise-since-build.changed.md
@@ -1,0 +1,1 @@
+Raised the plugin's `sinceBuild` to 2026.1 from 2025.3 which does not support `EelApi`.

--- a/changelog.d/+sbt-scala-compat.fixed.md
+++ b/changelog.d/+sbt-scala-compat.fixed.md
@@ -1,0 +1,3 @@
+Fixed the SBT run configuration breaking on IntelliJ IDEA 2026.2 and later, where
+the Scala plugin made `SbtCommandLineState` final and removed
+`SbtRunConfiguration.preprocessTasks`.

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/MirrordSbtRunConfiguration.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/MirrordSbtRunConfiguration.kt
@@ -1,13 +1,13 @@
 package com.metalbear.mirrord.products.idea
 
-import com.intellij.execution.ExecutionResult
+import com.intellij.execution.ExecutionListener
+import com.intellij.execution.ExecutionManager
 import com.intellij.execution.Executor
 import com.intellij.execution.configurations.RunConfigurationBase
-import com.intellij.execution.process.ProcessAdapter
-import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.execution.runners.ProgramRunner
 import com.intellij.openapi.components.service
+import com.intellij.util.execution.ParametersListUtil
 import com.metalbear.mirrord.MirrordExecution
 import com.metalbear.mirrord.MirrordLogger
 import com.metalbear.mirrord.MirrordLogsService
@@ -15,9 +15,6 @@ import com.metalbear.mirrord.MirrordProjectService
 import com.metalbear.mirrord.bifrost.MirrordEnvironments
 import org.jetbrains.sbt.runner.SbtCommandLineState
 import org.jetbrains.sbt.runner.SbtRunConfiguration
-import scala.Function1
-import scala.Option
-import scala.runtime.BoxedUnit
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.SortedMap
@@ -55,7 +52,7 @@ class MirrordSbtRunConfiguration(
             pendingMirrordExecution = executionInfo
             super.getState(executor, env) as SbtCommandLineState
         } else {
-            createDirectLaunchState(executionInfo, env)
+            createDirectLaunchState(executionInfo, executor, env)
         }
     }
 
@@ -65,7 +62,7 @@ class MirrordSbtRunConfiguration(
      */
     override fun preprocessTasks(): String {
         if (!useSbtShell) {
-            return super.preprocessTasks()
+            return preprocessedTasks()
         }
 
         val processedCommands = buildMirrordAwareCommands()
@@ -76,7 +73,7 @@ class MirrordSbtRunConfiguration(
     }
 
     private fun buildMirrordAwareCommands(): String {
-        val originalCommands = super.preprocessTasks()
+        val originalCommands = preprocessedTasks()
         val executionInfo = pendingMirrordExecution.also { pendingMirrordExecution = null } ?: return originalCommands
 
         val taskScope = resolveTaskScope(originalCommands) ?: run {
@@ -164,7 +161,7 @@ class MirrordSbtRunConfiguration(
         if (useSbtShell) {
             maybeWarnAboutPlayProject()
 
-            val originalCommands = super.preprocessTasks()
+            val originalCommands = preprocessedTasks()
             val taskScope = resolveTaskScope(originalCommands) ?: run {
                 logWarningToUser(
                     "mirrord SBT currently supports only simple `run`, `runMain`, and `fgRun` shell tasks. " +
@@ -189,6 +186,7 @@ class MirrordSbtRunConfiguration(
 
     private fun createDirectLaunchState(
         executionInfo: MirrordExecution,
+        executor: Executor,
         env: ExecutionEnvironment
     ): SbtCommandLineState {
         val originalEnv = HashMap(environmentVariables())
@@ -200,33 +198,50 @@ class MirrordSbtRunConfiguration(
         environmentVariables().clear()
         environmentVariables().putAll(injectedEnv)
 
-        return object : SbtCommandLineState(
-            preprocessTasks(),
-            this@MirrordSbtRunConfiguration,
-            env,
-            Option.empty<Function1<String, BoxedUnit>>()
-        ) {
-            override fun execute(executor: Executor, runner: ProgramRunner<*>): ExecutionResult {
-                return try {
-                    super.execute(executor, runner).also { result ->
-                        val processHandler = result.processHandler
-                        if (processHandler == null) {
-                            restoreEnvironment(originalEnv)
-                        } else {
-                            processHandler.addProcessListener(object : ProcessAdapter() {
-                                override fun processTerminated(event: ProcessEvent) {
-                                    restoreEnvironment(originalEnv)
-                                }
-                            })
-                        }
+        val state = try {
+            super.getState(executor, env) as SbtCommandLineState
+        } catch (t: Throwable) {
+            restoreEnvironment(originalEnv)
+            throw t
+        }
+
+        restoreEnvironmentWhenLaunchEnds(env, originalEnv)
+        return state
+    }
+
+    private fun restoreEnvironmentWhenLaunchEnds(env: ExecutionEnvironment, originalEnv: Map<String, String>) {
+        val connection = project.messageBus.connect(project)
+
+        connection.subscribe(
+            ExecutionManager.EXECUTION_TOPIC,
+            object : ExecutionListener {
+                override fun processNotStarted(executorId: String, environment: ExecutionEnvironment) {
+                    launchEnded(environment)
+                }
+
+                override fun processTerminated(
+                    executorId: String,
+                    environment: ExecutionEnvironment,
+                    handler: ProcessHandler,
+                    exitCode: Int
+                ) {
+                    launchEnded(environment)
+                }
+
+                /** The topic carries every launch in the project, so ignore everyone else's. */
+                private fun launchEnded(environment: ExecutionEnvironment) {
+                    if (environment !== env) {
+                        return
                     }
-                } catch (t: Throwable) {
+
                     restoreEnvironment(originalEnv)
-                    throw t
+                    connection.disconnect()
                 }
             }
-        }
+        )
     }
+
+    private fun preprocessedTasks(): String = preprocessSbtTasks(tasks, useSbtShell)
 
     private fun restoreEnvironment(originalEnv: Map<String, String>) {
         environmentVariables().clear()
@@ -276,5 +291,21 @@ class MirrordSbtRunConfiguration(
             )
             emptyMap()
         }
+    }
+}
+
+fun preprocessSbtTasks(rawTasks: String, useSbtShell: Boolean): String {
+    if (!useSbtShell || rawTasks.trim().startsWith(MIRRORD_SBT_COMMAND_SEPARATOR)) {
+        return rawTasks
+    }
+
+    val commands = ParametersListUtil.parse(rawTasks, false)
+    return if (commands.size == 1) {
+        commands.single()
+    } else {
+        commands.joinToString(
+            separator = " $MIRRORD_SBT_COMMAND_SEPARATOR",
+            prefix = MIRRORD_SBT_COMMAND_SEPARATOR
+        )
     }
 }

--- a/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/MirrordSbtRunConfiguration.kt
+++ b/modules/products/idea/src/main/kotlin/com/metalbear/mirrord/products/idea/MirrordSbtRunConfiguration.kt
@@ -15,6 +15,7 @@ import com.metalbear.mirrord.MirrordProjectService
 import com.metalbear.mirrord.bifrost.MirrordEnvironments
 import org.jetbrains.sbt.runner.SbtCommandLineState
 import org.jetbrains.sbt.runner.SbtRunConfiguration
+import java.lang.reflect.Method
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.SortedMap
@@ -49,34 +50,40 @@ class MirrordSbtRunConfiguration(
         val executionInfo = prepareMirrordExecution() ?: return super.getState(executor, env) as SbtCommandLineState
 
         return if (useSbtShell) {
-            pendingMirrordExecution = executionInfo
-            super.getState(executor, env) as SbtCommandLineState
+            createShellLaunchState(executionInfo, executor, env)
         } else {
             createDirectLaunchState(executionInfo, executor, env)
         }
     }
 
     /**
-     * The Scala plugin calls `preprocessTasks` before submitting shell commands.
-     * We use that moment to replace a supported app task with a mirrord-aware chained shell command.
+     * Replaces a supported app task with a mirrord-aware chained shell command.
+     *
+     * This is the injection point on Scala 2026.1 and older, where the plugin calls `preprocessTasks`
+     * while building the launch. Newer plugins never call it -- [createShellLaunchState] writes the
+     * command in for those.
      */
     override fun preprocessTasks(): String {
         if (!useSbtShell) {
             return preprocessedTasks()
         }
 
-        val processedCommands = buildMirrordAwareCommands()
+        val processedCommands = buildMirrordAwareCommands(preprocessedTasks())
         MirrordLogger.logger.debug(
             "[${this.javaClass.name}] preprocessTasks: configuration=`$name`, commands=`$processedCommands`"
         )
         return processedCommands
     }
 
-    private fun buildMirrordAwareCommands(): String {
-        val originalCommands = preprocessedTasks()
+    private fun buildMirrordAwareCommands(originalCommands: String): String {
         val executionInfo = pendingMirrordExecution.also { pendingMirrordExecution = null } ?: return originalCommands
 
-        val taskScope = resolveTaskScope(originalCommands) ?: run {
+        return buildMirrordSbtShellCommands(
+            originalCommands = originalCommands,
+            configurationEnv = getSbtConfigurationEnv(this),
+            mirrordEnv = executionInfo.environment,
+            envToUnset = executionInfo.envToUnset.orEmpty().toSet()
+        ) ?: run {
             MirrordLogger.logger.warn(
                 "[${this.javaClass.name}] buildMirrordAwareCommands: unsupported SBT task `$originalCommands` for `$name`, running without shell env injection"
             )
@@ -84,72 +91,9 @@ class MirrordSbtRunConfiguration(
                 "mirrord SBT currently supports only simple `run`, `runMain`, and `fgRun` shell tasks. " +
                     "Task `$originalCommands` will run without mirrord shell env injection."
             )
-            return originalCommands
-        }
-
-        val originalEnv = getSbtConfigurationEnv(this)
-        val targetEnv = originalEnv +
-            executionInfo.environment +
-            mapOf("MIRRORD_DETECT_DEBUGGER_PORT" to "javaagent") -
-            executionInfo.envToUnset.orEmpty().toSet()
-
-        val envMapLiteral = toSbtMapLiteral(targetEnv)
-        return buildString {
-            append(MIRRORD_SBT_COMMAND_SEPARATOR)
-            append("set ")
-            append(taskScope)
-            append(" / fork := true")
-            append(MIRRORD_SBT_COMMAND_SEPARATOR)
-            append("set ")
-            append(taskScope)
-            append(" / envVars := ")
-            append(envMapLiteral)
-            append(MIRRORD_SBT_COMMAND_SEPARATOR)
-            append(originalCommands)
+            originalCommands
         }
     }
-
-    /**
-     * Maps a shell command to the SBT task scope whose `fork` and `envVars` settings should be changed.
-     *
-     * We only support simple single-command app launches. Chained commands and watcher commands are left untouched.
-     */
-    private fun resolveTaskScope(commands: String): String? {
-        val command = commands.trim()
-        if (command.isEmpty() || command.startsWith(MIRRORD_SBT_COMMAND_SEPARATOR) || command.contains(MIRRORD_SBT_COMMAND_SEPARATOR)) {
-            return null
-        }
-
-        return when {
-            command == MIRRORD_SBT_RUN_TASK -> "Compile / run"
-            command.startsWith("$MIRRORD_SBT_RUN_MAIN_TASK ") -> "Compile / runMain"
-            command == MIRRORD_SBT_RUN_MAIN_TASK -> "Compile / runMain"
-            command.endsWith("/$MIRRORD_SBT_RUN_TASK") -> command
-            command.endsWith("/$MIRRORD_SBT_RUN_MAIN_TASK") -> command
-            command == MIRRORD_SBT_FG_RUN_TASK -> MIRRORD_SBT_FG_RUN_TASK
-            command.endsWith("/$MIRRORD_SBT_FG_RUN_TASK") -> command
-            else -> null
-        }
-    }
-
-    private fun toSbtMapLiteral(env: Map<String, String>): String {
-        val sortedEnv: SortedMap<String, String> = TreeMap(env)
-        return sortedEnv.entries.joinToString(
-            prefix = "Map(",
-            postfix = ")",
-            separator = ", "
-        ) { (key, value) ->
-            "\"${escapeSbtString(key)}\" -> \"${escapeSbtString(value)}\""
-        }
-    }
-
-    private fun escapeSbtString(value: String): String =
-        value
-            .replace("\\", "\\\\")
-            .replace("\"", "\\\"")
-            .replace("\n", "\\n")
-            .replace("\r", "\\r")
-            .replace("\t", "\\t")
 
     /**
      * Prepares mirrord before delegating to either SBT shell execution or direct SBT launch.
@@ -161,8 +105,8 @@ class MirrordSbtRunConfiguration(
         if (useSbtShell) {
             maybeWarnAboutPlayProject()
 
-            val originalCommands = preprocessedTasks()
-            val taskScope = resolveTaskScope(originalCommands) ?: run {
+            val originalCommands = originalShellCommands()
+            val taskScope = resolveSbtTaskScope(originalCommands) ?: run {
                 logWarningToUser(
                     "mirrord SBT currently supports only simple `run`, `runMain`, and `fgRun` shell tasks. " +
                         "Task `$originalCommands` is not supported."
@@ -183,6 +127,46 @@ class MirrordSbtRunConfiguration(
         val environment = MirrordEnvironments.forProject(project)
         return service.execManager.wrapper("idea", getSbtConfigurationEnv(this), environment).start()
     }
+
+    /**
+     * Builds the state for an SBT *shell* launch, with mirrord's command rewrite in place.
+     *
+     * The Scala plugin changed where it takes that command from. Up to 2026.1 `getState` called
+     * `preprocessTasks` while constructing the state, so [preprocessTasks] was enough of a hook. From
+     * 2026.2 it reads the stored `commands` string instead and never calls `preprocessTasks` at all.
+     * So on the newer plugin the command is written into the configuration before delegating,
+     * and put back straight after.
+     *
+     * Restoring immediately is safe: `SbtCommandLineState` copies the string in its constructor and
+     * never reads the configuration again, so the run keeps mirrord's command while what the user
+     * sees in their settings stays their own.
+     */
+    private fun createShellLaunchState(
+        executionInfo: MirrordExecution,
+        executor: Executor,
+        env: ExecutionEnvironment
+    ): SbtCommandLineState {
+        pendingMirrordExecution = executionInfo
+
+        // Older plugin: `preprocessTasks` is still the hook, and it consumes pendingMirrordExecution.
+        val storedCommands = SbtStoredCommands.of(this)
+            ?: return super.getState(executor, env) as SbtCommandLineState
+
+        val originalCommands = storedCommands.value
+        return try {
+            val mirrordCommands = buildMirrordAwareCommands(originalCommands)
+            MirrordLogger.logger.debug(
+                "[${this.javaClass.name}] createShellLaunchState: configuration=`$name`, commands=`$mirrordCommands`"
+            )
+            storedCommands.value = mirrordCommands
+            super.getState(executor, env) as SbtCommandLineState
+        } finally {
+            storedCommands.value = originalCommands
+            pendingMirrordExecution = null
+        }
+    }
+
+    private fun originalShellCommands(): String = SbtStoredCommands.of(this)?.value ?: preprocessedTasks()
 
     private fun createDirectLaunchState(
         executionInfo: MirrordExecution,
@@ -309,3 +293,108 @@ fun preprocessSbtTasks(rawTasks: String, useSbtShell: Boolean): String {
         )
     }
 }
+
+/**
+ * Reads and writes `SbtRunConfiguration.commands`, the stored command string that Scala 2026.2 and
+ * later build an SBT shell launch from.
+ */
+private class SbtStoredCommands private constructor(
+    private val configuration: SbtRunConfiguration,
+    private val getter: Method,
+    private val setter: Method
+) {
+    var value: String
+        get() = getter.invoke(configuration) as String
+        set(newValue) {
+            setter.invoke(configuration, newValue)
+        }
+
+    companion object {
+        /** Null on Scala 2026.1 and older, which is the signal to leave the `preprocessTasks` path alone. */
+        fun of(configuration: SbtRunConfiguration): SbtStoredCommands? = try {
+            SbtStoredCommands(
+                configuration,
+                SbtRunConfiguration::class.java.getMethod("getCommands"),
+                SbtRunConfiguration::class.java.getMethod("setCommands", String::class.java)
+            )
+        } catch (_: NoSuchMethodException) {
+            null
+        }
+    }
+}
+
+/**
+ * The SBT shell command that runs [originalCommands] with mirrord's environment applied, or null when
+ * the task is not a shape mirrord can wrap.
+ */
+fun buildMirrordSbtShellCommands(
+    originalCommands: String,
+    configurationEnv: Map<String, String>,
+    mirrordEnv: Map<String, String>,
+    envToUnset: Set<String>
+): String? {
+    val taskScope = resolveSbtTaskScope(originalCommands) ?: return null
+
+    val targetEnv = configurationEnv +
+        mirrordEnv +
+        mapOf("MIRRORD_DETECT_DEBUGGER_PORT" to "javaagent") -
+        envToUnset
+
+    val envMapLiteral = toSbtMapLiteral(targetEnv)
+    return buildString {
+        append(MIRRORD_SBT_COMMAND_SEPARATOR)
+        append("set ")
+        append(taskScope)
+        append(" / fork := true")
+        append(MIRRORD_SBT_COMMAND_SEPARATOR)
+        append("set ")
+        append(taskScope)
+        append(" / envVars := ")
+        append(envMapLiteral)
+        append(MIRRORD_SBT_COMMAND_SEPARATOR)
+        append(originalCommands)
+    }
+}
+
+/**
+ * Maps a shell command to the SBT task scope whose `fork` and `envVars` settings should be changed.
+ *
+ * Only simple single-command app launches are supported. Chained commands and watcher commands are
+ * left untouched.
+ */
+private fun resolveSbtTaskScope(commands: String): String? {
+    val command = commands.trim()
+    if (command.isEmpty() || command.startsWith(MIRRORD_SBT_COMMAND_SEPARATOR) || command.contains(MIRRORD_SBT_COMMAND_SEPARATOR)) {
+        return null
+    }
+
+    return when {
+        command == MIRRORD_SBT_RUN_TASK -> "Compile / run"
+        command.startsWith("$MIRRORD_SBT_RUN_MAIN_TASK ") -> "Compile / runMain"
+        command == MIRRORD_SBT_RUN_MAIN_TASK -> "Compile / runMain"
+        command.endsWith("/$MIRRORD_SBT_RUN_TASK") -> command
+        command.endsWith("/$MIRRORD_SBT_RUN_MAIN_TASK") -> command
+        command == MIRRORD_SBT_FG_RUN_TASK -> MIRRORD_SBT_FG_RUN_TASK
+        command.endsWith("/$MIRRORD_SBT_FG_RUN_TASK") -> command
+        else -> null
+    }
+}
+
+private fun toSbtMapLiteral(env: Map<String, String>): String {
+    val sortedEnv: SortedMap<String, String> = TreeMap(env)
+    return sortedEnv.entries.joinToString(
+        prefix = "Map(",
+        postfix = ")",
+        separator = ", "
+    ) { (key, value) ->
+        "\"${escapeSbtString(key)}\" -> \"${escapeSbtString(value)}\""
+    }
+}
+
+private fun escapeSbtString(value: String): String =
+    value
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")

--- a/src/test/kotlin/com/metalbear/mirrord/products/idea/MirrordSbtShellCommandTest.kt
+++ b/src/test/kotlin/com/metalbear/mirrord/products/idea/MirrordSbtShellCommandTest.kt
@@ -1,0 +1,104 @@
+package com.metalbear.mirrord.products.idea
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MirrordSbtShellCommandTest {
+    private fun build(
+        commands: String,
+        configurationEnv: Map<String, String> = emptyMap(),
+        mirrordEnv: Map<String, String> = mapOf("MIRRORD_CONFIG" to "/tmp/c.json"),
+        envToUnset: Set<String> = emptySet()
+    ) = buildMirrordSbtShellCommands(commands, configurationEnv, mirrordEnv, envToUnset)
+
+    @Test
+    fun `forks the task and sets its env, then runs the original command`() {
+        assertEquals(
+            ";set Compile / run / fork := true" +
+                ";set Compile / run / envVars := " +
+                "Map(\"MIRRORD_CONFIG\" -> \"/tmp/c.json\", \"MIRRORD_DETECT_DEBUGGER_PORT\" -> \"javaagent\")" +
+                ";run",
+            build("run")
+        )
+    }
+
+    @Test
+    fun `marks the forked JVM debuggable through the java agent`() {
+        // Without this the debugger port is not detected and debugging an SBT run silently misbehaves.
+        assertTrue(build("run")!!.contains("\"MIRRORD_DETECT_DEBUGGER_PORT\" -> \"javaagent\""))
+    }
+
+    @Test
+    fun `lets mirrord's variables win over the configuration's`() {
+        val result = build(
+            "run",
+            configurationEnv = mapOf("SHARED" to "from-config"),
+            mirrordEnv = mapOf("SHARED" to "from-mirrord")
+        )!!
+        assertTrue(result.contains("\"SHARED\" -> \"from-mirrord\""))
+        assertTrue(!result.contains("from-config"))
+    }
+
+    @Test
+    fun `drops variables mirrord asks to unset, even ones the user set`() {
+        val result = build(
+            "run",
+            configurationEnv = mapOf("DROP_ME" to "user-value", "KEEP" to "kept"),
+            mirrordEnv = mapOf("DROP_ME" to "mirrord-value"),
+            envToUnset = setOf("DROP_ME")
+        )!!
+        assertTrue(!result.contains("DROP_ME"))
+        assertTrue(result.contains("\"KEEP\" -> \"kept\""))
+    }
+
+    @Test
+    fun `orders the env map by key so the command is deterministic`() {
+        val result = build("run", configurationEnv = mapOf("ZED" to "z", "ALPHA" to "a"))!!
+        assertTrue(result.indexOf("\"ALPHA\"") < result.indexOf("\"ZED\""))
+    }
+
+    @Test
+    fun `escapes quotes and backslashes so the literal stays parseable`() {
+        val result = build("run", configurationEnv = mapOf("Q" to """a"b\c"""))!!
+        assertTrue(result.contains("\"Q\" -> \"a\\\"b\\\\c\""))
+    }
+
+    @Test
+    fun `escapes newlines and tabs rather than breaking the command across lines`() {
+        val result = build("run", configurationEnv = mapOf("N" to "a\nb\tc"))!!
+        assertTrue(result.contains("""a\nb\tc"""))
+    }
+
+    @Test
+    fun `scopes runMain to Compile`() {
+        assertTrue(build("runMain com.Example")!!.startsWith(";set Compile / runMain / fork := true"))
+    }
+
+    @Test
+    fun `keeps a project-qualified task as its own scope`() {
+        assertTrue(build("backend/run")!!.startsWith(";set backend/run / fork := true"))
+    }
+
+    @Test
+    fun `scopes fgRun without a Compile prefix`() {
+        assertTrue(build("fgRun")!!.startsWith(";set fgRun / fork := true"))
+    }
+
+    @Test
+    fun `declines an already chained command`() {
+        // Several commands have no single scope to attach fork and envVars to.
+        assertNull(build(";clean ;run"))
+    }
+
+    @Test
+    fun `declines a task it does not recognise`() {
+        assertNull(build("test"))
+    }
+
+    @Test
+    fun `declines an empty command`() {
+        assertNull(build(""))
+    }
+}

--- a/src/test/kotlin/com/metalbear/mirrord/products/idea/MirrordSbtTaskPreprocessingTest.kt
+++ b/src/test/kotlin/com/metalbear/mirrord/products/idea/MirrordSbtTaskPreprocessingTest.kt
@@ -1,0 +1,43 @@
+package com.metalbear.mirrord.products.idea
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MirrordSbtTaskPreprocessingTest {
+    @Test
+    fun `passes the raw string through when the SBT shell is off`() {
+        // Without the shell the string reaches the launcher as typed; chaining would corrupt it.
+        assertEquals("clean compile run", preprocessSbtTasks("clean compile run", useSbtShell = false))
+    }
+
+    @Test
+    fun `leaves an already chained command list alone`() {
+        assertEquals(";clean ;run", preprocessSbtTasks(";clean ;run", useSbtShell = true))
+    }
+
+    @Test
+    fun `ignores leading whitespace when spotting an already chained list`() {
+        assertEquals("  ;clean ;run", preprocessSbtTasks("  ;clean ;run", useSbtShell = true))
+    }
+
+    @Test
+    fun `returns a single command unchained`() {
+        // The leading `;` is what tells SBT a list follows, so one command must not get one.
+        assertEquals("run", preprocessSbtTasks("run", useSbtShell = true))
+    }
+
+    @Test
+    fun `chains several commands`() {
+        assertEquals(";clean ;compile ;run", preprocessSbtTasks("clean compile run", useSbtShell = true))
+    }
+
+    @Test
+    fun `splits a quoted argument into its own command, as the Scala plugin did`() {
+        assertEquals(";runMain ;com.Example arg", preprocessSbtTasks("runMain \"com.Example arg\"", useSbtShell = true))
+    }
+
+    @Test
+    fun `turns an empty task list into a bare separator`() {
+        assertEquals(";", preprocessSbtTasks("", useSbtShell = true))
+    }
+}


### PR DESCRIPTION
Bump plugin compatibility to since build 2026.1 as EelApi doesn't exist before that.
Also fix changes from Scala extension that breaks our extension point since 2026.2. Sbt run config extension is manually tested in both 2026.1 and 2026.2. Both plain Scala project and Play sample project work.