### PR TITLE
Ignore missing Tomcat and javaee reports

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -149,6 +149,10 @@ intellijPlatform {
     pluginVerification {
         failureLevel = EnumSet.of(VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS, VerifyPluginTask.FailureLevel.INVALID_PLUGIN)
 
+        if (platformType != "IU") {
+            ignoredProblemsFile = layout.projectDirectory.file("gradle/plugin-verifier-allowlist.txt")
+        }
+
         // Without this block the verifier has no IDE to check against, so the weekly job
         // proves nothing.
         ides {

--- a/changelog.d/+verifier-allowlist.internal.md
+++ b/changelog.d/+verifier-allowlist.internal.md
@@ -1,0 +1,1 @@
+Ignore plugin verifier's claim of missing Tomcat and JavaEE packages

--- a/gradle/plugin-verifier-allowlist.txt
+++ b/gradle/plugin-verifier-allowlist.txt
@@ -1,0 +1,7 @@
+// Tomcat support lives behind 
+// `<depends optional="true" config-file="mirrord-tomcat.xml">Tomcat</depends>`, so those classes
+// only load in an IDE that ships the Tomcat plugin. PyCharm, GoLand and Rider do not, but the 
+// verifier checks every class in the artifact regardless of the optional descriptor.
+// Ignore reports about missing Tomcat and JavaEE packages.
+com.metalbear.mirrord::Package 'org\.jetbrains\.idea(\.tomcat)?' is not found
+com.metalbear.mirrord::Package 'com\.intellij\.javaee(\.appServers)?' is not found


### PR DESCRIPTION
Ignore plugin verifier's claim of missing packages. Tomcat and JavaEE related classes are loaded optionally for IU only, but verifier checks them unconditionally for all platform type.